### PR TITLE
feat: support resizing panes

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ With vim-style navigation:
 | `j` / `k`, arrows         | Move down / up                       |
 | `J`, `K` / `H`, `L`       | Scroll viewport                      |
 | `Ctrl+d` / `Ctrl+u`       | Half-page scroll                     |
+| `Alt+h/l/←/→`             | Resize focused pane width            |
 | `g` / `G`, `Home` / `End` | Jump or scroll to top / bottom       |
 | `Enter`                   | Open or activate the selected item   |
 | `Space`                   | Open leader shortcut window          |

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,9 @@ pub struct DisplayOptions {
     pub image_preview_quality: ImagePreviewQualityPreset,
     pub show_custom_emoji: bool,
     pub desktop_notifications: bool,
+    pub server_width: u16,
+    pub channel_list_width: u16,
+    pub member_list_width: u16,
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
@@ -60,6 +63,9 @@ impl Default for DisplayOptions {
             image_preview_quality: ImagePreviewQualityPreset::default(),
             show_custom_emoji: true,
             desktop_notifications: true,
+            server_width: 20,
+            channel_list_width: 24,
+            member_list_width: 26,
         }
     }
 }
@@ -199,6 +205,9 @@ mod tests {
             image_preview_quality: ImagePreviewQualityPreset::Balanced,
             show_custom_emoji: true,
             desktop_notifications: true,
+            server_width: 20,
+            channel_list_width: 24,
+            member_list_width: 26,
         };
 
         assert!(!options.avatars_visible());
@@ -229,6 +238,9 @@ mod tests {
             assert_eq!(config.display.image_preview_quality, image_preview_quality);
             assert!(config.display.show_custom_emoji);
             assert!(config.display.desktop_notifications);
+            assert_eq!(config.display.server_width, 20);
+            assert_eq!(config.display.channel_list_width, 24);
+            assert_eq!(config.display.member_list_width, 26);
         }
     }
 
@@ -242,6 +254,9 @@ mod tests {
             image_preview_quality: ImagePreviewQualityPreset::Original,
             show_custom_emoji: false,
             desktop_notifications: false,
+            server_width: 12,
+            channel_list_width: 30,
+            member_list_width: 18,
         };
 
         save_display_options_to_path(&path, &options).expect("config should save");

--- a/src/tui/input/keyboard.rs
+++ b/src/tui/input/keyboard.rs
@@ -89,6 +89,12 @@ pub fn handle_key(state: &mut DashboardState, key: KeyEvent) -> Option<AppComman
         KeyCode::Char('2') => state.show_and_focus_pane(FocusPane::Channels),
         KeyCode::Char('3') => state.show_and_focus_pane(FocusPane::Messages),
         KeyCode::Char('4') => state.show_and_focus_pane(FocusPane::Members),
+        KeyCode::Left if key.modifiers.contains(KeyModifiers::SHIFT) => {
+            state.adjust_focused_pane_width(-1)
+        }
+        KeyCode::Right if key.modifiers.contains(KeyModifiers::SHIFT) => {
+            state.adjust_focused_pane_width(1)
+        }
         KeyCode::Char('j') | KeyCode::Down => state.move_down(),
         KeyCode::Char('J') if focus == FocusPane::Messages => state.scroll_message_viewport_down(),
         KeyCode::Char('L') => state.scroll_focused_pane_horizontal_right(),

--- a/src/tui/input/keyboard.rs
+++ b/src/tui/input/keyboard.rs
@@ -89,10 +89,10 @@ pub fn handle_key(state: &mut DashboardState, key: KeyEvent) -> Option<AppComman
         KeyCode::Char('2') => state.show_and_focus_pane(FocusPane::Channels),
         KeyCode::Char('3') => state.show_and_focus_pane(FocusPane::Messages),
         KeyCode::Char('4') => state.show_and_focus_pane(FocusPane::Members),
