### PR TITLE
feat: allow pasting raw image data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.52.0",
+ "wl-clipboard-rs",
+ "x11rb",
+]
+
+[[package]]
 name = "arg_enum_proc_macro"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,6 +554,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -576,6 +606,7 @@ checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 name = "concord"
 version = "1.3.0"
 dependencies = [
+ "arboard",
  "base64",
  "chrono",
  "crossterm",
@@ -584,6 +615,7 @@ dependencies = [
  "image",
  "mime_guess",
  "notify-rust",
+ "png",
  "qrcode",
  "rand 0.8.6",
  "ratatui",
@@ -910,6 +942,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,6 +1024,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "euclid"
@@ -1097,6 +1141,12 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -1250,6 +1300,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2170,6 +2230,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-graphics",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2178,6 +2250,19 @@ dependencies = [
  "bitflags 2.11.1",
  "dispatch2",
  "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.11.1",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -2195,6 +2280,17 @@ dependencies = [
  "bitflags 2.11.1",
  "block2",
  "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2237,6 +2333,16 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2366,6 +2472,17 @@ checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
  "sha2",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset 0.5.7",
+ "hashbrown 0.15.5",
+ "indexmap",
 ]
 
 [[package]]
@@ -2636,6 +2753,15 @@ name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]
@@ -3463,7 +3589,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
 dependencies = [
- "quick-xml",
+ "quick-xml 0.37.5",
  "thiserror 2.0.18",
  "windows 0.61.3",
  "windows-version",
@@ -3515,7 +3641,7 @@ dependencies = [
  "fancy-regex",
  "filedescriptor",
  "finl_unicode",
- "fixedbitset",
+ "fixedbitset 0.4.2",
  "hex",
  "lazy_static",
  "libc",
@@ -3841,6 +3967,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom 8.0.0",
+ "petgraph",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4130,6 +4267,76 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix 1.1.4",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags 2.11.1",
+ "rustix 1.1.4",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.39.4",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
 ]
 
 [[package]]
@@ -4655,6 +4862,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix 1.1.4",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4668,6 +4893,23 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix 1.1.4",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "y4m"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["command-line-utilities"]
 exclude = ["docs/", ".github/", "dist-workspace.toml"]
 
 [dependencies]
+arboard = { version = "3.6.1", features = ["wl-clipboard-rs", "wayland-data-control"] }
 base64 = "0.22"
 chrono = { version = "0.4.44", default-features = false, features = ["clock"] }
 crossterm = { version = "0.29.0", features = ["event-stream"] }
@@ -21,6 +22,7 @@ futures = "0.3.32"
 image = "0.25.10"
 mime_guess = "2.0"
 notify-rust = "4"
+png = "0.18.1"
 qrcode = { version = "0.14", default-features = false }
 rand = "0.8"
 ratatui = "0.30.0"

--- a/src/discord/commands.rs
+++ b/src/discord/commands.rs
@@ -1,8 +1,11 @@
 use std::path::PathBuf;
 
-use crate::discord::ids::{
-    Id,
-    marker::{ChannelMarker, EmojiMarker, GuildMarker, MessageMarker, UserMarker},
+use crate::{
+    discord::ids::{
+        Id,
+        marker::{ChannelMarker, EmojiMarker, GuildMarker, MessageMarker, UserMarker},
+    },
+    logging,
 };
 
 pub const MAX_UPLOAD_FILE_BYTES: u64 = 10 * 1024 * 1024;
@@ -14,6 +17,23 @@ pub struct MessageAttachmentUpload {
     pub path: PathBuf,
     pub filename: String,
     pub size_bytes: u64,
+    pub requires_cleanup: bool,
+}
+
+impl Drop for MessageAttachmentUpload {
+    fn drop(&mut self) {
+        if self.requires_cleanup {
+            if let Err(e) = std::fs::remove_file(&self.path) {
+                logging::error(
+                    "app",
+                    format!(
+                        "could not remove temp attachment file {}: {e}",
+                        &self.path.display()
+                    ),
+                );
+            }
+        }
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/src/discord/rest.rs
+++ b/src/discord/rest.rs
@@ -1156,6 +1156,7 @@ mod tests {
             path: "/tmp/cat.png".into(),
             filename: "cat.png".to_owned(),
             size_bytes: 2_048,
+            requires_cleanup: false,
         }];
 
         validate_message_payload("   ", &attachments).expect("file-only messages should be valid");
@@ -1173,6 +1174,7 @@ mod tests {
             path: "/tmp/large.bin".into(),
             filename: "large.bin".to_owned(),
             size_bytes: MAX_UPLOAD_FILE_BYTES + 1,
+            requires_cleanup: false,
         }];
         let error = validate_message_payload("", &too_large_file)
             .expect_err("oversized attachment must fail");
@@ -1183,16 +1185,19 @@ mod tests {
                 path: "/tmp/a.bin".into(),
                 filename: "a.bin".to_owned(),
                 size_bytes: MAX_UPLOAD_FILE_BYTES - 1,
+                requires_cleanup: false,
             },
             MessageAttachmentUpload {
                 path: "/tmp/b.bin".into(),
                 filename: "b.bin".to_owned(),
                 size_bytes: MAX_UPLOAD_FILE_BYTES - 1,
+                requires_cleanup: false,
             },
             MessageAttachmentUpload {
                 path: "/tmp/c.bin".into(),
                 filename: "c.bin".to_owned(),
                 size_bytes: MAX_UPLOAD_FILE_BYTES - 1,
+                requires_cleanup: false,
             },
         ];
         let error = validate_message_payload("", &too_large_total)
@@ -1214,6 +1219,7 @@ mod tests {
             path: path.clone(),
             filename: "changed.bin".to_owned(),
             size_bytes: 1,
+            requires_cleanup: false,
         };
         std::fs::write(&path, vec![0_u8; (MAX_UPLOAD_FILE_BYTES + 1) as usize])
             .expect("oversized temp file can be written");

--- a/src/tui/input/keyboard.rs
+++ b/src/tui/input/keyboard.rs
@@ -268,13 +268,13 @@ fn handle_leader_action_key(state: &mut DashboardState, key: KeyEvent) -> Option
     }
 }
 
