### PR TITLE
feat: support muting channels and servers via actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Tokens are saved to `$XDG_CONFIG_HOME/concord/credential` (default `~/.config/co
 - Load pinned messages per channel
 - Open channel actions for pinned messages, thread lists, and mark-as-read
 - Track unread messages and mention counts per channel
+- Mute and unmute channels and servers
 
 ### Messaging
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -11,13 +11,15 @@ use crate::discord::ids::{
     Id,
     marker::{ChannelMarker, MessageMarker},
 };
+use chrono::{Duration as ChronoDuration, SecondsFormat, Utc};
 use tokio::sync::{Semaphore, mpsc};
 use tokio::time::{Duration, timeout};
 
 use crate::{
     DiscordClient, Result,
     discord::{
-        AppCommand, AppEvent, AttachmentUpdate, MessageInfo, ReactionUsersInfo,
+        AppCommand, AppEvent, AttachmentUpdate, ChannelNotificationOverrideInfo,
+        GuildNotificationSettingsInfo, MessageInfo, MuteDuration, ReactionUsersInfo,
         validate_token_header,
     },
     error::AppError,
@@ -736,6 +738,94 @@ fn start_command_loop(
                             log_app_error("ack channel failed", &error);
                         }
                     }
+                    AppCommand::SetGuildMuted {
+                        guild_id,
+                        muted,
+                        duration,
+                        label,
+                    } => {
+                        let mute_end_time = mute_end_time_from_duration(duration, muted);
+                        match client.set_guild_muted(guild_id, muted, mute_end_time).await {
+                            Ok(()) => {
+                                client
+                                    .publish_event(AppEvent::UserGuildNotificationSettingsUpdate {
+                                        settings: guild_notification_settings_update(
+                                            &client,
+                                            Some(guild_id),
+                                            Some((muted, mute_end_time)),
+                                            None,
+                                        ),
+                                    })
+                                    .await;
+                                client
+                                    .publish_event(AppEvent::StatusMessage {
+                                        message: if muted {
+                                            format!(
+                                                "muted server {label}{}",
+                                                mute_status_suffix(duration)
+                                            )
+                                        } else {
+                                            format!("unmuted server {label}")
+                                        },
+                                    })
+                                    .await;
+                            }
+                            Err(error) => {
+                                log_app_error("set guild mute failed", &error);
+                                client
+                                    .publish_event(AppEvent::GatewayError {
+                                        message: format!("set guild mute failed: {error}"),
+                                    })
+                                    .await;
+                            }
+                        }
+                    }
+                    AppCommand::SetChannelMuted {
+                        guild_id,
+                        channel_id,
+                        muted,
+                        duration,
+                        label,
+                    } => {
+                        let mute_end_time = mute_end_time_from_duration(duration, muted);
+                        match client
+                            .set_channel_muted(guild_id, channel_id, muted, mute_end_time)
+                            .await
+                        {
+                            Ok(()) => {
+                                client
+                                    .publish_event(AppEvent::UserGuildNotificationSettingsUpdate {
+                                        settings: guild_notification_settings_update(
+                                            &client,
+                                            guild_id,
+                                            None,
+                                            Some((channel_id, muted, mute_end_time)),
+                                        ),
+                                    })
+                                    .await;
+                                client
+                                    .publish_event(AppEvent::StatusMessage {
+                                        message: if muted {
+                                            format!(
+                                                "muted channel {label}{}",
+                                                mute_status_suffix(duration)
+                                            )
+                                        } else {
+                                            format!("unmuted channel {label}")
+                                        },
+                                    })
+                                    .await;
+                            }
+                            Err(error) => {
+                                log_app_error("set channel mute failed", &error);
+                                client
+                                    .publish_event(AppEvent::GatewayError {
+                                        message: format!("set channel mute failed: {error}"),
+                                    })
+                                    .await;
+                            }
+                        }
+                    }
                     AppCommand::AckChannels { targets } => {
                         // Fire-and-forget: the TUI already cleared its local
                         // unread state, a failure here only loses the cross-
@@ -755,6 +845,73 @@ fn log_app_error(context: &str, error: &AppError) {
         "app",
         format!("{context}: {}; detail={}", error, error.log_detail()),
     );
+}
+
+fn mute_end_time_from_duration(
+    duration: Option<MuteDuration>,
+    muted: bool,
+) -> Option<chrono::DateTime<Utc>> {
+    if !muted {
+        return None;
+    }
+    duration
+        .and_then(MuteDuration::minutes)
+        .filter(|minutes| *minutes > 0)
+        .and_then(|minutes| i64::try_from(minutes).ok())
+        .map(|minutes| Utc::now() + ChronoDuration::minutes(minutes))
+}
+
+fn mute_status_suffix(duration: Option<MuteDuration>) -> String {
+    match duration {
+        Some(MuteDuration::Minutes(15)) => " for 15m".to_owned(),
+        Some(MuteDuration::Minutes(60)) => " for 1h".to_owned(),
+        Some(MuteDuration::Minutes(minutes)) if minutes % 60 == 0 => {
+            format!(" for {}h", minutes / 60)
+        }
+        Some(MuteDuration::Minutes(minutes)) => format!(" for {minutes}m"),
+        Some(MuteDuration::Permanent) | None => String::new(),
+    }
+}
+
+fn guild_notification_settings_update(
+    client: &DiscordClient,
+    guild_id: Option<Id<crate::discord::ids::marker::GuildMarker>>,
+    guild_update: Option<(bool, Option<chrono::DateTime<Utc>>)>,
+    channel_override: Option<(
+        Id<crate::discord::ids::marker::ChannelMarker>,
+        bool,
+        Option<chrono::DateTime<Utc>>,
+    )>,
+) -> GuildNotificationSettingsInfo {
+    let snapshot = client.current_discord_snapshot();
+    let mut settings = snapshot.state.guild_notification_settings_info(guild_id);
+    if let Some((muted, mute_end_time)) = guild_update {
+        settings.muted = muted;
+        settings.mute_end_time =
+            mute_end_time.map(|value| value.to_rfc3339_opts(SecondsFormat::Millis, true));
+    }
+    if let Some((channel_id, muted, mute_end_time)) = channel_override {
+        if let Some(override_info) = settings
+            .channel_overrides
+            .iter_mut()
+            .find(|override_info| override_info.channel_id == channel_id)
+        {
+            override_info.muted = muted;
+            override_info.mute_end_time =
+                mute_end_time.map(|value| value.to_rfc3339_opts(SecondsFormat::Millis, true));
+        } else {
+            settings
+                .channel_overrides
+                .push(ChannelNotificationOverrideInfo {
+                    channel_id,
+                    message_notifications: None,
+                    muted,
+                    mute_end_time: mute_end_time
+                        .map(|value| value.to_rfc3339_opts(SecondsFormat::Millis, true)),
+                });
+        }
+    }
+    settings
 }
 
 /// Builds the Discord REST endpoint string for a message-history request so

--- a/src/app.rs
+++ b/src/app.rs
@@ -745,7 +745,12 @@ fn start_command_loop(
                         label,
                     } => {
                         let mute_end_time = mute_end_time_from_duration(duration, muted);
-                        match client.set_guild_muted(guild_id, muted, mute_end_time).await {
+                        let selected_time_window =
+                            selected_time_window_from_duration(duration, muted);
+                        match client
+                            .set_guild_muted(guild_id, muted, mute_end_time, selected_time_window)
+                            .await
+                        {
                             Ok(()) => {
                                 client
                                     .publish_event(AppEvent::UserGuildNotificationSettingsUpdate {
@@ -788,8 +793,16 @@ fn start_command_loop(
                         label,
                     } => {
                         let mute_end_time = mute_end_time_from_duration(duration, muted);
+                        let selected_time_window =
+                            selected_time_window_from_duration(duration, muted);
                         match client
-                            .set_channel_muted(guild_id, channel_id, muted, mute_end_time)
+                            .set_channel_muted(
+                                guild_id,
+                                channel_id,
+                                muted,
+                                mute_end_time,
+                                selected_time_window,
+                            )
                             .await
                         {
                             Ok(()) => {
@@ -859,6 +872,14 @@ fn mute_end_time_from_duration(
         .filter(|minutes| *minutes > 0)
         .and_then(|minutes| i64::try_from(minutes).ok())
         .map(|minutes| Utc::now() + ChronoDuration::minutes(minutes))
+}
+
+fn selected_time_window_from_duration(duration: Option<MuteDuration>, muted: bool) -> Option<i64> {
+    muted.then(|| {
+        duration
+            .unwrap_or(MuteDuration::Permanent)
+            .selected_time_window_seconds()
+    })
 }
 
 fn mute_status_suffix(duration: Option<MuteDuration>) -> String {

--- a/src/discord/client.rs
+++ b/src/discord/client.rs
@@ -220,9 +220,10 @@ impl DiscordClient {
         guild_id: Id<GuildMarker>,
         muted: bool,
         mute_end_time: Option<DateTime<Utc>>,
+        selected_time_window: Option<i64>,
     ) -> Result<()> {
         self.rest
-            .set_guild_muted(guild_id, muted, mute_end_time)
+            .set_guild_muted(guild_id, muted, mute_end_time, selected_time_window)
             .await
     }
 
@@ -232,9 +233,16 @@ impl DiscordClient {
         channel_id: Id<ChannelMarker>,
         muted: bool,
         mute_end_time: Option<DateTime<Utc>>,
+        selected_time_window: Option<i64>,
     ) -> Result<()> {
         self.rest
-            .set_channel_muted(guild_id, channel_id, muted, mute_end_time)
+            .set_channel_muted(
+                guild_id,
+                channel_id,
+                muted,
+                mute_end_time,
+                selected_time_window,
+            )
             .await
     }
 

--- a/src/discord/client.rs
+++ b/src/discord/client.rs
@@ -7,6 +7,7 @@ use crate::discord::ids::{
     Id,
     marker::{ChannelMarker, GuildMarker, MessageMarker, UserMarker},
 };
+use chrono::{DateTime, Utc};
 use reqwest::header::HeaderValue;
 use tokio::{
     sync::{Mutex as AsyncMutex, mpsc, watch},
@@ -212,6 +213,29 @@ impl DiscordClient {
         message_id: Id<MessageMarker>,
     ) -> Result<()> {
         self.rest.ack_channel(channel_id, message_id).await
+    }
+
+    pub async fn set_guild_muted(
+        &self,
+        guild_id: Id<GuildMarker>,
+        muted: bool,
+        mute_end_time: Option<DateTime<Utc>>,
+    ) -> Result<()> {
+        self.rest
+            .set_guild_muted(guild_id, muted, mute_end_time)
+            .await
+    }
+
+    pub async fn set_channel_muted(
+        &self,
+        guild_id: Option<Id<GuildMarker>>,
+        channel_id: Id<ChannelMarker>,
+        muted: bool,
+        mute_end_time: Option<DateTime<Utc>>,
+    ) -> Result<()> {
+        self.rest
+            .set_channel_muted(guild_id, channel_id, muted, mute_end_time)
+            .await
     }
 
     pub async fn ack_channels(

--- a/src/discord/commands.rs
+++ b/src/discord/commands.rs
@@ -62,6 +62,13 @@ impl MuteDuration {
             Self::Permanent => None,
         }
     }
+
+    pub fn selected_time_window_seconds(self) -> i64 {
+        match self {
+            Self::Minutes(minutes) => i64::try_from(minutes.saturating_mul(60)).unwrap_or(i64::MAX),
+            Self::Permanent => -1,
+        }
+    }
 }
 
 impl ReactionEmoji {

--- a/src/discord/commands.rs
+++ b/src/discord/commands.rs
@@ -49,6 +49,21 @@ impl ForumPostArchiveState {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum MuteDuration {
+    Minutes(u64),
+    Permanent,
+}
+
+impl MuteDuration {
+    pub fn minutes(self) -> Option<u64> {
+        match self {
+            Self::Minutes(minutes) => Some(minutes),
+            Self::Permanent => None,
+        }
+    }
+}
+
 impl ReactionEmoji {
     pub fn status_label(&self) -> String {
         match self {
@@ -166,6 +181,19 @@ pub enum AppCommand {
     AckChannel {
         channel_id: Id<ChannelMarker>,
         message_id: Id<MessageMarker>,
+    },
+    SetGuildMuted {
+        guild_id: Id<GuildMarker>,
+        muted: bool,
+        duration: Option<MuteDuration>,
+        label: String,
+    },
+    SetChannelMuted {
+        guild_id: Option<Id<GuildMarker>>,
+        channel_id: Id<ChannelMarker>,
+        muted: bool,
+        duration: Option<MuteDuration>,
+        label: String,
     },
     AckChannels {
         targets: Vec<(Id<ChannelMarker>, Id<MessageMarker>)>,

--- a/src/discord/mod.rs
+++ b/src/discord/mod.rs
@@ -12,7 +12,7 @@ mod state;
 
 pub use client::DiscordClient;
 pub(crate) use client::validate_token_header;
-pub use commands::{AppCommand, ForumPostArchiveState};
+pub use commands::{AppCommand, ForumPostArchiveState, MuteDuration};
 pub use commands::{
     MAX_UPLOAD_ATTACHMENT_COUNT, MAX_UPLOAD_FILE_BYTES, MAX_UPLOAD_TOTAL_BYTES,
     MessageAttachmentUpload, ReactionEmoji,

--- a/src/discord/rest.rs
+++ b/src/discord/rest.rs
@@ -203,6 +203,7 @@ impl DiscordRest {
         guild_id: Id<GuildMarker>,
         muted: bool,
         mute_end_time: Option<DateTime<Utc>>,
+        selected_time_window: Option<i64>,
     ) -> Result<()> {
         self.raw_http
             .patch(format!(
@@ -210,7 +211,11 @@ impl DiscordRest {
                 guild_id.get()
             ))
             .header(AUTHORIZATION, &self.token)
-            .json(&mute_request_body(muted, mute_end_time))
+            .json(&mute_request_body(
+                muted,
+                mute_end_time,
+                selected_time_window,
+            ))
             .send()
             .await
             .map_err(|error| {
@@ -227,6 +232,7 @@ impl DiscordRest {
         channel_id: Id<ChannelMarker>,
         muted: bool,
         mute_end_time: Option<DateTime<Utc>>,
+        selected_time_window: Option<i64>,
     ) -> Result<()> {
         let endpoint = match guild_id {
             Some(guild_id) => format!(
@@ -240,7 +246,11 @@ impl DiscordRest {
             .header(AUTHORIZATION, &self.token)
             .json(&json!({
                 "channel_overrides": {
-                    channel_id.to_string(): mute_request_body(muted, mute_end_time),
+                    channel_id.to_string(): mute_request_body(
+                        muted,
+                        mute_end_time,
+                        selected_time_window,
+                    ),
                 }
             }))
             .send()
@@ -763,11 +773,18 @@ impl DiscordRest {
     }
 }
 
-fn mute_request_body(muted: bool, mute_end_time: Option<DateTime<Utc>>) -> Value {
+fn mute_request_body(
+    muted: bool,
+    mute_end_time: Option<DateTime<Utc>>,
+    selected_time_window: Option<i64>,
+) -> Value {
     json!({
         "muted": muted,
-        "mute_config": mute_end_time.map(|end_time| json!({
-            "end_time": end_time.to_rfc3339_opts(SecondsFormat::Millis, true),
+        "mute_config": selected_time_window.map(|selected_time_window| json!({
+            "end_time": mute_end_time.map(|end_time| {
+                end_time.to_rfc3339_opts(SecondsFormat::Millis, true)
+            }),
+            "selected_time_window": selected_time_window,
         })),
     })
 }
@@ -1188,6 +1205,8 @@ pub fn validate_message_content(content: &str) -> Result<()> {
 mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
+    use chrono::{TimeZone, Utc};
+
     use crate::discord::ids::{
         Id,
         marker::{ChannelMarker, EmojiMarker, GuildMarker},
@@ -1199,10 +1218,10 @@ mod tests {
             ChannelInfo, MAX_UPLOAD_FILE_BYTES, MessageAttachmentUpload, ReactionEmoji,
             rest::{
                 ForumPostPage, ForumSearchSort, is_search_index_warming, merge_forum_pages,
-                message_multipart_form, message_request_body, next_reaction_users_after,
-                parse_forum_preview_messages, parse_forum_thread_page, parse_user_profile_response,
-                poll_vote_request_body, reaction_route_component, upload_content_type,
-                validate_message_content, validate_message_payload,
+                message_multipart_form, message_request_body, mute_request_body,
+                next_reaction_users_after, parse_forum_preview_messages, parse_forum_thread_page,
+                parse_user_profile_response, poll_vote_request_body, reaction_route_component,
+                upload_content_type, validate_message_content, validate_message_payload,
             },
         },
     };
@@ -1544,6 +1563,42 @@ mod tests {
         assert_eq!(
             poll_vote_request_body(&[]),
             serde_json::json!({ "answer_ids": [] })
+        );
+    }
+
+    #[test]
+    fn mute_request_body_includes_selected_time_window() {
+        let end_time = Utc
+            .with_ymd_and_hms(2026, 5, 10, 12, 30, 45)
+            .single()
+            .expect("valid test timestamp");
+
+        assert_eq!(
+            mute_request_body(true, Some(end_time), Some(900)),
+            serde_json::json!({
+                "muted": true,
+                "mute_config": {
+                    "end_time": "2026-05-10T12:30:45.000Z",
+                    "selected_time_window": 900,
+                },
+            })
+        );
+        assert_eq!(
+            mute_request_body(true, None, Some(-1)),
+            serde_json::json!({
+                "muted": true,
+                "mute_config": {
+                    "end_time": null,
+                    "selected_time_window": -1,
+                },
+            })
+        );
+        assert_eq!(
+            mute_request_body(false, None, None),
+            serde_json::json!({
+                "muted": false,
+                "mute_config": null,
+            })
         );
     }
 

--- a/src/discord/rest.rs
+++ b/src/discord/rest.rs
@@ -5,6 +5,7 @@ use crate::discord::ids::{
     Id,
     marker::{ChannelMarker, GuildMarker, MessageMarker, RoleMarker, UserMarker},
 };
+use chrono::{DateTime, SecondsFormat, Utc};
 use reqwest::{
     StatusCode,
     header::AUTHORIZATION,
@@ -194,6 +195,63 @@ impl DiscordRest {
             })?
             .error_for_status()
             .map_err(|error| AppError::DiscordRequest(format!("ack channel failed: {error}")))?;
+        Ok(())
+    }
+
+    pub async fn set_guild_muted(
+        &self,
+        guild_id: Id<GuildMarker>,
+        muted: bool,
+        mute_end_time: Option<DateTime<Utc>>,
+    ) -> Result<()> {
+        self.raw_http
+            .patch(format!(
+                "https://discord.com/api/v9/users/@me/guilds/{}/settings",
+                guild_id.get()
+            ))
+            .header(AUTHORIZATION, &self.token)
+            .json(&mute_request_body(muted, mute_end_time))
+            .send()
+            .await
+            .map_err(|error| {
+                AppError::DiscordRequest(format!("set guild mute request failed: {error}"))
+            })?
+            .error_for_status()
+            .map_err(|error| AppError::DiscordRequest(format!("set guild mute failed: {error}")))?;
+        Ok(())
+    }
+
+    pub async fn set_channel_muted(
+        &self,
+        guild_id: Option<Id<GuildMarker>>,
+        channel_id: Id<ChannelMarker>,
+        muted: bool,
+        mute_end_time: Option<DateTime<Utc>>,
+    ) -> Result<()> {
+        let endpoint = match guild_id {
+            Some(guild_id) => format!(
+                "https://discord.com/api/v9/users/@me/guilds/{}/settings",
+                guild_id.get()
+            ),
+            None => "https://discord.com/api/v9/users/@me/guilds/@me/settings".to_owned(),
+        };
+        self.raw_http
+            .patch(endpoint)
+            .header(AUTHORIZATION, &self.token)
+            .json(&json!({
+                "channel_overrides": {
+                    channel_id.to_string(): mute_request_body(muted, mute_end_time),
+                }
+            }))
+            .send()
+            .await
+            .map_err(|error| {
+                AppError::DiscordRequest(format!("set channel mute request failed: {error}"))
+            })?
+            .error_for_status()
+            .map_err(|error| {
+                AppError::DiscordRequest(format!("set channel mute failed: {error}"))
+            })?;
         Ok(())
     }
 
@@ -703,6 +761,15 @@ impl DiscordRest {
             .map_err(|error| AppError::DiscordRequest(format!("poll vote failed: {error}")))?;
         Ok(())
     }
+}
+
+fn mute_request_body(muted: bool, mute_end_time: Option<DateTime<Utc>>) -> Value {
+    json!({
+        "muted": muted,
+        "mute_config": mute_end_time.map(|end_time| json!({
+            "end_time": end_time.to_rfc3339_opts(SecondsFormat::Millis, true),
+        })),
+    })
 }
 
 fn poll_vote_request_body(answer_ids: &[u8]) -> Value {

--- a/src/discord/state.rs
+++ b/src/discord/state.rs
@@ -2275,8 +2275,14 @@ mod tests {
 
         assert_eq!(state.channel_unread_message_count(channel_id), 0);
         assert_eq!(state.channel_unread(channel_id), ChannelUnreadState::Unread);
-        assert_eq!(state.channel_sidebar_unread(channel_id), ChannelUnreadState::Seen);
-        assert_eq!(state.guild_sidebar_unread(guild_id), ChannelUnreadState::Unread);
+        assert_eq!(
+            state.channel_sidebar_unread(channel_id),
+            ChannelUnreadState::Seen
+        );
+        assert_eq!(
+            state.guild_sidebar_unread(guild_id),
+            ChannelUnreadState::Unread
+        );
     }
 
     #[test]
@@ -2432,7 +2438,10 @@ mod tests {
 
         assert_eq!(state.channel_unread_message_count(channel_id), 0);
         assert_eq!(state.channel_unread(channel_id), ChannelUnreadState::Unread);
-        assert_eq!(state.channel_sidebar_unread(channel_id), ChannelUnreadState::Seen);
+        assert_eq!(
+            state.channel_sidebar_unread(channel_id),
+            ChannelUnreadState::Seen
+        );
     }
 
     #[test]

--- a/src/discord/state.rs
+++ b/src/discord/state.rs
@@ -2286,6 +2286,105 @@ mod tests {
     }
 
     #[test]
+    fn explicit_channel_unmute_override_beats_muted_parent_category() {
+        let guild_id = Id::new(1);
+        let category_id = Id::new(2);
+        let channel_id = Id::new(3);
+        let current_user_id = Id::new(10);
+        let author_id = Id::new(20);
+        let mut state = DiscordState::default();
+        let mut settings = notification_settings(guild_id, NotificationLevel::AllMessages);
+        settings
+            .channel_overrides
+            .push(ChannelNotificationOverrideInfo {
+                channel_id: category_id,
+                message_notifications: Some(NotificationLevel::AllMessages),
+                muted: true,
+                mute_end_time: None,
+            });
+        settings
+            .channel_overrides
+            .push(ChannelNotificationOverrideInfo {
+                channel_id,
+                message_notifications: Some(NotificationLevel::AllMessages),
+                muted: false,
+                mute_end_time: None,
+            });
+
+        state.apply_event(&AppEvent::Ready {
+            user: "me".to_owned(),
+            user_id: Some(current_user_id),
+        });
+        state.apply_event(&AppEvent::GuildCreate {
+            guild_id,
+            name: "guild".to_owned(),
+            member_count: None,
+            owner_id: None,
+            channels: vec![
+                ChannelInfo {
+                    guild_id: Some(guild_id),
+                    channel_id: category_id,
+                    parent_id: None,
+                    position: Some(0),
+                    last_message_id: None,
+                    name: "category".to_owned(),
+                    kind: "category".to_owned(),
+                    message_count: None,
+                    total_message_sent: None,
+                    thread_archived: None,
+                    thread_locked: None,
+                    thread_pinned: None,
+                    recipients: None,
+                    permission_overwrites: Vec::new(),
+                },
+                ChannelInfo {
+                    guild_id: Some(guild_id),
+                    channel_id,
+                    parent_id: Some(category_id),
+                    position: Some(1),
+                    last_message_id: Some(Id::new(30)),
+                    name: "general".to_owned(),
+                    kind: "text".to_owned(),
+                    message_count: None,
+                    total_message_sent: None,
+                    thread_archived: None,
+                    thread_locked: None,
+                    thread_pinned: None,
+                    recipients: None,
+                    permission_overwrites: Vec::new(),
+                },
+            ],
+            members: Vec::new(),
+            presences: Vec::new(),
+            roles: Vec::new(),
+            emojis: Vec::new(),
+        });
+        state.apply_event(&AppEvent::UserGuildNotificationSettingsInit {
+            settings: vec![settings],
+        });
+
+        state.apply_event(&message_create(
+            Some(guild_id),
+            channel_id,
+            Id::new(30),
+            author_id,
+            "hello",
+            Vec::new(),
+        ));
+
+        assert!(!state.channel_notification_muted(channel_id));
+        assert_eq!(state.channel_unread_message_count(channel_id), 1);
+        assert_eq!(
+            state.channel_unread(channel_id),
+            ChannelUnreadState::Notified(1)
+        );
+        assert_eq!(
+            state.channel_sidebar_unread(channel_id),
+            ChannelUnreadState::Notified(1)
+        );
+    }
+
+    #[test]
     fn only_mentions_settings_count_direct_mentions() {
         let guild_id = Id::new(1);
         let channel_id = Id::new(2);

--- a/src/discord/state.rs
+++ b/src/discord/state.rs
@@ -2275,6 +2275,8 @@ mod tests {
 
         assert_eq!(state.channel_unread_message_count(channel_id), 0);
         assert_eq!(state.channel_unread(channel_id), ChannelUnreadState::Unread);
+        assert_eq!(state.channel_sidebar_unread(channel_id), ChannelUnreadState::Seen);
+        assert_eq!(state.guild_sidebar_unread(guild_id), ChannelUnreadState::Unread);
     }
 
     #[test]
@@ -2430,6 +2432,7 @@ mod tests {
 
         assert_eq!(state.channel_unread_message_count(channel_id), 0);
         assert_eq!(state.channel_unread(channel_id), ChannelUnreadState::Unread);
+        assert_eq!(state.channel_sidebar_unread(channel_id), ChannelUnreadState::Seen);
     }
 
     #[test]

--- a/src/discord/state/notifications.rs
+++ b/src/discord/state/notifications.rs
@@ -394,14 +394,8 @@ impl DiscordState {
         settings: &GuildNotificationSettingsState,
         channel_id: Id<ChannelMarker>,
     ) -> bool {
-        let direct_muted = settings
-            .channel_overrides
-            .get(&channel_id)
-            .is_some_and(|setting| {
-                notification_setting_muted(setting.muted, setting.mute_end_time.as_deref())
-            });
-        if direct_muted {
-            return true;
+        if let Some(setting) = settings.channel_overrides.get(&channel_id) {
+            return notification_setting_muted(setting.muted, setting.mute_end_time.as_deref());
         }
         self.channels
             .get(&channel_id)

--- a/src/discord/state/notifications.rs
+++ b/src/discord/state/notifications.rs
@@ -46,6 +46,66 @@ pub(super) struct GuildNotificationSettingsState {
 }
 
 impl DiscordState {
+    pub fn channel_sidebar_unread(&self, channel_id: Id<ChannelMarker>) -> ChannelUnreadState {
+        if self.channel_notification_muted(channel_id) {
+            ChannelUnreadState::Seen
+        } else {
+            self.channel_unread(channel_id)
+        }
+    }
+
+    pub fn guild_sidebar_unread(&self, guild_id: Id<GuildMarker>) -> ChannelUnreadState {
+        if self.guild_notification_muted(guild_id) {
+            ChannelUnreadState::Seen
+        } else {
+            self.guild_unread(guild_id)
+        }
+    }
+
+    pub fn guild_notification_muted(&self, guild_id: Id<GuildMarker>) -> bool {
+        self.notification_settings
+            .get(&guild_id)
+            .is_some_and(|settings| {
+                notification_setting_muted(settings.muted, settings.mute_end_time.as_deref())
+            })
+    }
+
+    pub fn channel_notification_muted(&self, channel_id: Id<ChannelMarker>) -> bool {
+        match self.channel_guild_id(channel_id) {
+            Some(guild_id) => self
+                .notification_settings
+                .get(&guild_id)
+                .is_some_and(|settings| {
+                    self.channel_notification_muted_in_settings(settings, channel_id)
+                }),
+            None => self
+                .private_notification_settings
+                .as_ref()
+                .is_some_and(|settings| {
+                    self.channel_notification_muted_in_settings(settings, channel_id)
+                }),
+        }
+    }
+
+    pub fn guild_notification_settings_info(
+        &self,
+        guild_id: Option<Id<GuildMarker>>,
+    ) -> GuildNotificationSettingsInfo {
+        let settings = match guild_id {
+            Some(guild_id) => self.notification_settings.get(&guild_id),
+            None => self.private_notification_settings.as_ref(),
+        };
+        GuildNotificationSettingsInfo {
+            guild_id,
+            message_notifications: settings.and_then(|settings| settings.message_notifications),
+            muted: settings.is_some_and(|settings| settings.muted),
+            mute_end_time: settings.and_then(|settings| settings.mute_end_time.clone()),
+            suppress_everyone: settings.is_some_and(|settings| settings.suppress_everyone),
+            suppress_roles: settings.is_some_and(|settings| settings.suppress_roles),
+            channel_overrides: settings.map(channel_override_infos).unwrap_or_default(),
+        }
+    }
+
     pub fn channel_unread(&self, channel_id: Id<ChannelMarker>) -> ChannelUnreadState {
         let latest = self
             .channels
@@ -221,7 +281,7 @@ impl DiscordState {
             };
         };
         if notification_setting_muted(settings.muted, settings.mute_end_time.as_deref())
-            || self.channel_notification_muted(settings, channel_id)
+            || self.channel_notification_muted_in_settings(settings, channel_id)
         {
             return MessageNotificationKind::None;
         }
@@ -251,7 +311,7 @@ impl DiscordState {
             return MessageNotificationKind::Notify;
         };
         if notification_setting_muted(settings.muted, settings.mute_end_time.as_deref())
-            || self.channel_notification_muted(settings, channel_id)
+            || self.channel_notification_muted_in_settings(settings, channel_id)
         {
             return MessageNotificationKind::None;
         }
@@ -329,7 +389,7 @@ impl DiscordState {
             .unwrap_or(NotificationLevel::OnlyMentions)
     }
 
-    fn channel_notification_muted(
+    fn channel_notification_muted_in_settings(
         &self,
         settings: &GuildNotificationSettingsState,
         channel_id: Id<ChannelMarker>,
@@ -383,6 +443,21 @@ impl DiscordState {
                     .any(|role_id| content.contains(&format!("<@&{}>", role_id.get())))
             })
     }
+}
+
+fn channel_override_infos(
+    settings: &GuildNotificationSettingsState,
+) -> Vec<ChannelNotificationOverrideInfo> {
+    settings
+        .channel_overrides
+        .iter()
+        .map(|(channel_id, setting)| ChannelNotificationOverrideInfo {
+            channel_id: *channel_id,
+            message_notifications: setting.message_notifications,
+            muted: setting.muted,
+            mute_end_time: setting.mute_end_time.clone(),
+        })
+        .collect()
 }
 
 fn notification_override_map(

--- a/src/tui/input/keyboard.rs
+++ b/src/tui/input/keyboard.rs
@@ -254,7 +254,7 @@ fn handle_leader_action_key(state: &mut DashboardState, key: KeyEvent) -> Option
         }
         KeyCode::Char(shortcut) if is_shortcut_key(key) => {
             let (matched, command) = state.activate_leader_action_shortcut(shortcut);
-            if !matched || !state.is_channel_action_threads_phase() {
+            if !matched || !state.is_any_action_menu_open() {
                 state.close_all_action_menus();
                 state.close_leader();
             }
@@ -474,7 +474,7 @@ fn handle_member_action_menu_key(state: &mut DashboardState, key: KeyEvent) -> O
 
 fn handle_guild_action_menu_key(state: &mut DashboardState, key: KeyEvent) -> Option<AppCommand> {
     match key.code {
-        KeyCode::Esc => state.close_guild_action_menu(),
+        KeyCode::Esc => state.back_guild_action_menu(),
         code if is_down_key(code) => state.move_guild_action_down(),
         code if is_up_key(code) => state.move_guild_action_up(),
         code if is_confirm_key(code) => return state.activate_selected_guild_action(),
@@ -491,7 +491,10 @@ fn handle_channel_action_menu_key(state: &mut DashboardState, key: KeyEvent) -> 
         // Esc steps back to the action list when viewing threads, otherwise
         // closes the menu entirely.
         KeyCode::Esc => state.back_channel_action_menu(),
-        code if is_left_key(code) && state.is_channel_action_threads_phase() => {
+        code if is_left_key(code)
+            && (state.is_channel_action_threads_phase()
+                || state.is_channel_action_mute_duration_phase()) =>
+        {
             state.back_channel_action_menu()
         }
         code if is_down_key(code) => state.move_channel_action_down(),

--- a/src/tui/input/tests.rs
+++ b/src/tui/input/tests.rs
@@ -385,6 +385,29 @@ fn leader_channel_actions_unmute_when_already_muted() {
 }
 
 #[test]
+fn leader_category_actions_offer_mute_duration_and_submit_command() {
+    let mut state = state_with_channel_tree();
+    state.focus_pane(FocusPane::Channels);
+    handle_key(&mut state, key(KeyCode::Up));
+
+    handle_key(&mut state, char_key(' '));
+    handle_key(&mut state, char_key('a'));
+    handle_key(&mut state, char_key('u'));
+    let command = handle_key(&mut state, char_key('1'));
+
+    assert_eq!(
+        command,
+        Some(AppCommand::SetChannelMuted {
+            guild_id: Some(Id::new(1)),
+            channel_id: Id::new(10),
+            muted: true,
+            duration: Some(crate::discord::MuteDuration::Minutes(15)),
+            label: "Text Channels".to_owned(),
+        })
+    );
+}
+
+#[test]
 fn leader_server_actions_unmute_when_already_muted() {
     let mut state = state_with_channel_tree();
     state.push_event(AppEvent::UserGuildNotificationSettingsInit {

--- a/src/tui/input/tests.rs
+++ b/src/tui/input/tests.rs
@@ -12,9 +12,10 @@ use super::{MouseClickTracker, handle_key, handle_mouse, handle_mouse_event, han
 use crate::{
     config::ImagePreviewQualityPreset,
     discord::{
-        AppCommand, AppEvent, ChannelInfo, ChannelRecipientInfo, CustomEmojiInfo, GuildFolder,
-        MemberInfo, MessageReferenceInfo, PollAnswerInfo, PollInfo, PresenceStatus, ReactionEmoji,
-        ReactionUserInfo, ReactionUsersInfo,
+        AppCommand, AppEvent, ChannelInfo, ChannelNotificationOverrideInfo, ChannelRecipientInfo,
+        CustomEmojiInfo, GuildFolder, GuildNotificationSettingsInfo, MemberInfo,
+        MessageReferenceInfo, NotificationLevel, PollAnswerInfo, PollInfo, PresenceStatus,
+        ReactionEmoji, ReactionUserInfo, ReactionUsersInfo,
     },
     tui::state::{ChannelPaneEntry, DashboardState, FocusPane, GuildPaneEntry, MessageActionKind},
 };
@@ -309,6 +310,109 @@ fn number_keys_show_hidden_panes_before_focusing() {
     handle_key(&mut state, char_key('4'));
     assert!(state.is_pane_visible(FocusPane::Members));
     assert_eq!(state.focus(), FocusPane::Members);
+}
+
+#[test]
+fn bare_m_no_longer_mutes_focused_channel() {
+    let mut state = state_with_channel_tree();
+    state.focus_pane(FocusPane::Channels);
+    handle_key(&mut state, key(KeyCode::Down));
+
+    let command = handle_key(&mut state, char_key('m'));
+
+    assert_eq!(command, None);
+}
+
+#[test]
+fn leader_channel_actions_offer_mute_duration_and_submit_command() {
+    let mut state = state_with_channel_tree();
+    state.focus_pane(FocusPane::Channels);
+    handle_key(&mut state, key(KeyCode::Down));
+
+    handle_key(&mut state, char_key(' '));
+    handle_key(&mut state, char_key('a'));
+    handle_key(&mut state, char_key('u'));
+    let command = handle_key(&mut state, char_key('1'));
+
+    assert_eq!(
+        command,
+        Some(AppCommand::SetChannelMuted {
+            guild_id: Some(Id::new(1)),
+            channel_id: Id::new(11),
+            muted: true,
+            duration: Some(crate::discord::MuteDuration::Minutes(15)),
+            label: "#general".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn leader_channel_actions_unmute_when_already_muted() {
+    let mut state = state_with_channel_tree();
+    state.push_event(AppEvent::UserGuildNotificationSettingsInit {
+        settings: vec![GuildNotificationSettingsInfo {
+            guild_id: Some(Id::new(1)),
+            message_notifications: Some(NotificationLevel::OnlyMentions),
+            muted: false,
+            mute_end_time: None,
+            suppress_everyone: false,
+            suppress_roles: false,
+            channel_overrides: vec![ChannelNotificationOverrideInfo {
+                channel_id: Id::new(11),
+                message_notifications: None,
+                muted: true,
+                mute_end_time: None,
+            }],
+        }],
+    });
+    state.focus_pane(FocusPane::Channels);
+    handle_key(&mut state, key(KeyCode::Down));
+
+    handle_key(&mut state, char_key(' '));
+    handle_key(&mut state, char_key('a'));
+    let command = handle_key(&mut state, char_key('u'));
+
+    assert_eq!(
+        command,
+        Some(AppCommand::SetChannelMuted {
+            guild_id: Some(Id::new(1)),
+            channel_id: Id::new(11),
+            muted: false,
+            duration: None,
+            label: "#general".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn leader_server_actions_unmute_when_already_muted() {
+    let mut state = state_with_channel_tree();
+    state.push_event(AppEvent::UserGuildNotificationSettingsInit {
+        settings: vec![GuildNotificationSettingsInfo {
+            guild_id: Some(Id::new(1)),
+            message_notifications: Some(NotificationLevel::OnlyMentions),
+            muted: true,
+            mute_end_time: None,
+            suppress_everyone: false,
+            suppress_roles: false,
+            channel_overrides: Vec::new(),
+        }],
+    });
+    state.focus_pane(FocusPane::Guilds);
+
+    handle_key(&mut state, char_key(' '));
+    handle_key(&mut state, char_key('a'));
+    let command = handle_key(&mut state, char_key('u'));
+
+    assert_eq!(
+        command,
+        Some(AppCommand::SetGuildMuted {
+            guild_id: Id::new(1),
+            muted: false,
+            duration: None,
+            label: "guild".to_owned(),
+        })
+    );
 }
 
 #[test]

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -839,6 +839,14 @@ impl DashboardState {
         self.discord.guild_sidebar_unread(guild_id)
     }
 
+    pub fn channel_notification_muted(&self, channel_id: Id<ChannelMarker>) -> bool {
+        self.discord.channel_notification_muted(channel_id)
+    }
+
+    pub fn guild_notification_muted(&self, guild_id: Id<GuildMarker>) -> bool {
+        self.discord.guild_notification_muted(guild_id)
+    }
+
     pub fn direct_message_unread_count(&self) -> usize {
         self.discord.direct_message_unread_count()
     }

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -866,22 +866,6 @@ impl DashboardState {
         })
     }
 
-    pub fn toggle_selected_channel_mute(
-        &mut self,
-        duration: Option<MuteDuration>,
-    ) -> Option<AppCommand> {
-        let channel_id = self.selected_channel_cursor_id()?;
-        let channel = self.discord.channel(channel_id)?;
-        let muted = !self.discord.channel_notification_muted(channel_id);
-        Some(AppCommand::SetChannelMuted {
-            guild_id: channel.guild_id,
-            channel_id,
-            muted,
-            duration,
-            label: self.channel_label(channel_id),
-        })
-    }
-
     pub(crate) fn desktop_notification_for_event(
         &self,
         event: &AppEvent,

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -11,7 +11,8 @@ use crate::discord::ids::{
 use crate::config::DisplayOptions;
 use crate::discord::{
     AppCommand, AppEvent, ChannelUnreadState, DiscordState, ForumPostArchiveState, MentionInfo,
-    MessageAttachmentUpload, MessageInfo, MessageSnapshotInfo, MessageState, PresenceStatus,
+    MessageAttachmentUpload, MessageInfo, MessageSnapshotInfo, MessageState, MuteDuration,
+    PresenceStatus,
 };
 use unicode_width::UnicodeWidthStr;
 
@@ -61,9 +62,9 @@ pub use member_grouping::{MemberEntry, MemberGroup};
 pub use model::{
     ChannelActionItem, ChannelPaneEntry, ChannelSwitcherItem, ChannelThreadItem, EmojiReactionItem,
     FORUM_POST_CARD_HEIGHT, FocusPane, GuildActionItem, GuildPaneEntry, ImageViewerItem,
-    MemberActionItem, MessageActionItem, MessageActionKind, PollVotePickerItem,
-    ThreadMessagePreview, ThreadSummary, channel_action_shortcut, guild_action_shortcut,
-    indexed_shortcut, member_action_shortcut, message_action_shortcut,
+    MemberActionItem, MessageActionItem, MessageActionKind, MuteActionDurationItem,
+    PollVotePickerItem, ThreadMessagePreview, ThreadSummary, channel_action_shortcut,
+    guild_action_shortcut, indexed_shortcut, member_action_shortcut, message_action_shortcut,
 };
 #[allow(unused_imports)]
 pub use model::{ChannelActionKind, ChannelBranch, GuildActionKind, GuildBranch, MemberActionKind};
@@ -736,12 +737,19 @@ impl DashboardState {
             );
         }
         if self.guild_action_menu.is_some() {
-            let actions = self.selected_guild_action_items();
-            let matched = actions.iter().enumerate().any(|(index, action)| {
-                action.enabled
-                    && guild_action_shortcut(&actions, index)
-                        .is_some_and(|candidate| candidate == shortcut)
-            });
+            let matched = if self.is_guild_action_mute_duration_phase() {
+                self.selected_guild_mute_duration_items()
+                    .iter()
+                    .enumerate()
+                    .any(|(index, _)| indexed_shortcut(index) == Some(shortcut))
+            } else {
+                let actions = self.selected_guild_action_items();
+                actions.iter().enumerate().any(|(index, action)| {
+                    action.enabled
+                        && guild_action_shortcut(&actions, index)
+                            .is_some_and(|candidate| candidate == shortcut)
+                })
+            };
             return (
                 matched,
                 matched
@@ -759,6 +767,11 @@ impl DashboardState {
                                 .is_some_and(|candidate| candidate == shortcut)
                     })
                 }
+                ChannelActionMenuState::MuteDuration { .. } => self
+                    .selected_channel_mute_duration_items()
+                    .iter()
+                    .enumerate()
+                    .any(|(index, _)| indexed_shortcut(index) == Some(shortcut)),
                 ChannelActionMenuState::Threads { .. } => self
                     .channel_action_thread_items()
                     .iter()
@@ -818,12 +831,55 @@ impl DashboardState {
         self.discord.guild_unread(guild_id)
     }
 
+    pub fn sidebar_channel_unread(&self, channel_id: Id<ChannelMarker>) -> ChannelUnreadState {
+        self.discord.channel_sidebar_unread(channel_id)
+    }
+
+    pub fn sidebar_guild_unread(&self, guild_id: Id<GuildMarker>) -> ChannelUnreadState {
+        self.discord.guild_sidebar_unread(guild_id)
+    }
+
     pub fn direct_message_unread_count(&self) -> usize {
         self.discord.direct_message_unread_count()
     }
 
     pub fn channel_unread_message_count(&self, channel_id: Id<ChannelMarker>) -> usize {
         self.discord.channel_unread_message_count(channel_id)
+    }
+
+    pub fn toggle_selected_guild_mute(
+        &mut self,
+        duration: Option<MuteDuration>,
+    ) -> Option<AppCommand> {
+        let guild_id = self.selected_guild_cursor_id()?;
+        let label = self
+            .discord
+            .guild(guild_id)
+            .map(|guild| guild.name.clone())
+            .unwrap_or_else(|| format!("server-{}", guild_id.get()));
+        let muted = !self.discord.guild_notification_muted(guild_id);
+        Some(AppCommand::SetGuildMuted {
+            guild_id,
+            muted,
+            duration,
+            label,
+        })
+    }
+
+    pub fn toggle_selected_channel_mute(
+        &mut self,
+        duration: Option<MuteDuration>,
+    ) -> Option<AppCommand> {
+        let channel_id = self.selected_channel_cursor_id()?;
+        let channel = self.discord.channel(channel_id)?;
+        let muted = !self.discord.channel_notification_muted(channel_id);
+        Some(AppCommand::SetChannelMuted {
+            guild_id: channel.guild_id,
+            channel_id,
+            muted,
+            duration,
+            label: self.channel_label(channel_id),
+        })
     }
 
     pub(crate) fn desktop_notification_for_event(
@@ -890,6 +946,20 @@ impl DashboardState {
         matches!(
             self.channel_action_menu,
             Some(ChannelActionMenuState::Threads { .. })
+        )
+    }
+
+    pub fn is_channel_action_mute_duration_phase(&self) -> bool {
+        matches!(
+            self.channel_action_menu,
+            Some(ChannelActionMenuState::MuteDuration { .. })
+        )
+    }
+
+    pub fn is_guild_action_mute_duration_phase(&self) -> bool {
+        matches!(
+            self.guild_action_menu,
+            Some(GuildActionMenuState::MuteDuration { .. })
         )
     }
 

--- a/src/tui/state/channels.rs
+++ b/src/tui/state/channels.rs
@@ -12,7 +12,7 @@ use super::{
 use super::{
     model::{
         ChannelActionItem, ChannelActionKind, ChannelBranch, ChannelPaneEntry, ChannelThreadItem,
-        FocusPane, channel_action_shortcut, indexed_shortcut,
+        FocusPane, MUTE_ACTION_DURATIONS, channel_action_shortcut, indexed_shortcut,
     },
     popups::ChannelActionMenuState,
     presentation::{is_direct_message_channel, sort_channels, sort_direct_message_channels},
@@ -26,6 +26,7 @@ impl DashboardState {
     pub fn channel_action_menu_title(&self) -> Option<String> {
         let channel_id = match self.channel_action_menu.as_ref()? {
             ChannelActionMenuState::Actions { channel_id, .. }
+            | ChannelActionMenuState::MuteDuration { channel_id, .. }
             | ChannelActionMenuState::Threads { channel_id, .. } => *channel_id,
         };
         let channel = self.discord.channel(channel_id)?;
@@ -60,16 +61,16 @@ impl DashboardState {
     }
 
     pub fn back_channel_action_menu(&mut self) {
-        if let Some(ChannelActionMenuState::Threads { channel_id, .. }) =
-            self.channel_action_menu.as_ref()
-        {
-            let channel_id = *channel_id;
-            self.channel_action_menu = Some(ChannelActionMenuState::Actions {
-                channel_id,
-                selected: 0,
-            });
-        } else {
-            self.channel_action_menu = None;
+        match self.channel_action_menu.as_ref() {
+            Some(ChannelActionMenuState::Threads { channel_id, .. })
+            | Some(ChannelActionMenuState::MuteDuration { channel_id, .. }) => {
+                let channel_id = *channel_id;
+                self.channel_action_menu = Some(ChannelActionMenuState::Actions {
+                    channel_id,
+                    selected: 0,
+                });
+            }
+            _ => self.channel_action_menu = None,
         }
     }
 
@@ -112,7 +113,20 @@ impl DashboardState {
                 label: "Mark as read".to_owned(),
                 enabled: mark_as_read_enabled,
             },
+            ChannelActionItem {
+                kind: ChannelActionKind::ToggleMute,
+                label: if self.discord.channel_notification_muted(channel_id) {
+                    "Unmute channel".to_owned()
+                } else {
+                    "Mute channel".to_owned()
+                },
+                enabled: true,
+            },
         ]
+    }
+
+    pub fn selected_channel_mute_duration_items(&self) -> &'static [super::MuteActionDurationItem] {
+        &MUTE_ACTION_DURATIONS
     }
 
     pub fn channel_action_thread_items(&self) -> Vec<ChannelThreadItem> {
@@ -357,6 +371,10 @@ impl DashboardState {
                 *selected,
                 self.selected_channel_action_items().len(),
             )),
+            ChannelActionMenuState::MuteDuration { selected, .. } => Some(clamp_selected_index(
+                *selected,
+                self.selected_channel_mute_duration_items().len(),
+            )),
             ChannelActionMenuState::Threads { selected, .. } => Some(clamp_selected_index(
                 *selected,
                 self.channel_action_thread_items().len(),
@@ -369,6 +387,9 @@ impl DashboardState {
             Some(ChannelActionMenuState::Actions { .. }) => {
                 self.selected_channel_action_items().len()
             }
+            Some(ChannelActionMenuState::MuteDuration { .. }) => {
+                self.selected_channel_mute_duration_items().len()
+            }
             Some(ChannelActionMenuState::Threads { .. }) => {
                 self.channel_action_thread_items().len()
             }
@@ -377,6 +398,7 @@ impl DashboardState {
         if let Some(menu) = self.channel_action_menu.as_mut() {
             let selected = match menu {
                 ChannelActionMenuState::Actions { selected, .. }
+                | ChannelActionMenuState::MuteDuration { selected, .. }
                 | ChannelActionMenuState::Threads { selected, .. } => selected,
             };
             move_index_down(selected, len);
@@ -387,6 +409,7 @@ impl DashboardState {
         if let Some(menu) = self.channel_action_menu.as_mut() {
             let selected = match menu {
                 ChannelActionMenuState::Actions { selected, .. }
+                | ChannelActionMenuState::MuteDuration { selected, .. }
                 | ChannelActionMenuState::Threads { selected, .. } => selected,
             };
             move_index_up(selected);
@@ -397,6 +420,9 @@ impl DashboardState {
         let len = match self.channel_action_menu.as_ref() {
             Some(ChannelActionMenuState::Actions { .. }) => {
                 self.selected_channel_action_items().len()
+            }
+            Some(ChannelActionMenuState::MuteDuration { .. }) => {
+                self.selected_channel_mute_duration_items().len()
             }
             Some(ChannelActionMenuState::Threads { .. }) => {
                 self.channel_action_thread_items().len()
@@ -409,6 +435,7 @@ impl DashboardState {
         if let Some(menu) = self.channel_action_menu.as_mut() {
             let selected = match menu {
                 ChannelActionMenuState::Actions { selected, .. }
+                | ChannelActionMenuState::MuteDuration { selected, .. }
                 | ChannelActionMenuState::Threads { selected, .. } => selected,
             };
             *selected = row;
@@ -452,7 +479,29 @@ impl DashboardState {
                         // there's nothing extra for the dispatch loop here.
                         None
                     }
+                    ChannelActionKind::ToggleMute => {
+                        if self.discord.channel_notification_muted(channel_id) {
+                            self.close_channel_action_menu();
+                            self.toggle_selected_channel_mute(None)
+                        } else {
+                            self.channel_action_menu = Some(ChannelActionMenuState::MuteDuration {
+                                channel_id,
+                                selected: 0,
+                            });
+                            None
+                        }
+                    }
                 }
+            }
+            ChannelActionMenuState::MuteDuration { selected, .. } => {
+                let item =
+                    self.selected_channel_mute_duration_items()
+                        .get(clamp_selected_index(
+                            selected,
+                            self.selected_channel_mute_duration_items().len(),
+                        ))?;
+                self.close_channel_action_menu();
+                self.toggle_selected_channel_mute(Some(item.duration))
             }
             ChannelActionMenuState::Threads { .. } => {
                 let items = self.channel_action_thread_items();
@@ -482,6 +531,15 @@ impl DashboardState {
                         && channel_action_shortcut(&actions, index)
                             .is_some_and(|candidate| candidate == shortcut)
                 })?;
+                self.select_channel_action_row(index);
+                self.activate_selected_channel_action()
+            }
+            ChannelActionMenuState::MuteDuration { .. } => {
+                let index = self
+                    .selected_channel_mute_duration_items()
+                    .iter()
+                    .enumerate()
+                    .position(|(index, _)| indexed_shortcut(index) == Some(shortcut))?;
                 self.select_channel_action_row(index);
                 self.activate_selected_channel_action()
             }

--- a/src/tui/state/channels.rs
+++ b/src/tui/state/channels.rs
@@ -29,15 +29,14 @@ impl DashboardState {
             | ChannelActionMenuState::MuteDuration { channel_id, .. }
             | ChannelActionMenuState::Threads { channel_id, .. } => *channel_id,
         };
-        let channel = self.discord.channel(channel_id)?;
-        Some(format!("#{}", channel.name))
+        Some(self.channel_label(channel_id))
     }
 
     pub fn open_selected_channel_actions(&mut self) {
         if self.focus != FocusPane::Channels {
             return;
         }
-        let Some(channel_id) = self.selected_channel_cursor_id() else {
+        let Some(channel_id) = self.selected_channel_action_target_id() else {
             return;
         };
         self.open_channel_actions(channel_id);
@@ -47,7 +46,7 @@ impl DashboardState {
         let Some(channel) = self.discord.channel(channel_id) else {
             return;
         };
-        if channel.is_category() || channel.is_thread() {
+        if channel.is_thread() {
             return;
         }
         self.channel_action_menu = Some(ChannelActionMenuState::Actions {
@@ -79,6 +78,20 @@ impl DashboardState {
             Some(ChannelActionMenuState::Actions { channel_id, .. }) => *channel_id,
             _ => return Vec::new(),
         };
+        let Some(channel) = self.discord.channel(channel_id) else {
+            return Vec::new();
+        };
+        if channel.is_category() {
+            return vec![ChannelActionItem {
+                kind: ChannelActionKind::ToggleMute,
+                label: if self.discord.channel_notification_muted(channel_id) {
+                    "Unmute category".to_owned()
+                } else {
+                    "Mute category".to_owned()
+                },
+                enabled: true,
+            }];
+        }
         let thread_count = self
             .channels()
             .into_iter()
@@ -482,7 +495,7 @@ impl DashboardState {
                     ChannelActionKind::ToggleMute => {
                         if self.discord.channel_notification_muted(channel_id) {
                             self.close_channel_action_menu();
-                            self.toggle_selected_channel_mute(None)
+                            self.toggle_channel_mute(channel_id, None)
                         } else {
                             self.channel_action_menu = Some(ChannelActionMenuState::MuteDuration {
                                 channel_id,
@@ -493,7 +506,10 @@ impl DashboardState {
                     }
                 }
             }
-            ChannelActionMenuState::MuteDuration { selected, .. } => {
+            ChannelActionMenuState::MuteDuration {
+                channel_id,
+                selected,
+            } => {
                 let item =
                     self.selected_channel_mute_duration_items()
                         .get(clamp_selected_index(
@@ -501,7 +517,7 @@ impl DashboardState {
                             self.selected_channel_mute_duration_items().len(),
                         ))?;
                 self.close_channel_action_menu();
-                self.toggle_selected_channel_mute(Some(item.duration))
+                self.toggle_channel_mute(channel_id, Some(item.duration))
             }
             ChannelActionMenuState::Threads { .. } => {
                 let items = self.channel_action_thread_items();
@@ -773,9 +789,26 @@ impl DashboardState {
             .map(|channel| match channel.kind.as_str() {
                 "dm" | "Private" => format!("@{}", channel.name),
                 "group-dm" | "Group" => channel.name.clone(),
+                "category" | "GuildCategory" => channel.name.clone(),
                 _ => format!("#{}", channel.name),
             })
             .unwrap_or_else(|| format!("#channel-{}", channel_id.get()))
+    }
+
+    fn toggle_channel_mute(
+        &mut self,
+        channel_id: Id<ChannelMarker>,
+        duration: Option<crate::discord::MuteDuration>,
+    ) -> Option<AppCommand> {
+        let channel = self.discord.channel(channel_id)?;
+        let muted = !self.discord.channel_notification_muted(channel_id);
+        Some(AppCommand::SetChannelMuted {
+            guild_id: channel.guild_id,
+            channel_id,
+            muted,
+            duration,
+            label: self.channel_label(channel_id),
+        })
     }
 
     pub fn message_pane_title(&self) -> String {
@@ -1037,6 +1070,14 @@ impl DashboardState {
                     _ => None,
                 }),
             _ => None,
+        }
+    }
+
+    fn selected_channel_action_target_id(&self) -> Option<Id<ChannelMarker>> {
+        match self.channel_pane_entries().get(self.selected_channel()) {
+            Some(ChannelPaneEntry::CategoryHeader { state, .. }) => Some(state.id),
+            Some(ChannelPaneEntry::Channel { state, .. }) => Some(state.id),
+            None => None,
         }
     }
 }

--- a/src/tui/state/guilds.rs
+++ b/src/tui/state/guilds.rs
@@ -10,7 +10,7 @@ use super::{ActiveGuildScope, DashboardState, FolderKey};
 use super::{
     model::{
         FocusPane, GuildActionItem, GuildActionKind, GuildBranch, GuildPaneEntry,
-        guild_action_shortcut,
+        MUTE_ACTION_DURATIONS, guild_action_shortcut, indexed_shortcut,
     },
     popups::GuildActionMenuState,
     scroll::{
@@ -169,6 +169,15 @@ impl DashboardState {
         }
     }
 
+    pub fn selected_guild_cursor_id(&self) -> Option<Id<GuildMarker>> {
+        match self.guild_pane_entries().get(self.selected_guild()) {
+            Some(GuildPaneEntry::Guild { state, .. }) => Some(state.id),
+            Some(GuildPaneEntry::DirectMessages | GuildPaneEntry::FolderHeader { .. }) | None => {
+                None
+            }
+        }
+    }
+
     pub fn is_active_guild_entry(&self, entry: &GuildPaneEntry<'_>) -> bool {
         match (self.active_guild, entry) {
             (ActiveGuildScope::DirectMessages, GuildPaneEntry::DirectMessages) => true,
@@ -187,7 +196,7 @@ impl DashboardState {
         }
         match self.guild_pane_entries().get(self.selected_guild()) {
             Some(GuildPaneEntry::DirectMessages | GuildPaneEntry::Guild { .. }) => {
-                self.guild_action_menu = Some(GuildActionMenuState { selected: 0 });
+                self.guild_action_menu = Some(GuildActionMenuState::Actions { selected: 0 });
             }
             Some(GuildPaneEntry::FolderHeader { .. }) | None => {}
         }
@@ -210,11 +219,22 @@ impl DashboardState {
             return Vec::new();
         }
         match self.guild_pane_entries().get(self.selected_guild()) {
-            Some(GuildPaneEntry::Guild { state, .. }) => vec![GuildActionItem {
-                kind: GuildActionKind::MarkAsRead,
-                label: "Mark server as read".to_owned(),
-                enabled: self.guild_ack_targets(state.id).next().is_some(),
-            }],
+            Some(GuildPaneEntry::Guild { state, .. }) => vec![
+                GuildActionItem {
+                    kind: GuildActionKind::MarkAsRead,
+                    label: "Mark server as read".to_owned(),
+                    enabled: self.guild_ack_targets(state.id).next().is_some(),
+                },
+                GuildActionItem {
+                    kind: GuildActionKind::ToggleMute,
+                    label: if self.discord.guild_notification_muted(state.id) {
+                        "Unmute server".to_owned()
+                    } else {
+                        "Mute server".to_owned()
+                    },
+                    enabled: true,
+                },
+            ],
             Some(GuildPaneEntry::DirectMessages) => vec![GuildActionItem {
                 kind: GuildActionKind::NoActionsYet,
                 label: "No server actions yet".to_owned(),
@@ -224,33 +244,64 @@ impl DashboardState {
         }
     }
 
+    pub fn selected_guild_mute_duration_items(&self) -> &'static [super::MuteActionDurationItem] {
+        &MUTE_ACTION_DURATIONS
+    }
+
     pub fn selected_guild_action_index(&self) -> Option<usize> {
-        let menu = self.guild_action_menu.as_ref()?;
-        Some(clamp_selected_index(
-            menu.selected,
-            self.selected_guild_action_items().len(),
-        ))
+        match self.guild_action_menu.as_ref()? {
+            GuildActionMenuState::Actions { selected } => Some(clamp_selected_index(
+                *selected,
+                self.selected_guild_action_items().len(),
+            )),
+            GuildActionMenuState::MuteDuration { selected } => Some(clamp_selected_index(
+                *selected,
+                self.selected_guild_mute_duration_items().len(),
+            )),
+        }
     }
 
     pub fn move_guild_action_down(&mut self) {
-        let len = self.selected_guild_action_items().len();
+        let len = match self.guild_action_menu.as_ref() {
+            Some(GuildActionMenuState::Actions { .. }) => self.selected_guild_action_items().len(),
+            Some(GuildActionMenuState::MuteDuration { .. }) => {
+                self.selected_guild_mute_duration_items().len()
+            }
+            None => return,
+        };
         if let Some(menu) = self.guild_action_menu.as_mut() {
-            move_index_down(&mut menu.selected, len);
+            match menu {
+                GuildActionMenuState::Actions { selected }
+                | GuildActionMenuState::MuteDuration { selected } => move_index_down(selected, len),
+            }
         }
     }
 
     pub fn move_guild_action_up(&mut self) {
         if let Some(menu) = self.guild_action_menu.as_mut() {
-            move_index_up(&mut menu.selected);
+            match menu {
+                GuildActionMenuState::Actions { selected }
+                | GuildActionMenuState::MuteDuration { selected } => move_index_up(selected),
+            }
         }
     }
 
     pub fn select_guild_action_row(&mut self, row: usize) -> bool {
-        if row >= self.selected_guild_action_items().len() {
+        let len = match self.guild_action_menu.as_ref() {
+            Some(GuildActionMenuState::Actions { .. }) => self.selected_guild_action_items().len(),
+            Some(GuildActionMenuState::MuteDuration { .. }) => {
+                self.selected_guild_mute_duration_items().len()
+            }
+            None => return false,
+        };
+        if row >= len {
             return false;
         }
         if let Some(menu) = self.guild_action_menu.as_mut() {
-            menu.selected = row;
+            match menu {
+                GuildActionMenuState::Actions { selected }
+                | GuildActionMenuState::MuteDuration { selected } => *selected = row,
+            }
             return true;
         }
         false
@@ -258,27 +309,76 @@ impl DashboardState {
 
     pub fn activate_selected_guild_action(&mut self) -> Option<AppCommand> {
         let menu = self.guild_action_menu.clone()?;
-        let items = self.selected_guild_action_items();
-        let item = items.get(clamp_selected_index(menu.selected, items.len()))?;
-        if !item.enabled {
-            return None;
-        }
-        match item.kind {
-            GuildActionKind::MarkAsRead => self.mark_selected_guild_as_read(),
-            GuildActionKind::NoActionsYet => None,
+        match menu {
+            GuildActionMenuState::Actions { selected } => {
+                let items = self.selected_guild_action_items();
+                let item = items.get(clamp_selected_index(selected, items.len()))?;
+                if !item.enabled {
+                    return None;
+                }
+                match item.kind {
+                    GuildActionKind::MarkAsRead => self.mark_selected_guild_as_read(),
+                    GuildActionKind::ToggleMute => {
+                        let guild_id = self.selected_guild_cursor_id()?;
+                        if self.discord.guild_notification_muted(guild_id) {
+                            self.close_guild_action_menu();
+                            self.toggle_selected_guild_mute(None)
+                        } else {
+                            self.guild_action_menu =
+                                Some(GuildActionMenuState::MuteDuration { selected: 0 });
+                            None
+                        }
+                    }
+                    GuildActionKind::NoActionsYet => None,
+                }
+            }
+            GuildActionMenuState::MuteDuration { selected } => {
+                let item = self
+                    .selected_guild_mute_duration_items()
+                    .get(clamp_selected_index(
+                        selected,
+                        self.selected_guild_mute_duration_items().len(),
+                    ))?;
+                self.close_guild_action_menu();
+                self.toggle_selected_guild_mute(Some(item.duration))
+            }
         }
     }
 
     pub fn activate_guild_action_shortcut(&mut self, shortcut: char) -> Option<AppCommand> {
         let shortcut = shortcut.to_ascii_lowercase();
-        let actions = self.selected_guild_action_items();
-        let index = actions.iter().enumerate().position(|(index, action)| {
-            action.enabled
-                && guild_action_shortcut(&actions, index)
-                    .is_some_and(|candidate| candidate == shortcut)
-        })?;
-        self.select_guild_action_row(index);
-        self.activate_selected_guild_action()
+        match self.guild_action_menu.as_ref()? {
+            GuildActionMenuState::Actions { .. } => {
+                let actions = self.selected_guild_action_items();
+                let index = actions.iter().enumerate().position(|(index, action)| {
+                    action.enabled
+                        && guild_action_shortcut(&actions, index)
+                            .is_some_and(|candidate| candidate == shortcut)
+                })?;
+                self.select_guild_action_row(index);
+                self.activate_selected_guild_action()
+            }
+            GuildActionMenuState::MuteDuration { .. } => {
+                let index = self
+                    .selected_guild_mute_duration_items()
+                    .iter()
+                    .enumerate()
+                    .position(|(index, _)| indexed_shortcut(index) == Some(shortcut))?;
+                self.select_guild_action_row(index);
+                self.activate_selected_guild_action()
+            }
+        }
+    }
+
+    pub fn back_guild_action_menu(&mut self) {
+        if matches!(
+            self.guild_action_menu,
+            Some(GuildActionMenuState::MuteDuration { .. })
+        ) {
+            self.guild_action_menu = Some(GuildActionMenuState::Actions { selected: 0 });
+        } else {
+            self.guild_action_menu = None;
+        }
     }
 
     fn mark_selected_guild_as_read(&mut self) -> Option<AppCommand> {

--- a/src/tui/state/model.rs
+++ b/src/tui/state/model.rs
@@ -4,7 +4,8 @@ use crate::discord::ids::{
 };
 
 use crate::discord::{
-    ChannelState, ChannelUnreadState, GuildFolder, GuildState, ReactionEmoji, ReactionInfo,
+    ChannelState, ChannelUnreadState, GuildFolder, GuildState, MuteDuration, ReactionEmoji,
+    ReactionInfo,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -98,6 +99,7 @@ pub enum ChannelActionKind {
     LoadPinnedMessages,
     ShowThreads,
     MarkAsRead,
+    ToggleMute,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -113,6 +115,7 @@ impl ChannelActionKind {
             ChannelActionKind::LoadPinnedMessages => 'p',
             ChannelActionKind::ShowThreads => 't',
             ChannelActionKind::MarkAsRead => 'm',
+            ChannelActionKind::ToggleMute => 'u',
         }
     }
 }
@@ -132,6 +135,7 @@ pub fn channel_action_shortcut(actions: &[ChannelActionItem], index: usize) -> O
 pub enum GuildActionKind {
     NoActionsYet,
     MarkAsRead,
+    ToggleMute,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -145,17 +149,52 @@ pub fn guild_action_shortcut(actions: &[GuildActionItem], index: usize) -> Optio
     let action = actions.get(index)?;
     let preferred = match action.kind {
         GuildActionKind::MarkAsRead => Some('m'),
+        GuildActionKind::ToggleMute => Some('u'),
         GuildActionKind::NoActionsYet => None,
     }?;
     unique_preferred_shortcut(
         Some(preferred),
         actions.iter().map(|item| match item.kind {
             GuildActionKind::MarkAsRead => Some('m'),
+            GuildActionKind::ToggleMute => Some('u'),
             GuildActionKind::NoActionsYet => None,
         }),
     )
     .or_else(|| indexed_shortcut(index))
 }
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct MuteActionDurationItem {
+    pub label: &'static str,
+    pub duration: MuteDuration,
+}
+
+pub const MUTE_ACTION_DURATIONS: [MuteActionDurationItem; 6] = [
+    MuteActionDurationItem {
+        label: "15 minutes",
+        duration: MuteDuration::Minutes(15),
+    },
+    MuteActionDurationItem {
+        label: "1 hour",
+        duration: MuteDuration::Minutes(60),
+    },
+    MuteActionDurationItem {
+        label: "3 hours",
+        duration: MuteDuration::Minutes(180),
+    },
+    MuteActionDurationItem {
+        label: "8 hours",
+        duration: MuteDuration::Minutes(480),
+    },
+    MuteActionDurationItem {
+        label: "24 hours",
+        duration: MuteDuration::Minutes(1_440),
+    },
+    MuteActionDurationItem {
+        label: "Permanently",
+        duration: MuteDuration::Permanent,
+    },
+];
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum MemberActionKind {

--- a/src/tui/state/popups.rs
+++ b/src/tui/state/popups.rs
@@ -25,8 +25,9 @@ pub(super) struct ImageViewerState {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub(super) struct GuildActionMenuState {
-    pub(super) selected: usize,
+pub(super) enum GuildActionMenuState {
+    Actions { selected: usize },
+    MuteDuration { selected: usize },
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -55,6 +56,10 @@ pub(super) struct MemberActionMenuState {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(super) enum ChannelActionMenuState {
     Actions {
+        channel_id: Id<ChannelMarker>,
+        selected: usize,
+    },
+    MuteDuration {
         channel_id: Id<ChannelMarker>,
         selected: usize,
     },

--- a/src/tui/state/tests/mod.rs
+++ b/src/tui/state/tests/mod.rs
@@ -3904,7 +3904,7 @@ fn channel_action_menu_lists_threads_for_selected_channel() {
 
     assert!(state.is_channel_action_menu_open());
     let actions = state.selected_channel_action_items();
-    assert_eq!(actions.len(), 3);
+    assert_eq!(actions.len(), 4);
     assert_eq!(actions[0].kind, ChannelActionKind::LoadPinnedMessages);
     assert_eq!(actions[0].label, "Show pinned messages");
     assert!(actions[0].enabled);
@@ -3912,6 +3912,8 @@ fn channel_action_menu_lists_threads_for_selected_channel() {
     assert!(actions[1].enabled);
     assert_eq!(actions[2].kind, ChannelActionKind::MarkAsRead);
     assert_eq!(actions[2].label, "Mark as read");
+    assert_eq!(actions[3].kind, ChannelActionKind::ToggleMute);
+    assert_eq!(actions[3].label, "Mute channel");
 
     state.move_channel_action_down();
     let command = state.activate_selected_channel_action();
@@ -4052,11 +4054,63 @@ fn guild_action_menu_lists_disabled_mark_server_read_when_guild_is_read() {
     assert!(state.is_guild_action_menu_open());
     assert_eq!(state.guild_action_menu_title(), Some("guild 1".to_owned()));
     let actions = state.selected_guild_action_items();
-    assert_eq!(actions.len(), 1);
+    assert_eq!(actions.len(), 2);
     assert_eq!(actions[0].kind, GuildActionKind::MarkAsRead);
     assert_eq!(actions[0].label, "Mark server as read");
     assert!(!actions[0].enabled);
+    assert_eq!(actions[1].kind, GuildActionKind::ToggleMute);
+    assert_eq!(actions[1].label, "Mute server");
     assert_eq!(state.activate_selected_guild_action(), None);
+}
+
+#[test]
+fn channel_action_menu_toggle_mute_opens_duration_then_dispatches_command() {
+    let mut state = state_with_channel_tree();
+    state.focus_pane(FocusPane::Channels);
+    state.move_down();
+    state.open_selected_channel_actions();
+    state.select_channel_action_row(3);
+
+    assert_eq!(state.activate_selected_channel_action(), None);
+    assert!(state.is_channel_action_mute_duration_phase());
+
+    let command = state.activate_selected_channel_action();
+
+    assert_eq!(
+        command,
+        Some(AppCommand::SetChannelMuted {
+            guild_id: Some(Id::new(1)),
+            channel_id: Id::new(11),
+            muted: true,
+            duration: Some(crate::discord::MuteDuration::Minutes(15)),
+            label: "#general".to_owned(),
+        })
+    );
+    assert!(!state.is_channel_action_menu_open());
+}
+
+#[test]
+fn guild_action_menu_toggle_mute_opens_duration_then_dispatches_command() {
+    let mut state = state_with_many_guilds(1);
+    state.focus_pane(FocusPane::Guilds);
+    state.open_selected_guild_actions();
+    state.select_guild_action_row(1);
+
+    assert_eq!(state.activate_selected_guild_action(), None);
+    assert!(state.is_guild_action_mute_duration_phase());
+
+    let command = state.activate_selected_guild_action();
+
+    assert_eq!(
+        command,
+        Some(AppCommand::SetGuildMuted {
+            guild_id: Id::new(1),
+            muted: true,
+            duration: Some(crate::discord::MuteDuration::Minutes(15)),
+            label: "guild 1".to_owned(),
+        })
+    );
+    assert!(!state.is_guild_action_menu_open());
 }
 
 #[test]

--- a/src/tui/state/tests/mod.rs
+++ b/src/tui/state/tests/mod.rs
@@ -4090,6 +4090,42 @@ fn channel_action_menu_toggle_mute_opens_duration_then_dispatches_command() {
 }
 
 #[test]
+fn category_action_menu_only_lists_mute_and_dispatches_command() {
+    let mut state = state_with_channel_tree();
+    state.focus_pane(FocusPane::Channels);
+    state.move_up();
+    state.open_selected_channel_actions();
+
+    assert!(state.is_channel_action_menu_open());
+    assert_eq!(
+        state.channel_action_menu_title(),
+        Some("Text Channels".to_owned())
+    );
+
+    let actions = state.selected_channel_action_items();
+    assert_eq!(actions.len(), 1);
+    assert_eq!(actions[0].kind, ChannelActionKind::ToggleMute);
+    assert_eq!(actions[0].label, "Mute category");
+
+    assert_eq!(state.activate_selected_channel_action(), None);
+    assert!(state.is_channel_action_mute_duration_phase());
+
+    let command = state.activate_selected_channel_action();
+
+    assert_eq!(
+        command,
+        Some(AppCommand::SetChannelMuted {
+            guild_id: Some(Id::new(1)),
+            channel_id: Id::new(10),
+            muted: true,
+            duration: Some(crate::discord::MuteDuration::Minutes(15)),
+            label: "Text Channels".to_owned(),
+        })
+    );
+    assert!(!state.is_channel_action_menu_open());
+}
+
+#[test]
 fn guild_action_menu_toggle_mute_opens_duration_then_dispatches_command() {
     let mut state = state_with_many_guilds(1);
     state.focus_pane(FocusPane::Guilds);

--- a/src/tui/ui/interaction.rs
+++ b/src/tui/ui/interaction.rs
@@ -107,9 +107,14 @@ fn action_menu_mouse_target(
         );
     }
     if state.is_guild_action_menu_open() {
+        let item_count = if state.is_guild_action_mute_duration_phase() {
+            state.selected_guild_mute_duration_items().len()
+        } else {
+            state.selected_guild_action_items().len()
+        };
         return action_menu_row_target(
             guild_action_menu_area(area, state),
-            state.selected_guild_action_items().len(),
+            item_count,
             ActionMenuTarget::Guild,
             column,
             row,
@@ -118,6 +123,8 @@ fn action_menu_mouse_target(
     if state.is_channel_action_menu_open() {
         let item_count = if state.is_channel_action_threads_phase() {
             state.channel_action_thread_items().len()
+        } else if state.is_channel_action_mute_duration_phase() {
+            state.selected_channel_mute_duration_items().len()
         } else {
             state.selected_channel_action_items().len()
         };
@@ -170,13 +177,20 @@ fn message_action_menu_area(area: Rect, state: &DashboardState) -> Option<Rect> 
 }
 
 fn guild_action_menu_area(area: Rect, state: &DashboardState) -> Option<Rect> {
-    let actions = state.selected_guild_action_items();
-    (!actions.is_empty()).then(|| centered_rect(area, 48, (actions.len() as u16).saturating_add(4)))
+    let row_count = if state.is_guild_action_mute_duration_phase() {
+        state.selected_guild_mute_duration_items().len()
+    } else {
+        state.selected_guild_action_items().len()
+    };
+    (row_count > 0).then(|| centered_rect(area, 48, (row_count as u16).saturating_add(4)))
 }
 
 fn channel_action_menu_area(area: Rect, state: &DashboardState) -> Option<Rect> {
     if state.is_channel_action_threads_phase() {
         let row_count = state.channel_action_thread_items().len().max(1) as u16;
+        Some(centered_rect(area, 54, row_count.saturating_add(4)))
+    } else if state.is_channel_action_mute_duration_phase() {
+        let row_count = state.selected_channel_mute_duration_items().len() as u16;
         Some(centered_rect(area, 54, row_count.saturating_add(4)))
     } else {
         let actions = state.selected_channel_action_items();

--- a/src/tui/ui/panes.rs
+++ b/src/tui/ui/panes.rs
@@ -102,7 +102,7 @@ pub(super) fn render_guilds(frame: &mut Frame, area: Rect, state: &DashboardStat
                     } => {
                         let prefix = branch.prefix();
                         let base_style = active_text_style(is_active, Style::default());
-                        let unread = dashboard.guild_unread(guild.id);
+                        let unread = dashboard.sidebar_guild_unread(guild.id);
                         let (badge, name_style) = if is_active {
                             let (badge, _) = channel_unread_decoration(unread, base_style, false);
                             (badge, base_style)
@@ -195,7 +195,7 @@ pub(super) fn render_channels(frame: &mut Frame, area: Rect, state: &DashboardSt
                         });
                         let prefix_width = prefix_span.content.width();
                         let base_style = active_text_style(is_active, Style::default());
-                        let unread = dashboard.channel_unread(state.id);
+                        let unread = dashboard.sidebar_channel_unread(state.id);
                         let (badge, name_style) =
                             channel_unread_decoration(unread, base_style, is_active);
                         let badge = if state.guild_id.is_none()
@@ -813,10 +813,16 @@ pub(super) fn footer_hint(state: &DashboardState) -> String {
         || state.is_guild_action_menu_open()
         || state.is_member_action_menu_open()
     {
-        "j/k choose action | enter select | esc close | q quit".to_owned()
+        if state.is_guild_action_mute_duration_phase() {
+            "j/k choose duration | enter select | esc back | q quit".to_owned()
+        } else {
+            "j/k choose action | enter select | esc close | q quit".to_owned()
+        }
     } else if state.is_channel_action_menu_open() {
         if state.is_channel_action_threads_phase() {
             "j/k choose thread | enter open | esc/← back | q quit".to_owned()
+        } else if state.is_channel_action_mute_duration_phase() {
+            "j/k choose duration | enter select | esc/← back | q quit".to_owned()
         } else {
             "j/k choose action | enter select | esc close | q quit".to_owned()
         }

--- a/src/tui/ui/panes.rs
+++ b/src/tui/ui/panes.rs
@@ -102,8 +102,9 @@ pub(super) fn render_guilds(frame: &mut Frame, area: Rect, state: &DashboardStat
                     } => {
                         let prefix = branch.prefix();
                         let base_style = active_text_style(is_active, Style::default());
+                        let is_muted = dashboard.guild_notification_muted(guild.id);
                         let unread = dashboard.sidebar_guild_unread(guild.id);
-                        let (badge, name_style) = if is_active {
+                        let (badge, mut name_style) = if is_active {
                             let (badge, _) = channel_unread_decoration(unread, base_style, false);
                             (badge, base_style)
                         } else if unread == ChannelUnreadState::Seen {
@@ -111,6 +112,9 @@ pub(super) fn render_guilds(frame: &mut Frame, area: Rect, state: &DashboardStat
                         } else {
                             channel_unread_decoration(unread, base_style, false)
                         };
+                        if is_muted {
+                            name_style = name_style.add_modifier(Modifier::DIM);
+                        }
                         let badge_width =
                             badge.as_ref().map(|span| span.content.width()).unwrap_or(0);
                         let label_width = max_width
@@ -175,6 +179,11 @@ pub(super) fn render_channels(frame: &mut Frame, area: Rect, state: &DashboardSt
                     ChannelPaneEntry::CategoryHeader { state, collapsed } => {
                         let arrow = if *collapsed { "▶ " } else { "▼ " };
                         let label_width = max_width.saturating_sub(arrow.width());
+                        let mut label_style =
+                            Style::default().fg(ACCENT).add_modifier(Modifier::BOLD);
+                        if dashboard.channel_notification_muted(state.id) {
+                            label_style = label_style.add_modifier(Modifier::DIM);
+                        }
                         ListItem::new(Line::from(vec![
                             selection_marker(is_selected),
                             Span::styled(arrow, Style::default().fg(ACCENT)),
@@ -184,7 +193,7 @@ pub(super) fn render_channels(frame: &mut Frame, area: Rect, state: &DashboardSt
                                     horizontal_scroll,
                                     label_width,
                                 ),
-                                Style::default().fg(ACCENT).add_modifier(Modifier::BOLD),
+                                label_style,
                             ),
                         ]))
                     }
@@ -195,9 +204,13 @@ pub(super) fn render_channels(frame: &mut Frame, area: Rect, state: &DashboardSt
                         });
                         let prefix_width = prefix_span.content.width();
                         let base_style = active_text_style(is_active, Style::default());
+                        let is_muted = dashboard.channel_notification_muted(state.id);
                         let unread = dashboard.sidebar_channel_unread(state.id);
-                        let (badge, name_style) =
+                        let (badge, mut name_style) =
                             channel_unread_decoration(unread, base_style, is_active);
+                        if is_muted {
+                            name_style = name_style.add_modifier(Modifier::DIM);
+                        }
                         let badge = if state.guild_id.is_none()
                             && !is_active
                             && unread != ChannelUnreadState::Seen

--- a/src/tui/ui/popups.rs
+++ b/src/tui/ui/popups.rs
@@ -1,5 +1,6 @@
 use super::message_list::render_image_preview;
 use super::*;
+use crate::tui::state::MuteActionDurationItem;
 use ratatui::layout::Position;
 
 const LEADER_POPUP_WIDTH: u16 = 74;
@@ -121,6 +122,16 @@ fn leader_action_lines(state: &DashboardState) -> Vec<Line<'static>> {
             .collect();
     }
     if state.is_guild_action_menu_open() {
+        if state.is_guild_action_mute_duration_phase() {
+            return state
+                .selected_guild_mute_duration_items()
+                .iter()
+                .enumerate()
+                .map(|(index, item)| {
+                    leader_shortcut_line(indexed_shortcut(index).unwrap_or(' '), item.label, true)
+                })
+                .collect();
+        }
         let actions = state.selected_guild_action_items();
         return actions
             .iter()
@@ -145,6 +156,16 @@ fn leader_action_lines(state: &DashboardState) -> Vec<Line<'static>> {
             .collect();
     }
     if state.is_channel_action_menu_open() {
+        if state.is_channel_action_mute_duration_phase() {
+            return state
+                .selected_channel_mute_duration_items()
+                .iter()
+                .enumerate()
+                .map(|(index, item)| {
+                    leader_shortcut_line(indexed_shortcut(index).unwrap_or(' '), item.label, true)
+                })
+                .collect();
+        }
         let actions = state.selected_channel_action_items();
         return actions
             .iter()
@@ -673,16 +694,32 @@ pub(super) fn render_guild_action_menu(frame: &mut Frame, area: Rect, state: &Da
         return;
     }
     let selected = state.selected_guild_action_index().unwrap_or(0);
-    let title = state
-        .guild_action_menu_title()
-        .map(|name| format!("Server actions — {name}"))
-        .unwrap_or_else(|| "Server actions".to_owned());
-    let popup = centered_rect(area, 48, (actions.len() as u16).saturating_add(4));
+    let is_duration_phase = state.is_guild_action_mute_duration_phase();
+    let title = state.guild_action_menu_title();
+    let row_count = if is_duration_phase {
+        state.selected_guild_mute_duration_items().len()
+    } else {
+        actions.len()
+    };
+    let popup = centered_rect(area, 48, (row_count as u16).saturating_add(4));
     frame.render_widget(Clear, popup);
     frame.render_widget(
-        Paragraph::new(guild_action_menu_lines(&actions, selected))
-            .block(panel_block_owned(title, true))
-            .wrap(Wrap { trim: false }),
+        Paragraph::new(if is_duration_phase {
+            mute_duration_menu_lines(state.selected_guild_mute_duration_items(), selected)
+        } else {
+            guild_action_menu_lines(&actions, selected)
+        })
+        .block(panel_block_owned(
+            if is_duration_phase {
+                format!("Mute server for... — {}", title.unwrap_or_default())
+            } else {
+                title
+                    .map(|name| format!("Server actions — {name}"))
+                    .unwrap_or_else(|| "Server actions".to_owned())
+            },
+            true,
+        ))
+        .wrap(Wrap { trim: false }),
         popup,
     );
 }
@@ -712,20 +749,34 @@ pub(super) fn render_channel_action_menu(frame: &mut Frame, area: Rect, state: &
         return;
     }
 
+    let is_duration_phase = state.is_channel_action_mute_duration_phase();
     let actions = state.selected_channel_action_items();
-    if actions.is_empty() {
+    if actions.is_empty() && !is_duration_phase {
         return;
     }
     let selected = state.selected_channel_action_index().unwrap_or(0);
-    let popup = centered_rect(area, 54, (actions.len() as u16).saturating_add(4));
+    let row_count = if is_duration_phase {
+        state.selected_channel_mute_duration_items().len()
+    } else {
+        actions.len()
+    };
+    let popup = centered_rect(area, 54, (row_count as u16).saturating_add(4));
     frame.render_widget(Clear, popup);
     frame.render_widget(
-        Paragraph::new(channel_action_menu_lines(&actions, selected))
-            .block(panel_block_owned(
-                format!("Channel actions{title_suffix}"),
-                true,
-            ))
-            .wrap(Wrap { trim: false }),
+        Paragraph::new(if is_duration_phase {
+            mute_duration_menu_lines(state.selected_channel_mute_duration_items(), selected)
+        } else {
+            channel_action_menu_lines(&actions, selected)
+        })
+        .block(panel_block_owned(
+            if is_duration_phase {
+                format!("Mute channel for...{title_suffix}")
+            } else {
+                format!("Channel actions{title_suffix}")
+            },
+            true,
+        ))
+        .wrap(Wrap { trim: false }),
         popup,
     );
 }
@@ -871,6 +922,36 @@ pub(super) fn guild_action_menu_lines(
         .collect();
     lines.push(Line::from(Span::styled(
         "Shortcut/Enter select · Esc close",
+        Style::default().fg(DIM),
+    )));
+    lines
+}
+
+fn mute_duration_menu_lines(
+    actions: &[MuteActionDurationItem],
+    selected: usize,
+) -> Vec<Line<'static>> {
+    let mut lines: Vec<Line<'static>> = actions
+        .iter()
+        .enumerate()
+        .map(|(index, action)| {
+            let marker = if index == selected { "› " } else { "  " };
+            let shortcut = shortcut_prefix(indexed_shortcut(index));
+            let mut style = Style::default();
+            if index == selected {
+                style = style
+                    .bg(Color::Rgb(40, 45, 90))
+                    .add_modifier(Modifier::BOLD);
+            }
+            Line::from(vec![
+                Span::styled(marker, Style::default().fg(ACCENT)),
+                Span::styled(shortcut, Style::default().fg(DIM)),
+                Span::styled(action.label, style),
+            ])
+        })
+        .collect();
+    lines.push(Line::from(Span::styled(
+        "Shortcut/Enter select · Esc back",
         Style::default().fg(DIM),
     )));
     lines

--- a/src/tui/ui/tests.rs
+++ b/src/tui/ui/tests.rs
@@ -87,11 +87,9 @@ fn options_popup_lines_show_selected_toggle_state() {
     assert_eq!(lines[1].spans[0].content, "› ");
     assert_eq!(lines[1].spans[1].content, "[x] ");
     assert_eq!(lines[2].spans[1].content, "[balanced] ");
-    assert!(
-        lines.last().expect("hint line").spans[0]
-            .content
-            .contains("config.toml")
-    );
+    let footer = &lines.last().expect("hint line").spans[0].content;
+    assert!(footer.contains("saved to "));
+    assert!(footer.contains("Esc close"));
 }
 
 #[test]
@@ -2442,6 +2440,11 @@ fn channel_action_menu_renders_pinned_and_thread_actions() {
             label: "Show threads (none)".to_owned(),
             enabled: false,
         },
+        ChannelActionItem {
+            kind: ChannelActionKind::ToggleMute,
+            label: "Mute channel".to_owned(),
+            enabled: true,
+        },
     ];
 
     let lines = channel_action_menu_lines(&actions, 0);
@@ -2451,6 +2454,7 @@ fn channel_action_menu_renders_pinned_and_thread_actions() {
         vec![
             "› [p] Show pinned messages",
             "  [t] Show threads (none)",
+            "  [u] Mute channel",
             "Shortcut/Enter select · Esc close",
         ]
     );
@@ -2476,12 +2480,19 @@ fn guild_action_menu_renders_placeholder_action() {
 }
 
 #[test]
-fn guild_action_menu_renders_mark_server_read_shortcut() {
-    let actions = vec![GuildActionItem {
-        kind: GuildActionKind::MarkAsRead,
-        label: "Mark server as read".to_owned(),
-        enabled: true,
-    }];
+fn guild_action_menu_renders_mark_server_read_and_mute_shortcuts() {
+    let actions = vec![
+        GuildActionItem {
+            kind: GuildActionKind::MarkAsRead,
+            label: "Mark server as read".to_owned(),
+            enabled: true,
+        },
+        GuildActionItem {
+            kind: GuildActionKind::ToggleMute,
+            label: "Mute server".to_owned(),
+            enabled: true,
+        },
+    ];
 
     let lines = guild_action_menu_lines(&actions, 0);
 
@@ -2489,6 +2500,7 @@ fn guild_action_menu_renders_mark_server_read_shortcut() {
         line_texts_from_ratatui(&lines),
         vec![
             "› [m] Mark server as read",
+            "  [u] Mute server",
             "Shortcut/Enter select · Esc close"
         ]
     );

--- a/src/tui/ui/tests.rs
+++ b/src/tui/ui/tests.rs
@@ -2461,6 +2461,22 @@ fn channel_action_menu_renders_pinned_and_thread_actions() {
 }
 
 #[test]
+fn channel_action_menu_renders_category_mute_shortcut() {
+    let actions = vec![ChannelActionItem {
+        kind: ChannelActionKind::ToggleMute,
+        label: "Mute category".to_owned(),
+        enabled: true,
+    }];
+
+    let lines = channel_action_menu_lines(&actions, 0);
+
+    assert_eq!(
+        line_texts_from_ratatui(&lines),
+        vec!["› [u] Mute category", "Shortcut/Enter select · Esc close",]
+    );
+}
+
+#[test]
 fn guild_action_menu_renders_placeholder_action() {
     let actions = vec![GuildActionItem {
         kind: GuildActionKind::NoActionsYet,

--- a/src/tui/ui/tests.rs
+++ b/src/tui/ui/tests.rs
@@ -33,11 +33,12 @@ use crate::{
     config::DisplayOptions,
     discord::{
         ActivityEmoji, ActivityInfo, ActivityKind, AppEvent, AttachmentInfo, ChannelInfo,
-        ChannelRecipientState, ChannelState, ChannelUnreadState, ChannelVisibilityStats, EmbedInfo,
-        FriendStatus, GuildMemberState, MemberInfo, MentionInfo, MessageAttachmentUpload,
+        ChannelNotificationOverrideInfo, ChannelRecipientState, ChannelState, ChannelUnreadState,
+        ChannelVisibilityStats, EmbedInfo, FriendStatus, GuildMemberState,
+        GuildNotificationSettingsInfo, MemberInfo, MentionInfo, MessageAttachmentUpload,
         MessageInfo, MessageKind, MessageSnapshotInfo, MessageState, MutualGuildInfo,
-        PollAnswerInfo, PollInfo, PresenceStatus, ReactionEmoji, ReactionInfo, ReactionUserInfo,
-        ReactionUsersInfo, ReadStateInfo, ReplyInfo, RoleInfo, UserProfileInfo,
+        NotificationLevel, PollAnswerInfo, PollInfo, PresenceStatus, ReactionEmoji, ReactionInfo,
+        ReactionUserInfo, ReactionUsersInfo, ReadStateInfo, ReplyInfo, RoleInfo, UserProfileInfo,
     },
     tui::{
         format::{TextHighlightKind, truncate_display_width, truncate_display_width_from},
@@ -728,6 +729,76 @@ fn server_pane_shows_direct_message_unread_channel_count() {
 }
 
 #[test]
+fn muted_server_name_is_dimmed() {
+    let guild_id = Id::new(1);
+    let channel_id = Id::new(2);
+    let mut state = DashboardState::new();
+    state.push_event(AppEvent::GuildCreate {
+        guild_id,
+        name: "guild".to_owned(),
+        member_count: None,
+        channels: vec![ChannelInfo {
+            guild_id: Some(guild_id),
+            channel_id,
+            parent_id: None,
+            position: None,
+            last_message_id: None,
+            name: "general".to_owned(),
+            kind: "GuildText".to_owned(),
+            message_count: None,
+            total_message_sent: None,
+            thread_archived: None,
+            thread_locked: None,
+            thread_pinned: None,
+            recipients: None,
+            permission_overwrites: Vec::new(),
+        }],
+        members: Vec::new(),
+        presences: Vec::new(),
+        roles: Vec::new(),
+        emojis: Vec::new(),
+        owner_id: None,
+    });
+    state.push_event(AppEvent::UserGuildNotificationSettingsInit {
+        settings: vec![GuildNotificationSettingsInfo {
+            guild_id: Some(guild_id),
+            message_notifications: Some(NotificationLevel::OnlyMentions),
+            muted: true,
+            mute_end_time: None,
+            suppress_everyone: false,
+            suppress_roles: false,
+            channel_overrides: Vec::new(),
+        }],
+    });
+    state.set_guild_view_height(20);
+    let backend = TestBackend::new(40, 6);
+    let mut terminal = Terminal::new(backend).expect("test terminal should build");
+
+    terminal
+        .draw(|frame| render_guilds(frame, frame.area(), &state))
+        .expect("draw should succeed");
+
+    let buffer = terminal.backend().buffer();
+    let mut checked = false;
+    for row in 0..buffer.area.height {
+        let text = (0..buffer.area.width)
+            .map(|col| buffer[(col, row)].symbol().to_owned())
+            .collect::<String>();
+        if let Some(name_col) = text.find("guild") {
+            assert!(
+                buffer[(name_col as u16, row)]
+                    .modifier
+                    .contains(Modifier::DIM)
+            );
+            checked = true;
+            break;
+        }
+    }
+
+    assert!(checked, "muted guild row should render guild name");
+}
+
+#[test]
 fn dm_channel_pane_shows_unread_channel_count_badge() {
     let mut state = state_with_unread_direct_messages();
     state.confirm_selected_guild();
@@ -772,6 +843,116 @@ fn dm_channel_pane_shows_loaded_unread_message_count_badge() {
 
     assert!(channel_rows.iter().any(|row| row.contains("(5) @ new")));
     assert!(!channel_rows.iter().any(|row| row.contains("(1) @ new")));
+}
+
+#[test]
+fn muted_category_and_channel_names_are_dimmed() {
+    let mut state = DashboardState::new();
+    let guild_id = Id::new(1);
+    let category_id = Id::new(10);
+    let channel_id = Id::new(11);
+    state.push_event(AppEvent::GuildCreate {
+        guild_id,
+        name: "guild".to_owned(),
+        member_count: None,
+        channels: vec![
+            ChannelInfo {
+                guild_id: Some(guild_id),
+                channel_id: category_id,
+                parent_id: None,
+                position: Some(0),
+                last_message_id: None,
+                name: "Text Channels".to_owned(),
+                kind: "category".to_owned(),
+                message_count: None,
+                total_message_sent: None,
+                thread_archived: None,
+                thread_locked: None,
+                thread_pinned: None,
+                recipients: None,
+                permission_overwrites: Vec::new(),
+            },
+            ChannelInfo {
+                guild_id: Some(guild_id),
+                channel_id,
+                parent_id: Some(category_id),
+                position: Some(0),
+                last_message_id: None,
+                name: "general".to_owned(),
+                kind: "text".to_owned(),
+                message_count: None,
+                total_message_sent: None,
+                thread_archived: None,
+                thread_locked: None,
+                thread_pinned: None,
+                recipients: None,
+                permission_overwrites: Vec::new(),
+            },
+        ],
+        members: Vec::new(),
+        presences: Vec::new(),
+        roles: Vec::new(),
+        emojis: Vec::new(),
+        owner_id: None,
+    });
+    state.confirm_selected_guild();
+    state.push_event(AppEvent::UserGuildNotificationSettingsInit {
+        settings: vec![GuildNotificationSettingsInfo {
+            guild_id: Some(guild_id),
+            message_notifications: Some(NotificationLevel::OnlyMentions),
+            muted: false,
+            mute_end_time: None,
+            suppress_everyone: false,
+            suppress_roles: false,
+            channel_overrides: vec![ChannelNotificationOverrideInfo {
+                channel_id: category_id,
+                message_notifications: None,
+                muted: true,
+                mute_end_time: None,
+            }],
+        }],
+    });
+    state.set_channel_view_height(20);
+    let backend = TestBackend::new(40, 8);
+    let mut terminal = Terminal::new(backend).expect("test terminal should build");
+
+    terminal
+        .draw(|frame| render_channels(frame, frame.area(), &state))
+        .expect("draw should succeed");
+
+    let buffer = terminal.backend().buffer();
+    let mut saw_category = false;
+    let mut saw_channel = false;
+    for row in 0..buffer.area.height {
+        let text = (0..buffer.area.width)
+            .map(|col| buffer[(col, row)].symbol().to_owned())
+            .collect::<String>();
+        if let Some(name_col) = text.find("Text Channels") {
+            assert!(
+                buffer[(name_col as u16, row)]
+                    .modifier
+                    .contains(Modifier::DIM)
+            );
+            saw_category = true;
+        }
+        if let Some(name_col) = text.find("general") {
+            assert!(
+                buffer[(name_col as u16, row)]
+                    .modifier
+                    .contains(Modifier::DIM)
+            );
+            saw_channel = true;
+        }
+    }
+
+    assert!(
+        saw_category,
+        "muted category row should render category name"
+    );
+    assert!(
+        saw_channel,
+        "muted category child row should render channel name"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Problem

Concord has no ability for a user to mute a server or channel. 

## Proposed solution

After @chojs23 requested that we not go the `m` shortcut key route, I re-implemented the solution as an action.  Now, when a server or channel is highlighted, going into the Actions menu now offers muting and unmuting functionality, with the durations matching the official Discord client.  It will also set an appropriate status.

## Demo


https://github.com/user-attachments/assets/45cf2d8c-f215-46f9-a502-b517c515641f