### PR TITLE
feat: prefs persistence

### DIFF
--- a/src/discord/mod.rs
+++ b/src/discord/mod.rs
@@ -31,6 +31,6 @@ pub use ids::{Id, marker};
 pub use rest::ForumPostPage;
 pub use state::{
     ChannelRecipientState, ChannelState, ChannelUnreadState, ChannelVisibilityStats,
-    DiscordSnapshot, DiscordState, GuildMemberState, GuildState, MessageCapabilities, MessageState,
-    RoleState, SnapshotRevision,
+    DiscordSnapshot, DiscordState, DiscordStateCache, GuildMemberState, GuildState,
+    MessageCapabilities, MessageState, RoleState, SnapshotRevision,
 };

--- a/src/discord/state.rs
+++ b/src/discord/state.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, VecDeque};
+use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 mod notifications;
@@ -13,8 +14,10 @@ use crate::discord::ids::{
     Id,
     marker::{ChannelMarker, GuildMarker, MessageMarker, RoleMarker, UserMarker},
 };
+use crate::paths;
 pub use notifications::ChannelUnreadState;
 use notifications::{GuildNotificationSettingsState, MessageNotificationKind};
+use serde::{Deserialize, Serialize};
 
 use super::{
     ActivityInfo, AppEvent, AttachmentInfo, AttachmentUpdate, ChannelInfo, ChannelRecipientInfo,
@@ -340,6 +343,12 @@ pub struct SnapshotRevision {
 pub struct DiscordSnapshot {
     pub revision: u64,
     pub state: DiscordState,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+pub struct DiscordStateCache {
+    pub(crate) last_channel_id: Option<u64>,
+    pub(crate) last_guild_id: Option<u64>,
 }
 
 struct MessageUpdateFields {
@@ -1636,6 +1645,66 @@ impl DiscordState {
 
         self.message_author_role_ids
             .insert(key, author_role_ids.to_vec());
+    }
+}
+
+impl DiscordStateCache {
+    pub fn set_last_channel(&mut self, channel: Id<ChannelMarker>) {
+        self.last_channel_id = Some(
+            channel
+                .to_string()
+                .parse::<u64>()
+                .expect("Channel ID should be u64"),
+        );
+    }
+
+    pub fn set_last_guild(&mut self, guild: Option<Id<GuildMarker>>) {
+        self.last_guild_id = guild.map(|g| {
+            g.to_string()
+                .parse::<u64>()
+                .expect("Guild ID should be u64, or, for DMs, empty.")
+        });
+    }
+
+    pub fn write_to_disk(&self) -> Result<(), std::io::Error> {
+        match toml::to_string(&self) {
+            Ok(toml) => std::fs::write(DiscordStateCache::get_cache_file()?, toml),
+            Err(e) => return Err(std::io::Error::other(e.to_string())),
+        }?;
+
+        Ok(())
+    }
+
+    pub fn read_from_disk(&mut self) -> Result<(), std::io::Error> {
+        match toml::from_str::<Self>(&std::fs::read_to_string(
+            DiscordStateCache::get_cache_file()?,
+        )?) {
+            Ok(toml) => {
+                self.last_channel_id = toml.last_channel_id;
+                self.last_guild_id = toml.last_guild_id;
+            }
+            Err(e) => return Err(std::io::Error::other(e.to_string())),
+        }
+
+        Ok(())
+    }
+
+    fn get_cache_file() -> Result<PathBuf, std::io::Error> {
+        let f = paths::data_dir().map_or_else(
+            || {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "could not resolve user data directory",
+                ))
+            },
+            |p| Ok(p.join("state.toml")),
+        )?;
+
+        if !f.exists() {
+            std::fs::write(&f, toml::to_string(&DiscordStateCache::default()).unwrap())?;
+        }
+
+        Ok(f)
     }
 }
 

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -25,3 +25,10 @@ pub fn log_file() -> Option<PathBuf> {
 pub fn download_dir() -> Option<PathBuf> {
     dirs::download_dir().or_else(|| Some(dirs::home_dir()?.join("Downloads")))
 }
+
+pub fn data_dir() -> Option<PathBuf> {
+    dirs::data_local_dir().map_or_else(
+        || Some(app_dir()?.join("state")),
+        |d| Some(d.join("concord")),
+    )
+}

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -3,9 +3,15 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::discord::ids::{
-    Id,
-    marker::{ChannelMarker, GuildMarker, MessageMarker, UserMarker},
+use crate::{
+    discord::{
+        DiscordStateCache,
+        ids::{
+            Id,
+            marker::{ChannelMarker, GuildMarker, MessageMarker, UserMarker},
+        },
+    },
+    logging,
 };
 
 use crate::config::DisplayOptions;
@@ -106,6 +112,15 @@ enum ActiveGuildScope {
     Guild(Id<GuildMarker>),
 }
 
+impl From<ActiveGuildScope> for Option<Id<GuildMarker>> {
+    fn from(val: ActiveGuildScope) -> Self {
+        match val {
+            ActiveGuildScope::Unset | ActiveGuildScope::DirectMessages => None,
+            ActiveGuildScope::Guild(id) => Some(id),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum LeaderMode {
     Root,
@@ -149,6 +164,7 @@ struct ForumPostListState {
 #[derive(Debug)]
 pub struct DashboardState {
     discord: DiscordState,
+    cache: DiscordStateCache,
     focus: FocusPane,
     active_guild: ActiveGuildScope,
     active_channel_id: Option<Id<ChannelMarker>>,
@@ -283,6 +299,11 @@ fn truncate_notification_text(value: &str, max_chars: usize) -> String {
 
 impl DashboardState {
     pub fn new() -> Self {
+        let mut cache = DiscordStateCache::default();
+        if let Err(e) = cache.read_from_disk() {
+            logging::error("app", format!("failed to read cached discord state: {}", e));
+        }
+
         Self {
             discord: DiscordState::default(),
             focus: FocusPane::Guilds,
@@ -361,6 +382,8 @@ impl DashboardState {
             collapsed_channel_categories: HashSet::new(),
             pending_read_acks: HashMap::new(),
             pending_commands: VecDeque::new(),
+
+            cache,
         }
     }
 
@@ -637,6 +660,15 @@ impl DashboardState {
         if let Some(user_id) = self.discord.current_user_id() {
             self.current_user_id = Some(user_id);
         }
+        if let Some(last_active_channel) = self.cache.last_channel_id {
+            self.active_channel_id = Some(Id::new(last_active_channel));
+        }
+        self.active_guild = match self.cache.last_guild_id {
+            Some(id) => ActiveGuildScope::Guild(Id::new(id)),
+            None if self.cache.last_channel_id.is_some() => ActiveGuildScope::DirectMessages,
+            _ => ActiveGuildScope::Unset,
+        };
+
         self.clamp_active_selection();
         self.restore_channel_cursor(channel_cursor_id);
         self.clamp_selection_indices();
@@ -660,6 +692,7 @@ impl DashboardState {
     }
 
     pub fn quit(&mut self) {
+        self.cache.write_to_disk().unwrap(); // Doesn't matter if we panic, we're quitting anyway
         self.should_quit = true;
     }
 

--- a/src/tui/state/channels.rs
+++ b/src/tui/state/channels.rs
@@ -910,6 +910,8 @@ impl DashboardState {
 
         self.clamp_message_viewport();
         self.queue_channel_ack(channel_id);
+
+        self.cache.set_last_channel(channel_id);
     }
 
     /// Ack the channel up to its latest message and retire the unread

--- a/src/tui/state/guilds.rs
+++ b/src/tui/state/guilds.rs
@@ -373,6 +373,8 @@ impl DashboardState {
         self.selected_member = 0;
         self.member_scroll = 0;
         self.member_keep_selection_visible = true;
+
+        self.cache.set_last_guild(scope.into());
     }
 
     fn selected_folder_key(&self) -> Option<FolderKey> {


### PR DESCRIPTION
Adds a `DiscordStateCache` to persist the previously visited channel/DM.
Automatically reloads the page upon app start.

Uses `dirs::data_dir` whilst falling back to the `$app_config/state` dir.
Persists the data in TOML format - only 2 keys needed.