-        KeyCode::Left if key.modifiers.contains(KeyModifiers::SHIFT) => {
+        KeyCode::Char('h') | KeyCode::Left if key.modifiers.contains(KeyModifiers::ALT) => {
             state.adjust_focused_pane_width(-1)
         }
-        KeyCode::Right if key.modifiers.contains(KeyModifiers::SHIFT) => {
+        KeyCode::Char('l') | KeyCode::Right if key.modifiers.contains(KeyModifiers::ALT) => {
             state.adjust_focused_pane_width(1)
         }
         KeyCode::Char('j') | KeyCode::Down => state.move_down(),

--- a/src/tui/input/tests.rs
+++ b/src/tui/input/tests.rs
@@ -35,8 +35,8 @@ fn shift_enter() -> KeyEvent {
     KeyEvent::new(KeyCode::Enter, KeyModifiers::SHIFT)
 }
 
-fn shift_key(code: KeyCode) -> KeyEvent {
-    KeyEvent::new(code, KeyModifiers::SHIFT)
+fn alt_key(code: KeyCode) -> KeyEvent {
+    KeyEvent::new(code, KeyModifiers::ALT)
 }
 
 fn mouse(kind: MouseEventKind, column: u16, row: u16) -> MouseEvent {
@@ -338,14 +338,14 @@ fn leader_number_keys_toggle_side_panes() {
 }
 
 #[test]
-fn shift_arrows_adjust_focused_side_pane_width() {
+fn alt_arrows_adjust_focused_side_pane_width() {
     let mut state = DashboardState::new();
 
     state.focus_pane(FocusPane::Channels);
-    handle_key(&mut state, shift_key(KeyCode::Right));
+    handle_key(&mut state, alt_key(KeyCode::Right));
     assert_eq!(state.pane_width(FocusPane::Channels), 25);
 
-    handle_key(&mut state, shift_key(KeyCode::Left));
+    handle_key(&mut state, alt_key(KeyCode::Left));
     assert_eq!(state.pane_width(FocusPane::Channels), 24);
     assert_eq!(
         state.take_display_options_save_request(),
@@ -353,9 +353,21 @@ fn shift_arrows_adjust_focused_side_pane_width() {
     );
 
     state.focus_pane(FocusPane::Messages);
-    handle_key(&mut state, shift_key(KeyCode::Right));
+    handle_key(&mut state, alt_key(KeyCode::Right));
     assert_eq!(state.pane_width(FocusPane::Channels), 24);
     assert_eq!(state.take_display_options_save_request(), None);
+}
+
+#[test]
+fn alt_h_l_adjust_focused_side_pane_width() {
+    let mut state = DashboardState::new();
+
+    state.focus_pane(FocusPane::Channels);
+    handle_key(&mut state, alt_key(KeyCode::Char('l')));
+    assert_eq!(state.pane_width(FocusPane::Channels), 25);
+
+    handle_key(&mut state, alt_key(KeyCode::Char('h')));
+    assert_eq!(state.pane_width(FocusPane::Channels), 24);
 }
 
 #[test]

--- a/src/tui/input/tests.rs
+++ b/src/tui/input/tests.rs
@@ -35,6 +35,10 @@ fn shift_enter() -> KeyEvent {
     KeyEvent::new(KeyCode::Enter, KeyModifiers::SHIFT)
 }
 
+fn shift_key(code: KeyCode) -> KeyEvent {
+    KeyEvent::new(code, KeyModifiers::SHIFT)
+}
+
 fn mouse(kind: MouseEventKind, column: u16, row: u16) -> MouseEvent {
     MouseEvent {
         kind,
@@ -331,6 +335,27 @@ fn leader_number_keys_toggle_side_panes() {
     handle_key(&mut state, char_key(' '));
     handle_key(&mut state, char_key('1'));
     assert!(state.is_pane_visible(FocusPane::Guilds));
+}
+
+#[test]
+fn shift_arrows_adjust_focused_side_pane_width() {
+    let mut state = DashboardState::new();
+
+    state.focus_pane(FocusPane::Channels);
+    handle_key(&mut state, shift_key(KeyCode::Right));
+    assert_eq!(state.pane_width(FocusPane::Channels), 25);
+
+    handle_key(&mut state, shift_key(KeyCode::Left));
+    assert_eq!(state.pane_width(FocusPane::Channels), 24);
+    assert_eq!(
+        state.take_display_options_save_request(),
+        Some(state.display_options())
+    );
+
+    state.focus_pane(FocusPane::Messages);
+    handle_key(&mut state, shift_key(KeyCode::Right));
+    assert_eq!(state.pane_width(FocusPane::Channels), 24);
+    assert_eq!(state.take_display_options_save_request(), None);
 }
 
 #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -241,6 +241,7 @@ fn deliver_desktop_notification(title: &str, body: &str) -> std::result::Result<
     }
 }
 
+#[cfg(not(target_os = "macos"))]
 fn deliver_notify_rust_notification(title: &str, body: &str) -> std::result::Result<(), String> {
     notify_rust::Notification::new()
         .summary(title)

--- a/src/tui/state/options.rs
+++ b/src/tui/state/options.rs
@@ -1,8 +1,10 @@
 use crate::config::{DisplayOptions, ImagePreviewQualityPreset};
 
-use super::{DashboardState, popups::OptionsPopupState};
+use super::{DashboardState, FocusPane, popups::OptionsPopupState};
 
 const OPTION_COUNT: usize = 6;
+const MIN_PANE_WIDTH: u16 = 8;
+const MAX_PANE_WIDTH: u16 = 80;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DisplayOptionItem {
@@ -43,6 +45,35 @@ impl DashboardState {
 
     pub fn desktop_notifications_enabled(&self) -> bool {
         self.display_options.desktop_notifications
+    }
+
+    pub fn pane_width(&self, pane: FocusPane) -> u16 {
+        match pane {
+            FocusPane::Guilds => self.display_options.server_width,
+            FocusPane::Channels => self.display_options.channel_list_width,
+            FocusPane::Members => self.display_options.member_list_width,
+            FocusPane::Messages => 0,
+        }
+    }
+
+    pub fn adjust_focused_pane_width(&mut self, delta: i16) {
+        let width = match self.focus {
+            FocusPane::Guilds => &mut self.display_options.server_width,
+            FocusPane::Channels => &mut self.display_options.channel_list_width,
+            FocusPane::Members => &mut self.display_options.member_list_width,
+            FocusPane::Messages => return,
+        };
+
+        let adjusted = if delta.is_negative() {
+            width.saturating_sub(delta.unsigned_abs())
+        } else {
+            width.saturating_add(delta as u16)
+        };
+        let adjusted = adjusted.clamp(MIN_PANE_WIDTH, MAX_PANE_WIDTH);
+        if adjusted != *width {
+            *width = adjusted;
+            self.display_options_save_pending = true;
+        }
     }
 
     pub fn is_options_popup_open(&self) -> bool {

--- a/src/tui/ui/layout.rs
+++ b/src/tui/ui/layout.rs
@@ -23,10 +23,19 @@ pub(super) fn dashboard_areas(area: Rect, state: &DashboardState) -> DashboardAr
     .areas(area);
 
     let [guilds, channels, center, members] = Layout::horizontal([
-        pane_width(state.is_pane_visible(FocusPane::Guilds), 20),
-        pane_width(state.is_pane_visible(FocusPane::Channels), 24),
+        pane_width(
+            state.is_pane_visible(FocusPane::Guilds),
+            state.pane_width(FocusPane::Guilds),
+        ),
+        pane_width(
+            state.is_pane_visible(FocusPane::Channels),
+            state.pane_width(FocusPane::Channels),
+        ),
         Constraint::Min(40),
-        pane_width(state.is_pane_visible(FocusPane::Members), 26),
+        pane_width(
+            state.is_pane_visible(FocusPane::Members),
+            state.pane_width(FocusPane::Members),
+        ),
     ])
     .areas(main);
 

--- a/src/tui/ui/panes.rs
+++ b/src/tui/ui/panes.rs
@@ -821,11 +821,11 @@ pub(super) fn footer_hint(state: &DashboardState) -> String {
             "j/k choose action | enter select | esc close | q quit".to_owned()
         }
     } else if state.focus() == FocusPane::Members {
-        "tab/shift+tab/1-4 focus | shift+←/→ width | j/k move | H/L scroll name | enter profile | space leader | i write | q quit".to_owned()
+        "tab/shift+tab/1-4 focus | alt+h/l/←/→ width | j/k move | H/L scroll name | enter profile | space leader | i write | q quit".to_owned()
     } else if state.focus() == FocusPane::Channels {
-        "tab/shift+tab/1-4 focus | shift+←/→ width | j/k move | H/L scroll name | enter open | space leader | h/← close | l/→ open | ` logs | i write | q quit".to_owned()
+        "tab/shift+tab/1-4 focus | alt+h/l/←/→ width | j/k move | H/L scroll name | enter open | space leader | h/← close | l/→ open | ` logs | i write | q quit".to_owned()
     } else if state.focus() == FocusPane::Guilds {
-        "tab/shift+tab/1-4 focus | shift+←/→ width | j/k move | J/K scroll | H/L scroll name | enter action/tree | space leader | h/← close | l/→ open | ` logs | i write | esc cancel | q quit".to_owned()
+        "tab/shift+tab/1-4 focus | alt+h/l/←/→ width | j/k move | J/K scroll | H/L scroll name | enter action/tree | space leader | h/← close | l/→ open | ` logs | i write | esc cancel | q quit".to_owned()
     } else {
         "tab/shift+tab/1-4 focus | j/k move | J/K scroll | enter actions | space leader | ` logs | i write | esc cancel | q quit".to_owned()
     }

--- a/src/tui/ui/panes.rs
+++ b/src/tui/ui/panes.rs
@@ -821,11 +821,11 @@ pub(super) fn footer_hint(state: &DashboardState) -> String {
             "j/k choose action | enter select | esc close | q quit".to_owned()
         }
     } else if state.focus() == FocusPane::Members {
-        "tab/shift+tab/1-4 focus | j/k move | H/L scroll name | enter profile | space leader | i write | q quit".to_owned()
+        "tab/shift+tab/1-4 focus | shift+←/→ width | j/k move | H/L scroll name | enter profile | space leader | i write | q quit".to_owned()
     } else if state.focus() == FocusPane::Channels {
-        "tab/shift+tab/1-4 focus | j/k move | H/L scroll name | enter open | space leader | h/← close | l/→ open | ` logs | i write | q quit".to_owned()
+        "tab/shift+tab/1-4 focus | shift+←/→ width | j/k move | H/L scroll name | enter open | space leader | h/← close | l/→ open | ` logs | i write | q quit".to_owned()
     } else if state.focus() == FocusPane::Guilds {
-        "tab/shift+tab/1-4 focus | j/k move | J/K scroll | H/L scroll name | enter action/tree | space leader | h/← close | l/→ open | ` logs | i write | esc cancel | q quit".to_owned()
+        "tab/shift+tab/1-4 focus | shift+←/→ width | j/k move | J/K scroll | H/L scroll name | enter action/tree | space leader | h/← close | l/→ open | ` logs | i write | esc cancel | q quit".to_owned()
     } else {
         "tab/shift+tab/1-4 focus | j/k move | J/K scroll | enter actions | space leader | ` logs | i write | esc cancel | q quit".to_owned()
     }

--- a/src/tui/ui/tests.rs
+++ b/src/tui/ui/tests.rs
@@ -369,6 +369,28 @@ fn focus_pane_at_expands_messages_over_hidden_panes() {
 }
 
 #[test]
+fn focus_pane_at_uses_configured_pane_widths() {
+    let state = DashboardState::new_with_display_options(DisplayOptions {
+        server_width: 10,
+        channel_list_width: 20,
+        member_list_width: 15,
+        ..DisplayOptions::default()
+    });
+    let area = Rect::new(0, 0, 100, 20);
+
+    assert_eq!(focus_pane_at(area, &state, 9, 1), Some(FocusPane::Guilds));
+    assert_eq!(
+        focus_pane_at(area, &state, 10, 1),
+        Some(FocusPane::Channels)
+    );
+    assert_eq!(
+        focus_pane_at(area, &state, 30, 1),
+        Some(FocusPane::Messages)
+    );
+    assert_eq!(focus_pane_at(area, &state, 85, 1), Some(FocusPane::Members));
+}
+
+#[test]
 fn sync_view_heights_reserves_space_for_composer_height() {
     enum ExpectedHeight {
         Exact(usize),


### PR DESCRIPTION
# Problem

On a large monitor, the pane widths seem arbitrarily and unnecessarily narrow and are hard to read when server/channel names are long

# Proposed solution

I've added two keyboard shortcuts (which are only active when the server/channel/user panes are selected) to allow the adjustment of each width, and which save these settings to the `config.toml` so that they will persist through uses.

~~I have proposed using `SHIFT+RIGHT` to expand the width by 1 character column at a time and `SHIFT+LEFT` to reduce it by 1, but I am not certain these are the best ones to use; they were just the first ones that I came up with.  I'm happy to replace them with better ones if you have any.~~

@chojs23 suggested we use `ALT+h` / `ALT-l` /  `ALT-←` / `ALT→` and I have updated the code to reflect that.

Before:
<img width="1754" height="972" alt="Screenshot 2026-05-09 at 8 32 28 PM" src="https://github.com/user-attachments/assets/930b69a8-88d5-4e00-ae90-a914fe6de350" />

After:
<img width="1754" height="972" alt="Screenshot 2026-05-09 at 8 32 39 PM" src="https://github.com/user-attachments/assets/29227aa0-19d3-47a7-a08c-54d19197e369" />

New `config.toml`:
```toml
[display]
disable_image_preview = false
show_avatars = true
show_images = true
image_preview_quality = "original"
show_custom_emoji = true
desktop_notifications = true
server_width = 36                   <---- NEW
channel_list_width = 41             <---- NEW
member_list_width = 37              <---- NEW
```