### PR TITLE
feat: implement shift+tab for switching backwards between panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ With vim-style navigation:
 | Key                       | Action                               |
 | ------------------------- | ------------------------------------ |
 | `1` `2` `3` `4`           | Focus pane                           |
-| `Tab`                     | Cycle focus                          |
+| `Tab` / `Shift+Tab`       | Cycle focus forward / backward       |
 | `j` / `k`, arrows         | Move down / up                       |
 | `J`, `K` / `H`, `L`       | Scroll viewport                      |
 | `Ctrl+d` / `Ctrl+u`       | Half-page scroll                     |

--- a/src/tui/input/keyboard.rs
+++ b/src/tui/input/keyboard.rs
@@ -119,6 +119,7 @@ pub fn handle_key(state: &mut DashboardState, key: KeyEvent) -> Option<AppComman
                 state.jump_bottom();
             }
         }
+        KeyCode::BackTab => state.cycle_focus_backward(),
         KeyCode::Tab => state.cycle_focus(),
         // Tree headers act like a small tree: Enter/Space toggles, Right
         // opens, and Left closes. Anywhere else these keys are no-ops.

--- a/src/tui/input/tests.rs
+++ b/src/tui/input/tests.rs
@@ -273,6 +273,26 @@ fn number_keys_focus_top_level_panes() {
 }
 
 #[test]
+fn tab_and_shift_tab_cycle_focus() {
+    let mut state = DashboardState::new();
+
+    handle_key(&mut state, key(KeyCode::Tab));
+    assert_eq!(state.focus(), FocusPane::Channels);
+
+    handle_key(&mut state, key(KeyCode::Tab));
+    assert_eq!(state.focus(), FocusPane::Messages);
+
+    handle_key(&mut state, key(KeyCode::BackTab));
+    assert_eq!(state.focus(), FocusPane::Channels);
+
+    handle_key(&mut state, key(KeyCode::BackTab));
+    assert_eq!(state.focus(), FocusPane::Guilds);
+
+    handle_key(&mut state, key(KeyCode::BackTab));
+    assert_eq!(state.focus(), FocusPane::Members);
+}
+
+#[test]
 fn left_click_focuses_top_level_pane() {
     let mut state = DashboardState::new();
 

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -1768,6 +1768,15 @@ impl DashboardState {
         };
     }
 
+    pub fn cycle_focus_backward(&mut self) {
+        self.focus = match self.focus {
+            FocusPane::Guilds => FocusPane::Members,
+            FocusPane::Channels => FocusPane::Guilds,
+            FocusPane::Messages => FocusPane::Channels,
+            FocusPane::Members => FocusPane::Messages,
+        };
+    }
+
     pub fn focus_pane(&mut self, pane: FocusPane) {
         self.focus = pane;
     }

--- a/src/tui/ui/panes.rs
+++ b/src/tui/ui/panes.rs
@@ -739,12 +739,12 @@ pub(super) fn footer_hint(state: &DashboardState) -> &'static str {
             "j/k choose action | enter select | esc close | q quit"
         }
     } else if state.focus() == FocusPane::Members {
-        "tab/1-4 focus | j/k move | H/L scroll name | enter/space profile | a actions | i write | q quit"
+        "tab/shift+tab/1-4 focus | j/k move | H/L scroll name | enter/space profile | a actions | i write | q quit"
     } else if state.focus() == FocusPane::Channels {
-        "tab/1-4 focus | j/k move | H/L scroll name | enter/space open | h/← close | l/→ open | a actions | ` logs | i write | q quit"
+        "tab/shift+tab/1-4 focus | j/k move | H/L scroll name | enter/space open | h/← close | l/→ open | a actions | ` logs | i write | q quit"
     } else if state.focus() == FocusPane::Guilds {
-        "tab/1-4 focus | j/k move | J/K scroll | H/L scroll name | enter/space action/tree | h/← close | l/→ open | ` logs | i write | esc cancel | q quit"
+        "tab/shift+tab/1-4 focus | j/k move | J/K scroll | H/L scroll name | enter/space action/tree | h/← close | l/→ open | ` logs | i write | esc cancel | q quit"
     } else {
-        "tab/1-4 focus | j/k move | J/K scroll | enter/space actions | ` logs | i write | esc cancel | q quit"
+        "tab/shift+tab/1-4 focus | j/k move | J/K scroll | enter/space actions | ` logs | i write | esc cancel | q quit"
     }
 }


### PR DESCRIPTION
Hey, thanks for the project/repository!

I forked it and added Shift+Tab support for cycling pane focus backward (because I use it everywhere else and it seems natural to me)
Not sure if you feel the same but here's the PR for it
Feel free to close it if it's not of your interest for the project or let me know if you'd like me to address anything else before merging, should it be of interest

Thanks again!