### PR TITLE
feat: add search to reaction picker + allow toggling of reactions

### DIFF
--- a/src/tui/input/keyboard.rs
+++ b/src/tui/input/keyboard.rs
@@ -506,6 +506,15 @@ fn handle_emoji_reaction_picker_key(
 ) -> Option<AppCommand> {
     match key.code {
         KeyCode::Esc => state.close_emoji_reaction_picker(),
+        KeyCode::Backspace if state.is_filtering_emoji_reactions() => {
+            state.pop_emoji_reaction_filter_char();
+        }
+        KeyCode::Char('/') if is_shortcut_key(key) && !state.is_filtering_emoji_reactions() => {
+            state.start_emoji_reaction_filter();
+        }
+        KeyCode::Char(value) if is_shortcut_key(key) && state.is_filtering_emoji_reactions() => {
+            state.push_emoji_reaction_filter_char(value);
+        }
         code if is_down_key(code) => state.move_emoji_reaction_down(),
         code if is_up_key(code) => state.move_emoji_reaction_up(),
         code if is_confirm_key(code) => return state.activate_selected_emoji_reaction(),

--- a/src/tui/input/tests.rs
+++ b/src/tui/input/tests.rs
@@ -1873,6 +1873,30 @@ fn emoji_picker_selection_returns_reaction_command() {
 }
 
 #[test]
+fn emoji_picker_selection_removes_existing_own_reaction() {
+    let mut state = state_with_messages(1);
+    state.focus_pane(FocusPane::Messages);
+    state.push_event(AppEvent::CurrentUserReactionAdd {
+        channel_id: Id::new(2),
+        message_id: Id::new(1),
+        emoji: ReactionEmoji::Unicode("👍".to_owned()),
+    });
+    open_emoji_picker(&mut state);
+
+    let command = handle_key(&mut state, key(KeyCode::Enter));
+
+    assert_eq!(
+        command,
+        Some(AppCommand::RemoveReaction {
+            channel_id: Id::new(2),
+            message_id: Id::new(1),
+            emoji: ReactionEmoji::Unicode("👍".to_owned()),
+        })
+    );
+    assert!(!state.is_emoji_reaction_picker_open());
+}
+
+#[test]
 fn emoji_picker_number_shortcut_selects_reaction() {
     let mut state = state_with_messages(1);
     state.focus_pane(FocusPane::Messages);

--- a/src/tui/input/tests.rs
+++ b/src/tui/input/tests.rs
@@ -1892,6 +1892,56 @@ fn emoji_picker_number_shortcut_selects_reaction() {
 }
 
 #[test]
+fn emoji_picker_slash_filter_matches_name_and_implementation_case_insensitively() {
+    let mut state = state_with_custom_emoji_message();
+    state.focus_pane(FocusPane::Messages);
+    open_emoji_picker(&mut state);
+
+    handle_key(&mut state, char_key('/'));
+    handle_key(&mut state, char_key('T'));
+    handle_key(&mut state, char_key('h'));
+    handle_key(&mut state, char_key('i'));
+
+    assert_eq!(state.emoji_reaction_filter(), Some("Thi"));
+    assert_eq!(
+        state.selected_emoji_reaction().map(|item| item.emoji),
+        Some(ReactionEmoji::Custom {
+            id: Id::new(51),
+            name: Some("this".to_owned()),
+            animated: false,
+        })
+    );
+
+    let command = handle_key(&mut state, key(KeyCode::Enter));
+
+    assert_eq!(
+        command,
+        Some(AppCommand::AddReaction {
+            channel_id: Id::new(2),
+            message_id: Id::new(1),
+            emoji: ReactionEmoji::Custom {
+                id: Id::new(51),
+                name: Some("this".to_owned()),
+                animated: false,
+            },
+        })
+    );
+}
+
+#[test]
+fn emoji_picker_filter_treats_vim_keys_as_text() {
+    let mut state = state_with_messages(1);
+    state.focus_pane(FocusPane::Messages);
+    open_emoji_picker(&mut state);
+
+    handle_key(&mut state, char_key('/'));
+    handle_key(&mut state, char_key('j'));
+
+    assert_eq!(state.emoji_reaction_filter(), Some("j"));
+    assert_eq!(state.selected_emoji_reaction(), None);
+}
+
+#[test]
 fn emoji_picker_selection_returns_custom_reaction_command() {
     let mut state = state_with_custom_emoji_message();
     state.focus_pane(FocusPane::Messages);
@@ -2482,12 +2532,20 @@ fn state_with_custom_emoji_message() -> DashboardState {
         members: Vec::new(),
         presences: Vec::new(),
         roles: Vec::new(),
-        emojis: vec![CustomEmojiInfo {
-            id: Id::new(50),
-            name: "party".to_owned(),
-            animated: false,
-            available: true,
-        }],
+        emojis: vec![
+            CustomEmojiInfo {
+                id: Id::new(50),
+                name: "party".to_owned(),
+                animated: false,
+                available: true,
+            },
+            CustomEmojiInfo {
+                id: Id::new(51),
+                name: "this".to_owned(),
+                animated: false,
+                available: true,
+            },
+        ],
         owner_id: None,
     });
     state.confirm_selected_guild();

--- a/src/tui/media/targets.rs
+++ b/src/tui/media/targets.rs
@@ -506,10 +506,10 @@ pub(in crate::tui) fn visible_emoji_image_targets(state: &DashboardState) -> Vec
 
     // Picker emojis (existing behaviour).
     if state.is_emoji_reaction_picker_open() {
-        let reactions = state.emoji_reaction_items();
+        let reactions = state.filtered_emoji_reaction_items_slice().unwrap_or(&[]);
         if !reactions.is_empty() {
             let selected = state
-                .selected_emoji_reaction_index()
+                .selected_emoji_reaction_index_for_len(reactions.len())
                 .unwrap_or(0)
                 .min(reactions.len().saturating_sub(1));
             let visible_items = reactions

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -241,6 +241,7 @@ fn deliver_desktop_notification(title: &str, body: &str) -> std::result::Result<
     }
 }
 
+#[cfg(not(target_os = "macos"))]
 fn deliver_notify_rust_notification(title: &str, body: &str) -> std::result::Result<(), String> {
     notify_rust::Notification::new()
         .summary(title)

--- a/src/tui/state/popups.rs
+++ b/src/tui/state/popups.rs
@@ -5,7 +5,7 @@ use crate::discord::ids::{
 
 use crate::discord::ReactionUsersInfo;
 
-use super::PollVotePickerItem;
+use super::{EmojiReactionItem, PollVotePickerItem};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MessageActionMenuState {
@@ -67,6 +67,9 @@ pub(super) enum ChannelActionMenuState {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EmojiReactionPickerState {
     pub(super) selected: usize,
+    pub(super) filter: Option<String>,
+    pub(super) items: Vec<EmojiReactionItem>,
+    pub(super) filtered_items: Vec<EmojiReactionItem>,
     pub(super) guild_id: Option<Id<GuildMarker>>,
     pub(super) channel_id: Id<ChannelMarker>,
     pub(super) message_id: Id<MessageMarker>,

--- a/src/tui/state/reactions.rs
+++ b/src/tui/state/reactions.rs
@@ -146,10 +146,26 @@ impl DashboardState {
     pub fn activate_selected_emoji_reaction(&mut self) -> Option<AppCommand> {
         let picker = self.emoji_reaction_picker.clone()?;
         let reaction = self.selected_emoji_reaction()?;
-        let command = AppCommand::AddReaction {
-            channel_id: picker.channel_id,
-            message_id: picker.message_id,
-            emoji: reaction.emoji,
+        let already_reacted = self.selected_message_state().is_some_and(|message| {
+            message.channel_id == picker.channel_id
+                && message.id == picker.message_id
+                && message
+                    .reactions
+                    .iter()
+                    .any(|existing| existing.me && existing.emoji == reaction.emoji)
+        });
+        let command = if already_reacted {
+            AppCommand::RemoveReaction {
+                channel_id: picker.channel_id,
+                message_id: picker.message_id,
+                emoji: reaction.emoji,
+            }
+        } else {
+            AppCommand::AddReaction {
+                channel_id: picker.channel_id,
+                message_id: picker.message_id,
+                emoji: reaction.emoji,
+            }
         };
         self.close_emoji_reaction_picker();
         Some(command)

--- a/src/tui/state/reactions.rs
+++ b/src/tui/state/reactions.rs
@@ -22,8 +22,18 @@ impl DashboardState {
     }
 
     pub fn emoji_reaction_items(&self) -> Vec<EmojiReactionItem> {
+        if let Some(picker) = &self.emoji_reaction_picker {
+            return picker.items.clone();
+        }
+
+        self.emoji_reaction_items_for_guild(self.picker_guild_id())
+    }
+
+    fn emoji_reaction_items_for_guild(
+        &self,
+        guild_id: Option<Id<GuildMarker>>,
+    ) -> Vec<EmojiReactionItem> {
         let mut items = unicode_emoji_reaction_items();
-        let guild_id = self.picker_guild_id();
 
         if let Some(guild_id) = guild_id {
             items.extend(
@@ -36,6 +46,35 @@ impl DashboardState {
         }
 
         items
+    }
+
+    pub fn filtered_emoji_reaction_items(&self) -> Vec<EmojiReactionItem> {
+        if let Some(picker) = &self.emoji_reaction_picker {
+            return picker.filtered_items.clone();
+        }
+
+        let items = self.emoji_reaction_items();
+        let Some(filter) = self.emoji_reaction_filter() else {
+            return items;
+        };
+
+        filter_emoji_reaction_items(items, filter)
+    }
+
+    pub fn filtered_emoji_reaction_items_slice(&self) -> Option<&[EmojiReactionItem]> {
+        self.emoji_reaction_picker
+            .as_ref()
+            .map(|picker| picker.filtered_items.as_slice())
+    }
+
+    pub fn emoji_reaction_filter(&self) -> Option<&str> {
+        self.emoji_reaction_picker
+            .as_ref()
+            .and_then(|picker| picker.filter.as_deref())
+    }
+
+    pub fn is_filtering_emoji_reactions(&self) -> bool {
+        self.emoji_reaction_filter().is_some()
     }
 
     pub fn close_emoji_reaction_picker(&mut self) {
@@ -80,7 +119,7 @@ impl DashboardState {
     }
 
     pub fn move_emoji_reaction_down(&mut self) {
-        let reactions_len = self.emoji_reaction_items().len();
+        let reactions_len = self.filtered_emoji_reaction_items().len();
         if let Some(picker) = &mut self.emoji_reaction_picker {
             move_index_down(&mut picker.selected, reactions_len);
         }
@@ -92,15 +131,16 @@ impl DashboardState {
         }
     }
 
-    pub fn selected_emoji_reaction_index(&self) -> Option<usize> {
+    pub fn selected_emoji_reaction_index_for_len(&self, len: usize) -> Option<usize> {
         self.emoji_reaction_picker
             .as_ref()
-            .map(|picker| clamp_selected_index(picker.selected, self.emoji_reaction_items().len()))
+            .map(|picker| clamp_selected_index(picker.selected, len))
     }
 
     pub fn selected_emoji_reaction(&self) -> Option<EmojiReactionItem> {
-        let index = self.selected_emoji_reaction_index()?;
-        self.emoji_reaction_items().get(index).cloned()
+        let items = self.filtered_emoji_reaction_items();
+        let index = self.selected_emoji_reaction_index_for_len(items.len())?;
+        items.get(index).cloned()
     }
 
     pub fn activate_selected_emoji_reaction(&mut self) -> Option<AppCommand> {
@@ -118,7 +158,7 @@ impl DashboardState {
     pub fn activate_emoji_reaction_shortcut(&mut self, shortcut: char) -> Option<AppCommand> {
         let shortcut = shortcut.to_ascii_lowercase();
         let index = self
-            .emoji_reaction_items()
+            .filtered_emoji_reaction_items()
             .iter()
             .enumerate()
             .position(|(index, _)| indexed_shortcut(index) == Some(shortcut))?;
@@ -128,13 +168,46 @@ impl DashboardState {
         self.activate_selected_emoji_reaction()
     }
 
+    pub fn start_emoji_reaction_filter(&mut self) {
+        if let Some(picker) = &mut self.emoji_reaction_picker {
+            picker.filter = Some(String::new());
+            picker.filtered_items = picker.items.clone();
+            picker.selected = 0;
+        }
+    }
+
+    pub fn push_emoji_reaction_filter_char(&mut self, value: char) {
+        if let Some(picker) = &mut self.emoji_reaction_picker
+            && let Some(filter) = &mut picker.filter
+        {
+            filter.push(value);
+            picker.filtered_items = filter_emoji_reaction_items_from_slice(&picker.items, filter);
+            picker.selected = 0;
+        }
+    }
+
+    pub fn pop_emoji_reaction_filter_char(&mut self) {
+        if let Some(picker) = &mut self.emoji_reaction_picker
+            && let Some(filter) = &mut picker.filter
+        {
+            filter.pop();
+            picker.filtered_items = filter_emoji_reaction_items_from_slice(&picker.items, filter);
+            picker.selected = 0;
+        }
+    }
+
     pub(super) fn open_emoji_reaction_picker(&mut self) {
         if let Some(message) = self.selected_message_state() {
+            let guild_id = message
+                .guild_id
+                .or_else(|| self.selected_channel_guild_id());
+            let items = self.emoji_reaction_items_for_guild(guild_id);
             self.emoji_reaction_picker = Some(EmojiReactionPickerState {
                 selected: 0,
-                guild_id: message
-                    .guild_id
-                    .or_else(|| self.selected_channel_guild_id()),
+                filter: None,
+                filtered_items: items.clone(),
+                items,
+                guild_id,
                 channel_id: message.channel_id,
                 message_id: message.id,
             });
@@ -151,4 +224,33 @@ impl DashboardState {
             })
             .or_else(|| self.selected_channel_guild_id())
     }
+}
+
+fn emoji_reaction_matches_filter(item: &EmojiReactionItem, filter: &str) -> bool {
+    if filter.is_empty() {
+        return true;
+    }
+
+    item.label.to_lowercase().contains(filter)
+        || item.emoji.status_label().to_lowercase().contains(filter)
+}
+
+fn filter_emoji_reaction_items(
+    items: Vec<EmojiReactionItem>,
+    filter: &str,
+) -> Vec<EmojiReactionItem> {
+    filter_emoji_reaction_items_from_slice(&items, filter)
+}
+
+fn filter_emoji_reaction_items_from_slice(
+    items: &[EmojiReactionItem],
+    filter: &str,
+) -> Vec<EmojiReactionItem> {
+    let filter = filter.to_lowercase();
+
+    items
+        .iter()
+        .filter(|item| emoji_reaction_matches_filter(item, &filter))
+        .cloned()
+        .collect()
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -102,10 +102,10 @@ use self::{
     },
     popups::{
         channel_action_menu_lines, channel_switcher_cursor_position, channel_switcher_lines,
-        debug_log_popup_lines, emoji_reaction_picker_lines, guild_action_menu_lines,
-        member_action_menu_lines, message_action_menu_lines, options_popup_lines,
-        poll_vote_picker_lines, reaction_users_popup_lines, user_profile_popup_lines,
-        user_profile_popup_lines_with_activities,
+        debug_log_popup_lines, emoji_reaction_picker_lines, filtered_emoji_reaction_picker_lines,
+        guild_action_menu_lines, member_action_menu_lines, message_action_menu_lines,
+        options_popup_lines, poll_vote_picker_lines, reaction_users_popup_lines,
+        user_profile_popup_lines, user_profile_popup_lines_with_activities,
     },
 };
 

--- a/src/tui/ui/popups.rs
+++ b/src/tui/ui/popups.rs
@@ -739,33 +739,39 @@ pub(super) fn render_emoji_reaction_picker(
         return;
     }
 
-    let reactions = state.emoji_reaction_items();
-    if reactions.is_empty() {
+    let reactions = state.filtered_emoji_reaction_items_slice().unwrap_or(&[]);
+    if reactions.is_empty() && !state.is_filtering_emoji_reactions() {
         return;
     }
+    let filter = state.emoji_reaction_filter();
 
-    let selected = state.selected_emoji_reaction_index().unwrap_or(0);
+    let selected = state
+        .selected_emoji_reaction_index_for_len(reactions.len())
+        .unwrap_or(0);
     let desired_visible_items = reactions
         .len()
         .clamp(1, super::super::selection::MAX_EMOJI_REACTION_VISIBLE_ITEMS);
-    let popup = centered_rect(area, 42, (desired_visible_items as u16).saturating_add(4));
+    let popup = centered_rect(area, 42, (desired_visible_items as u16).saturating_add(5));
     let ready_urls = emoji_images
         .iter()
         .map(|image| image.url.clone())
         .collect::<Vec<_>>();
     let block = panel_block("Choose reaction", true);
     let content = block.inner(popup);
-    let visible_items = usize::from(content.height.saturating_sub(1)).min(desired_visible_items);
+    let footer_lines = if filter.is_some() { 2 } else { 1 };
+    let visible_items =
+        usize::from(content.height.saturating_sub(footer_lines)).min(desired_visible_items);
     let visible_range =
         super::super::selection::visible_item_range(reactions.len(), selected, visible_items);
     frame.render_widget(Clear, popup);
     frame.render_widget(
         Paragraph::new(emoji_reaction_picker_lines_with_custom_emoji_images(
-            &reactions,
+            reactions,
             selected,
             visible_items,
             &ready_urls,
             state.show_custom_emoji(),
+            filter,
         ))
         .block(block)
         .wrap(Wrap { trim: false }),
@@ -775,7 +781,7 @@ pub(super) fn render_emoji_reaction_picker(
         render_emoji_reaction_images(
             frame,
             content,
-            &reactions,
+            reactions,
             selected,
             visible_items,
             emoji_images,
@@ -1679,6 +1685,25 @@ pub(super) fn emoji_reaction_picker_lines(
         max_visible_items,
         thumbnail_urls,
         true,
+        None,
+    )
+}
+
+#[cfg(test)]
+pub(super) fn filtered_emoji_reaction_picker_lines(
+    reactions: &[EmojiReactionItem],
+    selected: usize,
+    max_visible_items: usize,
+    thumbnail_urls: &[String],
+    filter: &str,
+) -> Vec<Line<'static>> {
+    emoji_reaction_picker_lines_with_custom_emoji_images(
+        reactions,
+        selected,
+        max_visible_items,
+        thumbnail_urls,
+        true,
+        Some(filter),
     )
 }
 
@@ -1688,6 +1713,7 @@ fn emoji_reaction_picker_lines_with_custom_emoji_images(
     max_visible_items: usize,
     thumbnail_urls: &[String],
     show_custom_emoji: bool,
+    filter: Option<&str>,
 ) -> Vec<Line<'static>> {
     let selected = selected.min(reactions.len().saturating_sub(1));
     let visible_items = max_visible_items.max(1).min(reactions.len().max(1));
@@ -1721,10 +1747,27 @@ fn emoji_reaction_picker_lines_with_custom_emoji_images(
             ])
         })
         .collect();
+
+    if reactions.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  no matching reactions",
+            Style::default().fg(DIM),
+        )));
+    }
+
     lines.push(Line::from(Span::styled(
-        "Shortcut/Enter/Space react · Esc close",
+        "Shortcut/Enter/Space react · / filter · Esc close",
         Style::default().fg(DIM),
     )));
+    if let Some(filter) = filter {
+        lines.push(Line::from(vec![
+            Span::styled("Filter ", Style::default().fg(DIM)),
+            Span::styled(
+                format!("/{filter}"),
+                Style::default().fg(ACCENT).add_modifier(Modifier::BOLD),
+            ),
+        ]));
+    }
     lines
 }
 

--- a/src/tui/ui/tests.rs
+++ b/src/tui/ui/tests.rs
@@ -16,17 +16,18 @@ use super::{
     channel_switcher_cursor_position, channel_switcher_lines, channel_unread_decoration,
     composer_content_line_count, composer_cursor_position, composer_lines,
     composer_prompt_line_count, composer_text, date_separator_line, debug_log_popup_lines,
-    dm_presence_dot_span, emoji_reaction_picker_lines, focus_pane_at, footer_hint,
-    format_message_sent_time, format_unix_millis_with_offset, forum_post_reaction_summary,
-    forum_post_scrollbar_visible_count, forum_post_viewport_lines, guild_action_menu_lines,
-    inline_image_preview_area, inline_image_preview_row, member_action_menu_lines,
-    member_display_label, member_name_style, message_action_menu_lines, message_author_style,
-    message_item_lines, message_starts_new_day, message_viewport_lines, new_messages_notice_line,
-    options_popup_lines, poll_vote_picker_lines, primary_activity_summary,
-    reaction_users_popup_lines, reaction_users_visible_line_count, render_channels, render_guilds,
-    selected_avatar_x_offset, selected_message_card_width, selected_message_content_x_offset,
-    sync_view_heights, user_profile_popup_has_avatar, user_profile_popup_lines,
-    user_profile_popup_lines_with_activities, user_profile_popup_text_geometry,
+    dm_presence_dot_span, emoji_reaction_picker_lines, filtered_emoji_reaction_picker_lines,
+    focus_pane_at, footer_hint, format_message_sent_time, format_unix_millis_with_offset,
+    forum_post_reaction_summary, forum_post_scrollbar_visible_count, forum_post_viewport_lines,
+    guild_action_menu_lines, inline_image_preview_area, inline_image_preview_row,
+    member_action_menu_lines, member_display_label, member_name_style, message_action_menu_lines,
+    message_author_style, message_item_lines, message_starts_new_day, message_viewport_lines,
+    new_messages_notice_line, options_popup_lines, poll_vote_picker_lines,
+    primary_activity_summary, reaction_users_popup_lines, reaction_users_visible_line_count,
+    render_channels, render_guilds, selected_avatar_x_offset, selected_message_card_width,
+    selected_message_content_x_offset, sync_view_heights, user_profile_popup_has_avatar,
+    user_profile_popup_lines, user_profile_popup_lines_with_activities,
+    user_profile_popup_text_geometry,
 };
 use crate::{
     config::DisplayOptions,
@@ -2492,7 +2493,7 @@ fn emoji_reaction_picker_marks_selected_reaction() {
         vec![
             "  [1] 👍 Thumbs up",
             "› [2] :party: Party",
-            "Shortcut/Enter/Space react · Esc close"
+            "Shortcut/Enter/Space react · / filter · Esc close"
         ]
     );
 }
@@ -2793,7 +2794,10 @@ fn emoji_reaction_picker_reserves_space_for_loaded_custom_image() {
 
     assert_eq!(
         line_texts_from_ratatui(&lines),
-        vec!["› [1]    Party", "Shortcut/Enter/Space react · Esc close"]
+        vec![
+            "› [1]    Party",
+            "Shortcut/Enter/Space react · / filter · Esc close"
+        ]
     );
 }
 
@@ -2820,7 +2824,30 @@ fn emoji_reaction_picker_windows_long_lists_around_selection() {
             "      :emoji_10: Emoji 10",
             "      :emoji_11: Emoji 11",
             "›     :emoji_12: Emoji 12",
-            "Shortcut/Enter/Space react · Esc close"
+            "Shortcut/Enter/Space react · / filter · Esc close"
+        ]
+    );
+}
+
+#[test]
+fn emoji_reaction_picker_shows_active_filter() {
+    let reactions = vec![EmojiReactionItem {
+        emoji: ReactionEmoji::Custom {
+            id: Id::new(42),
+            name: Some("this".to_owned()),
+            animated: false,
+        },
+        label: "This goose".to_owned(),
+    }];
+
+    let lines = filtered_emoji_reaction_picker_lines(&reactions, 0, 10, &[], "thi");
+
+    assert_eq!(
+        line_texts_from_ratatui(&lines),
+        vec![
+            "› [1] :this: This goose",
+            "Shortcut/Enter/Space react · / filter · Esc close",
+            "Filter /thi",
         ]
     );
 }


### PR DESCRIPTION
# Problem

On servers with many reactions, finding the exact one you want can be difficult.  Also, once a reaction is added, there isn't a way to remove it.

# Proposed solution

In the reaction picker, if a user enters the `/` key, they can then begin typing to filter down the reactions to only ones with the entered text in the shortcut (e.g. `:this:`) or description.  Searching is case-insensitive.

I've also added the ability to remove an already-set reaction; simply select it again to remove it.

Demo:
https://github.com/user-attachments/assets/bfd86ae5-2d1e-4e30-ab2c-015221eee67d