-pub fn handle_paste(state: &mut DashboardState, text: &str) -> bool {
+pub fn handle_paste(state: &mut DashboardState, text: &str, requires_cleanup: bool) -> bool {
     if !state.is_composing() {
         return false;
     }
 
     if state.composer_accepts_attachments() {
-        if let Some(attachments) = pasted_file_attachments(text) {
+        if let Some(attachments) = pasted_file_attachments(text, requires_cleanup) {
             state.add_pending_composer_attachments(attachments);
             return true;
         }
@@ -288,7 +288,10 @@ pub fn handle_paste(state: &mut DashboardState, text: &str) -> bool {
     true
 }
 
-fn pasted_file_attachments(text: &str) -> Option<Vec<MessageAttachmentUpload>> {
+fn pasted_file_attachments(
+    text: &str,
+    requires_cleanup: bool,
+) -> Option<Vec<MessageAttachmentUpload>> {
     let mut attachments = Vec::new();
     for line in meaningful_paste_lines(text) {
         let values = if let Some(path) = pasted_file_path(line).filter(|path| path.is_file()) {
@@ -310,6 +313,7 @@ fn pasted_file_attachments(text: &str) -> Option<Vec<MessageAttachmentUpload>> {
                     .to_owned(),
                 path,
                 size_bytes: metadata.len(),
+                requires_cleanup,
             });
         }
     }

--- a/src/tui/input/tests.rs
+++ b/src/tui/input/tests.rs
@@ -1121,7 +1121,7 @@ fn paste_inserts_text_while_composing() {
     handle_key(&mut state, key(KeyCode::Enter));
     handle_key(&mut state, char_key('i'));
 
-    assert!(handle_paste(&mut state, "hello\r\nworld"));
+    assert!(handle_paste(&mut state, "hello\r\nworld", false));
 
     assert_eq!(state.composer_input(), "hello\nworld");
 }
@@ -1140,7 +1140,7 @@ fn paste_inserts_text_at_composer_cursor() {
         handle_key(&mut state, key(KeyCode::Left));
     }
 
-    assert!(handle_paste(&mut state, " "));
+    assert!(handle_paste(&mut state, " ", false));
 
     assert_eq!(state.composer_input(), "hello world");
     assert_eq!(state.composer_cursor_byte_index(), "hello ".len());
@@ -1157,7 +1157,8 @@ fn paste_file_path_adds_pending_attachment() {
 
     assert!(handle_paste(
         &mut state,
-        path.to_str().expect("temp path is valid unicode")
+        path.to_str().expect("temp path is valid unicode"),
+        false,
     ));
 
     assert_eq!(state.composer_input(), "");
@@ -1181,7 +1182,7 @@ fn paste_single_quoted_file_path_adds_pending_attachment() {
     handle_key(&mut state, char_key('i'));
     let pasted = format!("'{}'", path.to_str().expect("temp path is valid unicode"));
 
-    assert!(handle_paste(&mut state, &pasted));
+    assert!(handle_paste(&mut state, &pasted, false));
 
     assert_eq!(state.composer_input(), "");
     assert_eq!(state.pending_composer_attachments().len(), 1);
@@ -1206,7 +1207,7 @@ fn paste_backslash_escaped_file_path_adds_pending_attachment() {
         .expect("temp path is valid unicode")
         .replace(' ', "\\ ");
 
-    assert!(handle_paste(&mut state, &pasted));
+    assert!(handle_paste(&mut state, &pasted, false));
 
     assert_eq!(state.composer_input(), "");
     assert_eq!(state.pending_composer_attachments().len(), 1);
@@ -1231,7 +1232,7 @@ fn paste_file_uri_list_can_submit_attachment_only_message() {
     handle_key(&mut state, key(KeyCode::Enter));
     handle_key(&mut state, char_key('i'));
 
-    assert!(handle_paste(&mut state, &uri));
+    assert!(handle_paste(&mut state, &uri, false));
     let command = handle_key(&mut state, key(KeyCode::Enter));
 
     assert_eq!(state.pending_composer_attachments(), &[]);
@@ -1245,6 +1246,7 @@ fn paste_file_uri_list_can_submit_attachment_only_message() {
                 path: path.clone(),
                 filename: "uri path.txt".to_owned(),
                 size_bytes: 6,
+                requires_cleanup: false
             }],
         })
     );
@@ -1267,7 +1269,7 @@ fn ctrl_backspace_removes_last_pending_attachment() {
         second.to_str().expect("temp path is valid unicode")
     );
 
-    assert!(handle_paste(&mut state, &pasted));
+    assert!(handle_paste(&mut state, &pasted, false));
     handle_key(
         &mut state,
         KeyEvent::new(KeyCode::Backspace, KeyModifiers::CONTROL),
@@ -1290,7 +1292,8 @@ fn paste_file_path_while_editing_inserts_text_instead_of_attachment() {
 
     assert!(handle_paste(
         &mut state,
-        path.to_str().expect("temp path is valid unicode")
+        path.to_str().expect("temp path is valid unicode"),
+        false
     ));
 
     assert!(state.pending_composer_attachments().is_empty());
@@ -1306,7 +1309,7 @@ fn paste_file_path_while_editing_inserts_text_instead_of_attachment() {
 fn paste_is_ignored_when_not_composing() {
     let mut state = state_with_channel_tree();
 
-    assert!(!handle_paste(&mut state, "hello"));
+    assert!(!handle_paste(&mut state, "hello", false));
 
     assert_eq!(state.composer_input(), "");
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -24,6 +24,7 @@ use crate::discord::ids::{
     Id,
     marker::{ChannelMarker, GuildMarker, UserMarker},
 };
+use arboard::Clipboard;
 use crossterm::{
     event::{
         DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
@@ -682,9 +683,22 @@ async fn run_dashboard(
                         redraw_diagnostics.resizes = redraw_diagnostics.resizes.saturating_add(1);
                         dirty = true;
                     }
-                    Some(Ok(TerminalEvent::Paste(text))) => {
-                        if input::handle_paste(&mut state, &text) {
-                            dirty = true;
+                    Some(Ok(TerminalEvent::Paste(_))) => {
+                        if let Ok(mut cb) = Clipboard::new() {
+                            let text = if let Ok(text) = cb.get_text() {
+                                text
+                            } else if let Ok(image_data) = cb.get_image() {
+                                match write_image_to_tmp(image_data) {
+                                    Ok(tmp_file) => format!("copy\nfile://{}", tmp_file.display()),
+                                    Err(_) => continue,
+                                }
+                            } else {
+                                continue;
+                            };
+
+                            if input::handle_paste(&mut state, text.as_str()) {
+                                dirty = true;
+                            }
                         }
                     }
                     Some(Ok(_)) => {}
@@ -1044,6 +1058,44 @@ fn save_display_options_if_needed(state: &mut DashboardState) {
             message: format!("save options failed: {error}"),
         }),
     }
+}
+
+fn write_image_to_tmp(img: arboard::ImageData<'_>) -> std::io::Result<std::path::PathBuf> {
+    let path = std::env::temp_dir().join(format!(
+        "concord-paste-{}.png",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis()
+    ));
+
+    let Ok(width) = u32::try_from(img.width) else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("Clipboard Image Width was invalid ({})", img.width),
+        ));
+    };
+
+    let Ok(height) = u32::try_from(img.height) else {
+        return Err(std::io::Error::other(format!(
+            "Clipboard Image Height was invalid ({})",
+            img.height
+        )));
+    };
+
+    if let Err(e) = image::save_buffer_with_format(
+        &path,
+        &img.bytes,
+        width,
+        height,
+        image::ColorType::Rgba8,
+        image::ImageFormat::Png,
+    ) {
+        logging::error("app", e.to_string());
+        return Err(std::io::Error::other(e.to_string()));
+    }
+
+    Ok(path)
 }
 
 #[cfg(test)]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1061,13 +1061,7 @@ fn save_display_options_if_needed(state: &mut DashboardState) {
 }
 
 fn write_image_to_tmp(img: arboard::ImageData<'_>) -> std::io::Result<std::path::PathBuf> {
-    let path = std::env::temp_dir().join(format!(
-        "concord-paste-{}.png",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis()
-    ));
+    let path = std::env::temp_dir().join(format!("concord-paste-{}.png", uuid::Uuid::new_v4()));
 
     let Ok(width) = u32::try_from(img.width) else {
         return Err(std::io::Error::new(

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -17,6 +17,7 @@ use std::sync::Once;
 use std::{
     collections::{HashSet, VecDeque},
     io::{Write, stdout},
+    path::PathBuf,
     sync::atomic::{AtomicBool, Ordering},
 };
 
@@ -683,22 +684,10 @@ async fn run_dashboard(
                         redraw_diagnostics.resizes = redraw_diagnostics.resizes.saturating_add(1);
                         dirty = true;
                     }
-                    Some(Ok(TerminalEvent::Paste(_))) => {
-                        if let Ok(mut cb) = Clipboard::new() {
-                            let text = if let Ok(text) = cb.get_text() {
-                                text
-                            } else if let Ok(image_data) = cb.get_image() {
-                                match write_image_to_tmp(image_data) {
-                                    Ok(tmp_file) => format!("copy\nfile://{}", tmp_file.display()),
-                                    Err(_) => continue,
-                                }
-                            } else {
-                                continue;
-                            };
-
-                            if input::handle_paste(&mut state, text.as_str()) {
-                                dirty = true;
-                            }
+                    Some(Ok(TerminalEvent::Paste(_text))) => {
+                        let Some((text, requires_cleanup)) = resolve_paste_text(_text) else { continue };
+                        if input::handle_paste(&mut state, text.as_str(), requires_cleanup) {
+                            dirty = true;
                         }
                     }
                     Some(Ok(_)) => {}
@@ -1090,6 +1079,23 @@ fn write_image_to_tmp(img: arboard::ImageData<'_>) -> std::io::Result<std::path:
     }
 
     Ok(path)
+}
+
+fn resolve_paste_text(text: String) -> Option<(String, bool)> {
+    if !text.is_empty() {
+        return Some((text, false));
+    }
+
+    let mut cb = Clipboard::new().ok()?;
+
+    if let Ok(text) = cb.get_text() {
+        Some((text, false))
+    } else if let Ok(image_data) = cb.get_image() {
+        let tmp_file = write_image_to_tmp(image_data).ok()?;
+        Some((format!("copy\nfile://{}", tmp_file.display()), true))
+    } else {
+        None
+    }
 }
 
 #[cfg(test)]

--- a/src/tui/state/tests/mod.rs
+++ b/src/tui/state/tests/mod.rs
@@ -3446,6 +3446,7 @@ fn cancel_composer_clears_pending_attachments() {
         path: "/tmp/cat.png".into(),
         filename: "cat.png".to_owned(),
         size_bytes: 2_048,
+        requires_cleanup: false,
     }]);
 
     state.cancel_composer();
@@ -3464,6 +3465,7 @@ fn pending_attachments_are_capped_at_upload_limit() {
             path: format!("/tmp/{index}.txt").into(),
             filename: format!("{index}.txt"),
             size_bytes: 1,
+            requires_cleanup: false,
         })
         .collect();
 

--- a/src/tui/ui/tests.rs
+++ b/src/tui/ui/tests.rs
@@ -465,6 +465,7 @@ fn composer_lines_show_pending_upload_above_input() {
         path: "/tmp/cat.png".into(),
         filename: "cat.png".to_owned(),
         size_bytes: 2_048,
+        requires_cleanup: false,
     }]);
 
     let lines = composer_lines(&state, 80);
@@ -502,6 +503,7 @@ fn composer_cursor_position_accounts_for_upload_and_reply_rows() {
         path: "/tmp/cat.png".into(),
         filename: "cat.png".to_owned(),
         size_bytes: 2_048,
+        requires_cleanup: false,
     }]);
     for value in "hi".chars() {
         state.push_composer_char(value);


### PR DESCRIPTION
some screenshotting tools provide the raw image data (image/png) rather than a URI to a file.
this commit allows users to paste the raw data, rather than creating a file each time.

**i have not added screenshots, since there is no difference in the ui to copy/pasting a normal file**