### PR TITLE
fix: activity emojis

### DIFF
--- a/src/discord/state.rs
+++ b/src/discord/state.rs
@@ -680,11 +680,6 @@ impl DiscordState {
                 }
                 self.refresh_message_author_display_name(*guild_id, member);
             }
-            AppEvent::GuildMemberListCounts { guild_id, online } => {
-                if let Some(guild) = self.guilds.get_mut(guild_id) {
-                    guild.online_count = Some(*online);
-                }
-            }
             AppEvent::GuildMemberUpsert { guild_id, member } => {
                 let entry = self.members.entry(*guild_id).or_default();
                 let previous_status = entry.get(&member.user_id).map(|m| m.status);

--- a/src/discord/state.rs
+++ b/src/discord/state.rs
@@ -416,6 +416,7 @@ impl DiscordState {
                         id: *guild_id,
                         name: name.clone(),
                         member_count: *member_count,
+                        online_count: None,
                         owner_id: *owner_id,
                         online_count: None,
                     },
@@ -665,6 +666,11 @@ impl DiscordState {
                 message_id,
                 ..
             } => self.delete_message(*channel_id, *message_id),
+            AppEvent::GuildMemberListCounts { guild_id, online } => {
+                if let Some(guild) = self.guilds.get_mut(guild_id) {
+                    guild.online_count = Some(*online);
+                }
+            }
             AppEvent::GuildMemberAdd { guild_id, member } => {
                 let entry = self.members.entry(*guild_id).or_default();
                 let was_known = entry.contains_key(&member.user_id);

--- a/src/discord/state.rs
+++ b/src/discord/state.rs
@@ -418,7 +418,6 @@ impl DiscordState {
                         member_count: *member_count,
                         online_count: None,
                         owner_id: *owner_id,
-                        online_count: None,
                     },
                 );
 

--- a/src/tui/media.rs
+++ b/src/tui/media.rs
@@ -357,10 +357,7 @@ impl EmojiImageCache {
 
     /// Returns decoded protocols for visible targets and refreshes their
     /// LRU timestamps so they survive the next pruning pass.
-    pub(super) fn render_state(
-        &mut self,
-        targets: &[EmojiImageTarget],
-    ) -> Vec<EmojiImage<'_>> {
+    pub(super) fn render_state(&mut self, targets: &[EmojiImageTarget]) -> Vec<EmojiImage<'_>> {
         let touch_tick = self.next_tick();
         for target in targets {
             if let Some(entry) = self.entries.get_mut(&target.url) {
@@ -460,31 +457,36 @@ impl EmojiImageCache {
         match image::load_from_memory(bytes) {
             Ok(img) => {
                 let (font_width, font_height) = picker.font_size();
-                let canvas_w =
-                    u32::from(EMOJI_REACTION_THUMB_WIDTH) * u32::from(font_width);
+                let canvas_w = u32::from(EMOJI_REACTION_THUMB_WIDTH) * u32::from(font_width);
                 let canvas_h = u32::from(font_height);
 
                 let max_h = (canvas_h * 3 / 4).max(1);
                 let scaled = img.resize(canvas_w, max_h, FilterType::Lanczos3);
                 let scaled_rgba = scaled.to_rgba8();
 
-                let x_off =
-                    ((canvas_w.saturating_sub(scaled_rgba.width())) / 2) as i64;
-                let y_off =
-                    ((canvas_h.saturating_sub(scaled_rgba.height())) / 2) as i64;
+                let x_off = ((canvas_w.saturating_sub(scaled_rgba.width())) / 2) as i64;
+                let y_off = ((canvas_h.saturating_sub(scaled_rgba.height())) / 2) as i64;
 
                 let mut canvas = image::RgbaImage::new(canvas_w, canvas_h);
                 image::imageops::overlay(&mut canvas, &scaled_rgba, x_off, y_off);
 
                 match picker.new_protocol(
                     DynamicImage::ImageRgba8(canvas),
-                    Rect::new(0, 0, EMOJI_REACTION_THUMB_WIDTH, EMOJI_REACTION_THUMB_HEIGHT),
+                    Rect::new(
+                        0,
+                        0,
+                        EMOJI_REACTION_THUMB_WIDTH,
+                        EMOJI_REACTION_THUMB_HEIGHT,
+                    ),
                     Resize::Fit(None),
                 ) {
                     Ok(protocol) => {
                         self.entries.insert(
                             url.to_owned(),
-                            EmojiImageEntry::Ready { protocol, last_used },
+                            EmojiImageEntry::Ready {
+                                protocol,
+                                last_used,
+                            },
                         );
                     }
                     Err(_) => {

--- a/src/tui/media.rs
+++ b/src/tui/media.rs
@@ -23,7 +23,7 @@ use crate::{
     logging,
 };
 
-use super::ui::{AvatarImage, EmojiReactionImage};
+use super::ui::{AvatarImage, EmojiImage};
 
 const AVATAR_PREVIEW_WIDTH: u16 = 2;
 const AVATAR_PREVIEW_HEIGHT: u16 = 2;
@@ -360,7 +360,7 @@ impl EmojiImageCache {
     pub(super) fn render_state(
         &mut self,
         targets: &[EmojiImageTarget],
-    ) -> Vec<EmojiReactionImage<'_>> {
+    ) -> Vec<EmojiImage<'_>> {
         let touch_tick = self.next_tick();
         for target in targets {
             if let Some(entry) = self.entries.get_mut(&target.url) {
@@ -373,7 +373,7 @@ impl EmojiImageCache {
                 let EmojiImageEntry::Ready { protocol, .. } = self.entries.get(&target.url)? else {
                     return None;
                 };
-                Some(EmojiReactionImage {
+                Some(EmojiImage {
                     url: target.url.clone(),
                     protocol,
                 })

--- a/src/tui/media.rs
+++ b/src/tui/media.rs
@@ -458,30 +458,39 @@ impl EmojiImageCache {
         };
 
         match image::load_from_memory(bytes) {
-            Ok(image) => {
-                let render_info = ImagePreviewRenderInfo {
-                    viewer: false,
-                    message_index: 0,
-                    preview_x_offset_columns: 0,
-                    preview_y_offset_rows: 0,
-                    preview_width: EMOJI_REACTION_THUMB_WIDTH,
-                    preview_height: EMOJI_REACTION_THUMB_HEIGHT,
-                    preview_overflow_count: 0,
-                    visible_preview_height: EMOJI_REACTION_THUMB_HEIGHT,
-                    top_clip_rows: 0,
-                    accent_color: None,
-                };
-                if let Some(protocol) = clipped_preview_protocol(picker, &image, render_info) {
-                    self.entries.insert(
-                        url.to_owned(),
-                        EmojiImageEntry::Ready {
-                            protocol,
-                            last_used,
-                        },
-                    );
-                } else {
-                    self.entries
-                        .insert(url.to_owned(), EmojiImageEntry::Failed { last_used });
+            Ok(img) => {
+                let (font_width, font_height) = picker.font_size();
+                let canvas_w =
+                    u32::from(EMOJI_REACTION_THUMB_WIDTH) * u32::from(font_width);
+                let canvas_h = u32::from(font_height);
+
+                let max_h = (canvas_h * 3 / 4).max(1);
+                let scaled = img.resize(canvas_w, max_h, FilterType::Lanczos3);
+                let scaled_rgba = scaled.to_rgba8();
+
+                let x_off =
+                    ((canvas_w.saturating_sub(scaled_rgba.width())) / 2) as i64;
+                let y_off =
+                    ((canvas_h.saturating_sub(scaled_rgba.height())) / 2) as i64;
+
+                let mut canvas = image::RgbaImage::new(canvas_w, canvas_h);
+                image::imageops::overlay(&mut canvas, &scaled_rgba, x_off, y_off);
+
+                match picker.new_protocol(
+                    DynamicImage::ImageRgba8(canvas),
+                    Rect::new(0, 0, EMOJI_REACTION_THUMB_WIDTH, EMOJI_REACTION_THUMB_HEIGHT),
+                    Resize::Fit(None),
+                ) {
+                    Ok(protocol) => {
+                        self.entries.insert(
+                            url.to_owned(),
+                            EmojiImageEntry::Ready { protocol, last_used },
+                        );
+                    }
+                    Err(_) => {
+                        self.entries
+                            .insert(url.to_owned(), EmojiImageEntry::Failed { last_used });
+                    }
                 }
             }
             Err(_) => {

--- a/src/tui/media/targets.rs
+++ b/src/tui/media/targets.rs
@@ -597,6 +597,21 @@ pub(in crate::tui) fn visible_emoji_image_targets(state: &DashboardState) -> Vec
         }
     }
 
+    // Activity emojis for visible member list members.
+    for member in state.flattened_members() {
+        for activity in state.user_activities(member.user_id()) {
+            if let Some(emoji) = &activity.emoji {
+                if let Some(id) = emoji.id {
+                    let ext = if emoji.animated { "gif" } else { "png" };
+                    let url = format!("https://cdn.discordapp.com/emojis/{}.{}", id.get(), ext);
+                    if seen.insert(url.clone()) {
+                        targets.push(EmojiImageTarget { url });
+                    }
+                }
+            }
+        }
+    }
+
     targets
 }
 

--- a/src/tui/state/tests/mod.rs
+++ b/src/tui/state/tests/mod.rs
@@ -1,6 +1,7 @@
 mod fixtures;
 
 use fixtures::*;
+use ratatui::text::Line;
 
 use ratatui::text::Line;
 

--- a/src/tui/state/tests/mod.rs
+++ b/src/tui/state/tests/mod.rs
@@ -3,8 +3,6 @@ mod fixtures;
 use fixtures::*;
 use ratatui::text::Line;
 
-use ratatui::text::Line;
-
 use crate::{
     config::{DisplayOptions, ImagePreviewQualityPreset},
     discord::ids::{

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -89,7 +89,7 @@ use self::types::{
 };
 pub(crate) use self::types::{ActionMenuTarget, MESSAGE_ROW_GAP, MouseTarget};
 pub use self::types::{
-    AvatarImage, EmojiReactionImage, ImagePreview, ImagePreviewLayout, ImagePreviewState,
+    AvatarImage, EmojiImage, ImagePreview, ImagePreviewLayout, ImagePreviewState,
 };
 #[cfg(test)]
 use self::{
@@ -166,7 +166,7 @@ pub fn render(
     state: &DashboardState,
     image_previews: Vec<ImagePreview<'_>>,
     avatar_images: Vec<AvatarImage>,
-    emoji_images: Vec<EmojiReactionImage<'_>>,
+    emoji_images: Vec<EmojiImage<'_>>,
     profile_avatar: Option<AvatarImage>,
 ) {
     let areas = dashboard_areas(frame.area(), state);

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -32,8 +32,8 @@ use super::{
     },
 };
 use crate::discord::{
-    ActivityInfo, ActivityKind, ChannelState, ChannelUnreadState, ChannelVisibilityStats,
-    FriendStatus, MessageState, PresenceStatus, ReactionInfo, ReactionUsersInfo, UserProfileInfo,
+    ActivityInfo, ChannelState, ChannelUnreadState, ChannelVisibilityStats, FriendStatus,
+    MessageState, PresenceStatus, ReactionInfo, ReactionUsersInfo, UserProfileInfo,
 };
 
 /// `#FFA500` — Discord's "you were mentioned" orange.

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -209,9 +209,9 @@ pub fn render(
     }
     render_options_popup(frame, areas.messages, state);
     render_poll_vote_picker(frame, areas.messages, state);
+    render_user_profile_popup(frame, areas.messages, state, profile_avatar, &emoji_images);
     render_emoji_reaction_picker(frame, areas.messages, state, emoji_images);
     render_reaction_users_popup(frame, areas.messages, state);
-    render_user_profile_popup(frame, areas.messages, state, profile_avatar);
     render_image_viewer(frame, areas.messages, state, viewer_image_preview);
     render_image_viewer_action_menu(frame, areas.messages, state);
     render_debug_log_popup(frame, areas.messages, state);

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -196,7 +196,7 @@ pub fn render(
         &emoji_images,
     );
     if state.is_pane_visible(FocusPane::Members) {
-        render_members(frame, areas.members, state);
+        render_members(frame, areas.members, state, &emoji_images);
     }
     render_footer(frame, areas.footer, state);
     render_leader_popup(frame, areas.messages, state);

--- a/src/tui/ui/forum.rs
+++ b/src/tui/ui/forum.rs
@@ -353,7 +353,7 @@ pub(super) fn render_forum_post_reaction_emojis(
     list: Rect,
     posts: &[ChannelThreadItem],
     width: usize,
-    emoji_images: &[EmojiReactionImage<'_>],
+    emoji_images: &[EmojiImage<'_>],
 ) {
     if emoji_images.is_empty() || list.height == 0 || list.width == 0 {
         return;

--- a/src/tui/ui/message_list.rs
+++ b/src/tui/ui/message_list.rs
@@ -32,7 +32,7 @@ pub(super) fn render_messages(
     state: &DashboardState,
     image_previews: Vec<ImagePreview<'_>>,
     avatar_images: Vec<AvatarImage>,
-    emoji_images: &[EmojiReactionImage<'_>],
+    emoji_images: &[EmojiImage<'_>],
 ) {
     let block = panel_block_owned(
         state.message_pane_title(),
@@ -325,7 +325,7 @@ fn render_inline_reaction_emojis(
     state: &DashboardState,
     content_width: usize,
     selected: Option<usize>,
-    emoji_images: &[EmojiReactionImage<'_>],
+    emoji_images: &[EmojiImage<'_>],
 ) {
     if emoji_images.is_empty() || list.height == 0 || list.width <= MESSAGE_AVATAR_OFFSET {
         return;
@@ -428,7 +428,7 @@ fn render_inline_message_body_emojis(
     state: &DashboardState,
     content_width: usize,
     selected: Option<usize>,
-    emoji_images: &[EmojiReactionImage<'_>],
+    emoji_images: &[EmojiImage<'_>],
 ) {
     if emoji_images.is_empty() || list.height == 0 || list.width <= MESSAGE_AVATAR_OFFSET {
         return;
@@ -574,7 +574,7 @@ pub(super) fn message_viewport_lines(
     selected: Option<usize>,
     state: &DashboardState,
     layout: MessageViewportLayout,
-    emoji_images: &[EmojiReactionImage<'_>],
+    emoji_images: &[EmojiImage<'_>],
 ) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
     for (index, message) in messages.iter().enumerate() {

--- a/src/tui/ui/message_list.rs
+++ b/src/tui/ui/message_list.rs
@@ -872,7 +872,7 @@ pub(super) fn selected_message_content_x_offset(selected: bool) -> u16 {
     }
 }
 
-fn loaded_custom_emoji_urls(emoji_images: &[EmojiReactionImage<'_>]) -> Vec<String> {
+fn loaded_custom_emoji_urls(emoji_images: &[EmojiImage<'_>]) -> Vec<String> {
     emoji_images.iter().map(|image| image.url.clone()).collect()
 }
 

--- a/src/tui/ui/panes.rs
+++ b/src/tui/ui/panes.rs
@@ -1207,7 +1207,7 @@ fn format_activity_summary(
             let image_url = activity
                 .emoji
                 .as_ref()
-                .and_then(|e| activity_emoji_image_url(e))
+                .and_then(activity_emoji_image_url)
                 .filter(|url| emoji_images.iter().any(|img| img.url == *url));
             let emoji = activity
                 .emoji

--- a/src/tui/ui/panes.rs
+++ b/src/tui/ui/panes.rs
@@ -1027,8 +1027,7 @@ pub(super) fn render_members(
                 PresenceStatus::Offline | PresenceStatus::Unknown
             ) {
                 let activities = state.user_activities(member.user_id());
-                if let Some((text, image_url)) =
-                    primary_activity_summary(activities, emoji_images)
+                if let Some((text, image_url)) = primary_activity_summary(activities, emoji_images)
                 {
                     let text = sanitize_for_display_width(&text);
                     let h_scroll = state.member_horizontal_scroll();
@@ -1059,7 +1058,11 @@ pub(super) fn render_members(
 
     let scroll = state.member_scroll();
     let content_height = state.member_content_height();
-    let lines: Vec<_> = lines.into_iter().skip(scroll).take(content_height).collect();
+    let lines: Vec<_> = lines
+        .into_iter()
+        .skip(scroll)
+        .take(content_height)
+        .collect();
 
     let block = panel_block_line(state.member_panel_title(), focused);
     let content_area = block.inner(area);
@@ -1249,7 +1252,11 @@ fn format_activity_summary(
 fn activity_emoji_image_url(emoji: &ActivityEmoji) -> Option<String> {
     let id = emoji.id?;
     let ext = if emoji.animated { "gif" } else { "png" };
-    Some(format!("https://cdn.discordapp.com/emojis/{}.{}", id.get(), ext))
+    Some(format!(
+        "https://cdn.discordapp.com/emojis/{}.{}",
+        id.get(),
+        ext
+    ))
 }
 
 pub(super) fn render_header(frame: &mut Frame, area: Rect, state: &DashboardState) {

--- a/src/tui/ui/panes.rs
+++ b/src/tui/ui/panes.rs
@@ -1033,15 +1033,13 @@ pub(super) fn render_members(
                     let text = sanitize_for_display_width(&text);
                     let h_scroll = state.member_horizontal_scroll();
                     let (prefix, text) = if image_url.is_some() {
-                        // 3-space indent + 2-cell image placeholder + 1-space
-                        // gap; skip 3 chars (placeholder + separator) from body.
                         let body = text.get(3..).unwrap_or("");
                         let body = truncate_display_width_from(
                             body,
                             h_scroll,
                             max_name_width.saturating_sub(3),
                         );
-                        ("      ", body.to_owned())
+                        ("     ", body.to_owned())
                     } else {
                         let t = truncate_display_width_from(&text, h_scroll, max_name_width);
                         ("   ", t)

--- a/src/tui/ui/panes.rs
+++ b/src/tui/ui/panes.rs
@@ -281,7 +281,7 @@ pub(super) fn render_composer(
     frame: &mut Frame,
     area: Rect,
     state: &DashboardState,
-    emoji_images: &[EmojiReactionImage<'_>],
+    emoji_images: &[EmojiImage<'_>],
 ) {
     let inner_width = composer_inner_width(area.width);
     let ready_urls = ready_custom_emoji_urls(emoji_images);
@@ -316,7 +316,7 @@ pub(super) fn render_composer(
     }
 }
 
-fn ready_custom_emoji_urls(emoji_images: &[EmojiReactionImage<'_>]) -> Vec<String> {
+fn ready_custom_emoji_urls(emoji_images: &[EmojiImage<'_>]) -> Vec<String> {
     emoji_images.iter().map(|image| image.url.clone()).collect()
 }
 
@@ -419,7 +419,7 @@ pub(super) fn render_composer_emoji_picker(
     frame: &mut Frame,
     message_areas: MessageAreas,
     state: &DashboardState,
-    emoji_images: &[EmojiReactionImage<'_>],
+    emoji_images: &[EmojiImage<'_>],
 ) {
     if state.composer_emoji_query().is_none() {
         return;
@@ -633,7 +633,7 @@ fn render_composer_emoji_picker_images(
     frame: &mut Frame,
     area: Rect,
     candidates: &[EmojiPickerEntry],
-    emoji_images: &[EmojiReactionImage<'_>],
+    emoji_images: &[EmojiImage<'_>],
 ) {
     let content = area.inner(ratatui::layout::Margin {
         horizontal: 1,
@@ -793,7 +793,7 @@ fn render_composer_custom_emoji_images(
     frame: &mut Frame,
     area: Rect,
     state: &DashboardState,
-    emoji_images: &[EmojiReactionImage<'_>],
+    emoji_images: &[EmojiImage<'_>],
 ) {
     if !state.is_composing() || area.width < 3 || area.height < 3 {
         return;

--- a/src/tui/ui/panes.rs
+++ b/src/tui/ui/panes.rs
@@ -1088,13 +1088,6 @@ pub(super) fn render_members(
         }
     }
 
-<<<<<<< HEAD
-    frame.render_widget(
-        Paragraph::new(lines)
-            .block(panel_block_line(state.member_panel_title(), focused))
-            .wrap(Wrap { trim: false }),
-        area,
-    );
     render_vertical_scrollbar(
         frame,
         panel_scrollbar_area(area),

--- a/src/tui/ui/panes.rs
+++ b/src/tui/ui/panes.rs
@@ -1175,20 +1175,17 @@ pub(super) fn primary_activity_summary(
 ) -> Option<(String, Option<String>)> {
     let mut sorted: Vec<&ActivityInfo> = activities.iter().collect();
     sorted.sort_by_key(|a| activity_priority(a.kind));
-    let mut custom_fallback = None;
+    let mut image_only_fallback = None;
     for activity in sorted {
-        if activity.kind == ActivityKind::Custom {
-            if custom_fallback.is_none() {
-                custom_fallback = Some(format_activity_summary(activity, emoji_images));
-            }
-            continue;
-        }
         let result = format_activity_summary(activity, emoji_images);
-        if !result.0.trim().is_empty() || result.1.is_some() {
+        if !result.0.trim().is_empty() {
             return Some(result);
         }
+        if result.1.is_some() && image_only_fallback.is_none() {
+            image_only_fallback = Some(result);
+        }
     }
-    custom_fallback.filter(|(text, url)| !text.trim().is_empty() || url.is_some())
+    image_only_fallback
 }
 
 fn activity_priority(kind: ActivityKind) -> u8 {

--- a/src/tui/ui/panes.rs
+++ b/src/tui/ui/panes.rs
@@ -9,7 +9,7 @@ use ratatui_image::Image as RatatuiImage;
 use unicode_width::UnicodeWidthStr;
 
 use crate::discord::{
-    ActivityInfo, ActivityKind, ChannelUnreadState, MessageState, PresenceStatus,
+    ActivityEmoji, ActivityInfo, ActivityKind, ChannelUnreadState, MessageState, PresenceStatus,
 };
 
 use super::super::{
@@ -972,9 +972,17 @@ fn reply_target_excerpt(message: &MessageState, state: &DashboardState) -> Strin
     }
 }
 
-pub(super) fn render_members(frame: &mut Frame, area: Rect, state: &DashboardState) {
+pub(super) fn render_members(
+    frame: &mut Frame,
+    area: Rect,
+    state: &DashboardState,
+    emoji_images: &[EmojiReactionImage<'_>],
+) {
     let groups = state.members_grouped();
     let mut lines: Vec<Line<'static>> = Vec::new();
+    // (absolute_line_index, cdn_url) for activity rows that have a loaded emoji image.
+    let mut emoji_line_urls: Vec<(usize, String)> = Vec::new();
+    let content_width = (area.width as usize).saturating_sub(2);
     let max_name_width = (area.width as usize).saturating_sub(6).max(8);
     let selected_line = state
         .focused_member_selection_line()
@@ -994,7 +1002,7 @@ pub(super) fn render_members(frame: &mut Frame, area: Rect, state: &DashboardSta
             lines.push(Line::from(""));
             line_index += 1;
         }
-        lines.push(member_group_header(group));
+        lines.push(member_group_header(group, content_width));
         line_index += 1;
         for member in &group.entries {
             let member = *member;
@@ -1014,36 +1022,72 @@ pub(super) fn render_members(frame: &mut Frame, area: Rect, state: &DashboardSta
             ]));
             line_index += 1;
 
-            // Three-space indent + max_name_width matches the name row's
-            // envelope so the activity row never overflows or wraps.
             if !matches!(
                 member.status(),
                 PresenceStatus::Offline | PresenceStatus::Unknown
             ) {
                 let activities = state.user_activities(member.user_id());
-                if let Some(summary) = primary_activity_summary(activities) {
-                    let summary = sanitize_for_display_width(&summary);
-                    let summary = truncate_display_width_from(
-                        &summary,
-                        state.member_horizontal_scroll(),
-                        max_name_width,
-                    );
+                if let Some((text, image_url)) =
+                    primary_activity_summary(activities, emoji_images)
+                {
+                    let text = sanitize_for_display_width(&text);
+                    let h_scroll = state.member_horizontal_scroll();
+                    let (prefix, text) = if image_url.is_some() {
+                        // 3-space indent + 2-cell image placeholder + 1-space
+                        // gap; skip 3 chars (placeholder + separator) from body.
+                        let body = text.get(3..).unwrap_or("");
+                        let body = truncate_display_width_from(
+                            body,
+                            h_scroll,
+                            max_name_width.saturating_sub(3),
+                        );
+                        ("      ", body.to_owned())
+                    } else {
+                        let t = truncate_display_width_from(&text, h_scroll, max_name_width);
+                        ("   ", t)
+                    };
                     lines.push(Line::from(vec![
-                        Span::raw("   "),
-                        Span::styled(summary, Style::default().fg(DIM)),
+                        Span::raw(prefix),
+                        Span::styled(text, Style::default().fg(DIM)),
                     ]));
+                    if let Some(url) = image_url {
+                        emoji_line_urls.push((line_index, url));
+                    }
                     line_index += 1;
                 }
             }
         }
     }
 
-    let lines: Vec<_> = lines
-        .into_iter()
-        .skip(state.member_scroll())
-        .take(state.member_content_height())
-        .collect();
+    let scroll = state.member_scroll();
+    let content_height = state.member_content_height();
+    let lines: Vec<_> = lines.into_iter().skip(scroll).take(content_height).collect();
 
+    let block = panel_block_line(state.member_panel_title(), focused);
+    let content_area = block.inner(area);
+    frame.render_widget(Paragraph::new(lines).block(block), area);
+
+    // Overlay custom emoji images on top of their placeholder cells.
+    if state.show_custom_emoji() {
+        for (line_idx, url) in &emoji_line_urls {
+            let Some(image) = emoji_images.iter().find(|img| img.url == *url) else {
+                continue;
+            };
+            let Some(visible_offset) = line_idx.checked_sub(scroll) else {
+                continue;
+            };
+            if visible_offset >= content_height {
+                continue;
+            }
+            let y = content_area.y.saturating_add(visible_offset as u16);
+            frame.render_widget(
+                ratatui_image::Image::new(image.protocol),
+                Rect::new(content_area.x.saturating_add(3), y, 2, 1),
+            );
+        }
+    }
+
+<<<<<<< HEAD
     frame.render_widget(
         Paragraph::new(lines)
             .block(panel_block_line(state.member_panel_title(), focused))
@@ -1053,24 +1097,24 @@ pub(super) fn render_members(frame: &mut Frame, area: Rect, state: &DashboardSta
     render_vertical_scrollbar(
         frame,
         panel_scrollbar_area(area),
-        state.member_scroll(),
-        state.member_content_height(),
+        scroll,
+        content_height,
         state.member_line_count(),
     );
 }
 
-fn member_group_header(group: &MemberGroup<'_>) -> Line<'static> {
+fn member_group_header(group: &MemberGroup<'_>, content_width: usize) -> Line<'static> {
+    let count_suffix = format!(" — {}", group.entries.len());
+    let label_max = content_width.saturating_sub(count_suffix.width());
+    let label = truncate_display_width(&group.label, label_max);
     Line::from(vec![
         Span::styled(
-            group.label.clone(),
+            label,
             Style::default()
                 .fg(discord_color(group.color, DIM))
                 .add_modifier(Modifier::BOLD),
         ),
-        Span::styled(
-            format!(" — {}", group.entries.len()),
-            Style::default().fg(DIM),
-        ),
+        Span::styled(count_suffix, Style::default().fg(DIM)),
     ])
 }
 
@@ -1129,11 +1173,16 @@ pub(super) fn member_display_label(
 }
 
 /// Priority: Custom > Streaming > Listening > Playing > Watching > Competing > Unknown.
-pub(super) fn primary_activity_summary(activities: &[ActivityInfo]) -> Option<String> {
-    activities
+/// Returns `(display_text, Option<cdn_url>)`. When the cdn_url is `Some`, the
+/// text contains a 2-space placeholder at the start for the image overlay.
+pub(super) fn primary_activity_summary(
+    activities: &[ActivityInfo],
+    emoji_images: &[EmojiReactionImage<'_>],
+) -> Option<(String, Option<String>)> {
+    let activity = activities
         .iter()
-        .min_by_key(|activity| activity_priority(activity.kind))
-        .map(format_activity_summary)
+        .min_by_key(|a| activity_priority(a.kind))?;
+    Some(format_activity_summary(activity, emoji_images))
 }
 
 fn activity_priority(kind: ActivityKind) -> u8 {
@@ -1148,14 +1197,24 @@ fn activity_priority(kind: ActivityKind) -> u8 {
     }
 }
 
-fn format_activity_summary(activity: &ActivityInfo) -> String {
+fn format_activity_summary(
+    activity: &ActivityInfo,
+    emoji_images: &[EmojiReactionImage<'_>],
+) -> (String, Option<String>) {
     match activity.kind {
         ActivityKind::Custom => {
+            let image_url = activity
+                .emoji
+                .as_ref()
+                .and_then(|e| activity_emoji_image_url(e))
+                .filter(|url| emoji_images.iter().any(|img| img.url == *url));
             let emoji = activity
                 .emoji
                 .as_ref()
                 .map(|emoji| {
-                    if emoji.id.is_some() {
+                    if image_url.is_some() {
+                        "  ".to_owned()
+                    } else if emoji.id.is_some() {
                         format!(":{}:", emoji.name)
                     } else {
                         emoji.name.clone()
@@ -1163,26 +1222,36 @@ fn format_activity_summary(activity: &ActivityInfo) -> String {
                 })
                 .unwrap_or_default();
             let body = activity.state.clone().unwrap_or_default();
-            match (emoji.is_empty(), body.is_empty()) {
+            let text = match (emoji.is_empty(), body.is_empty()) {
                 (true, true) => activity.name.clone(),
                 (false, true) => emoji,
                 (true, false) => body,
                 (false, false) => format!("{emoji} {body}"),
-            }
+            };
+            (text, image_url)
         }
-        ActivityKind::Playing => format!("Playing {}", activity.name),
-        ActivityKind::Streaming => format!("Streaming {}", activity.name),
-        ActivityKind::Listening => match (activity.details.as_deref(), activity.state.as_deref()) {
-            (Some(track), Some(artist)) => {
-                format!("Listening to {} — {} by {}", activity.name, track, artist)
-            }
-            (Some(track), None) => format!("Listening to {} — {}", activity.name, track),
-            _ => format!("Listening to {}", activity.name),
-        },
-        ActivityKind::Watching => format!("Watching {}", activity.name),
-        ActivityKind::Competing => format!("Competing in {}", activity.name),
-        ActivityKind::Unknown => activity.name.clone(),
+        ActivityKind::Playing => (format!("Playing {}", activity.name), None),
+        ActivityKind::Streaming => (format!("Streaming {}", activity.name), None),
+        ActivityKind::Listening => {
+            let text = match (activity.details.as_deref(), activity.state.as_deref()) {
+                (Some(track), Some(artist)) => {
+                    format!("Listening to {} — {} by {}", activity.name, track, artist)
+                }
+                (Some(track), None) => format!("Listening to {} — {}", activity.name, track),
+                _ => format!("Listening to {}", activity.name),
+            };
+            (text, None)
+        }
+        ActivityKind::Watching => (format!("Watching {}", activity.name), None),
+        ActivityKind::Competing => (format!("Competing in {}", activity.name), None),
+        ActivityKind::Unknown => (activity.name.clone(), None),
     }
+}
+
+fn activity_emoji_image_url(emoji: &ActivityEmoji) -> Option<String> {
+    let id = emoji.id?;
+    let ext = if emoji.animated { "gif" } else { "png" };
+    Some(format!("https://cdn.discordapp.com/emojis/{}.{}", id.get(), ext))
 }
 
 pub(super) fn render_header(frame: &mut Frame, area: Rect, state: &DashboardState) {

--- a/src/tui/ui/panes.rs
+++ b/src/tui/ui/panes.rs
@@ -30,7 +30,7 @@ use super::{
     layout::{composer_inner_width, panel_scrollbar_area},
     panel_block, panel_block_line, panel_content_height, render_vertical_scrollbar,
     selection_marker, styled_list_item,
-    types::{ACCENT, DIM, EmojiReactionImage, MessageAreas},
+    types::{ACCENT, DIM, EmojiImage, MessageAreas},
 };
 
 pub(super) fn render_guilds(frame: &mut Frame, area: Rect, state: &DashboardState) {
@@ -976,7 +976,7 @@ pub(super) fn render_members(
     frame: &mut Frame,
     area: Rect,
     state: &DashboardState,
-    emoji_images: &[EmojiReactionImage<'_>],
+    emoji_images: &[EmojiImage<'_>],
 ) {
     let groups = state.members_grouped();
     let mut lines: Vec<Line<'static>> = Vec::new();
@@ -1175,7 +1175,7 @@ pub(super) fn member_display_label(
 /// text contains a 2-space placeholder at the start for the image overlay.
 pub(super) fn primary_activity_summary(
     activities: &[ActivityInfo],
-    emoji_images: &[EmojiReactionImage<'_>],
+    emoji_images: &[EmojiImage<'_>],
 ) -> Option<(String, Option<String>)> {
     let activity = activities
         .iter()
@@ -1197,7 +1197,7 @@ fn activity_priority(kind: ActivityKind) -> u8 {
 
 fn format_activity_summary(
     activity: &ActivityInfo,
-    emoji_images: &[EmojiReactionImage<'_>],
+    emoji_images: &[EmojiImage<'_>],
 ) -> (String, Option<String>) {
     match activity.kind {
         ActivityKind::Custom => {

--- a/src/tui/ui/panes.rs
+++ b/src/tui/ui/panes.rs
@@ -1173,20 +1173,32 @@ pub(super) fn primary_activity_summary(
     activities: &[ActivityInfo],
     emoji_images: &[EmojiImage<'_>],
 ) -> Option<(String, Option<String>)> {
-    let activity = activities
-        .iter()
-        .min_by_key(|a| activity_priority(a.kind))?;
-    Some(format_activity_summary(activity, emoji_images))
+    let mut sorted: Vec<&ActivityInfo> = activities.iter().collect();
+    sorted.sort_by_key(|a| activity_priority(a.kind));
+    let mut custom_fallback = None;
+    for activity in sorted {
+        if activity.kind == ActivityKind::Custom {
+            if custom_fallback.is_none() {
+                custom_fallback = Some(format_activity_summary(activity, emoji_images));
+            }
+            continue;
+        }
+        let result = format_activity_summary(activity, emoji_images);
+        if !result.0.trim().is_empty() || result.1.is_some() {
+            return Some(result);
+        }
+    }
+    custom_fallback.filter(|(text, url)| !text.trim().is_empty() || url.is_some())
 }
 
 fn activity_priority(kind: ActivityKind) -> u8 {
     match kind {
-        ActivityKind::Custom => 0,
-        ActivityKind::Streaming => 1,
+        ActivityKind::Streaming => 0,
+        ActivityKind::Playing => 1,
         ActivityKind::Listening => 2,
-        ActivityKind::Playing => 3,
-        ActivityKind::Watching => 4,
-        ActivityKind::Competing => 5,
+        ActivityKind::Watching => 3,
+        ActivityKind::Competing => 4,
+        ActivityKind::Custom => 5,
         ActivityKind::Unknown => 6,
     }
 }

--- a/src/tui/ui/panes.rs
+++ b/src/tui/ui/panes.rs
@@ -1029,24 +1029,44 @@ pub(super) fn render_members(
                 let activities = state.user_activities(member.user_id());
                 if let Some((text, image_url)) = primary_activity_summary(activities, emoji_images)
                 {
-                    let text = sanitize_for_display_width(&text);
                     let h_scroll = state.member_horizontal_scroll();
-                    let (prefix, text) = if image_url.is_some() {
+                    let line = if image_url.is_some() {
                         let body = text.get(3..).unwrap_or("");
                         let body = truncate_display_width_from(
                             body,
                             h_scroll,
                             max_name_width.saturating_sub(3),
                         );
-                        ("     ", body.to_owned())
+                        Line::from(vec![
+                            Span::raw("     "),
+                            Span::styled(body, Style::default().fg(DIM)),
+                        ])
+                    } else if let Some(icon) = text
+                        .chars()
+                        .next()
+                        .filter(|c| matches!(c, '▶' | '◉' | '♪' | '▷'))
+                    {
+                        let icon_len = icon.len_utf8();
+                        let body = text.get(icon_len + 1..).unwrap_or("");
+                        let body = truncate_display_width_from(
+                            body,
+                            h_scroll,
+                            max_name_width.saturating_sub(2),
+                        );
+                        Line::from(vec![
+                            Span::raw("   "),
+                            Span::styled(icon.to_string(), Style::default().fg(Color::Green)),
+                            Span::raw(" "),
+                            Span::styled(body, Style::default().fg(DIM)),
+                        ])
                     } else {
                         let t = truncate_display_width_from(&text, h_scroll, max_name_width);
-                        ("   ", t)
+                        Line::from(vec![
+                            Span::raw("   "),
+                            Span::styled(t, Style::default().fg(DIM)),
+                        ])
                     };
-                    lines.push(Line::from(vec![
-                        Span::raw(prefix),
-                        Span::styled(text, Style::default().fg(DIM)),
-                    ]));
+                    lines.push(line);
                     if let Some(url) = image_url {
                         emoji_line_urls.push((line_index, url));
                     }
@@ -1233,21 +1253,35 @@ fn format_activity_summary(
             };
             (text, image_url)
         }
-        ActivityKind::Playing => (format!("Playing {}", activity.name), None),
-        ActivityKind::Streaming => (format!("Streaming {}", activity.name), None),
+        ActivityKind::Playing => (
+            format!("▶ {}", sanitize_for_display_width(&activity.name)),
+            None,
+        ),
+        ActivityKind::Streaming => (
+            format!("◉ {}", sanitize_for_display_width(&activity.name)),
+            None,
+        ),
         ActivityKind::Listening => {
+            let name = sanitize_for_display_width(&activity.name);
             let text = match (activity.details.as_deref(), activity.state.as_deref()) {
-                (Some(track), Some(artist)) => {
-                    format!("Listening to {} — {} by {}", activity.name, track, artist)
-                }
-                (Some(track), None) => format!("Listening to {} — {}", activity.name, track),
-                _ => format!("Listening to {}", activity.name),
+                (Some(track), Some(artist)) => format!("♪ {} — {} by {}", name, track, artist),
+                (Some(track), None) => format!("♪ {} — {}", name, track),
+                _ => format!("♪ {}", name),
             };
             (text, None)
         }
-        ActivityKind::Watching => (format!("Watching {}", activity.name), None),
-        ActivityKind::Competing => (format!("Competing in {}", activity.name), None),
-        ActivityKind::Unknown => (activity.name.clone(), None),
+        ActivityKind::Watching => (
+            format!("▷ {}", sanitize_for_display_width(&activity.name)),
+            None,
+        ),
+        ActivityKind::Competing => (
+            format!(
+                "Competing in {}",
+                sanitize_for_display_width(&activity.name)
+            ),
+            None,
+        ),
+        ActivityKind::Unknown => (sanitize_for_display_width(&activity.name), None),
     }
 }
 

--- a/src/tui/ui/popups.rs
+++ b/src/tui/ui/popups.rs
@@ -1,5 +1,6 @@
 use super::message_list::render_image_preview;
 use super::*;
+use crate::discord::ActivityEmoji;
 use crate::tui::state::MuteActionDurationItem;
 use ratatui::layout::Position;
 
@@ -997,6 +998,7 @@ pub(super) fn render_user_profile_popup(
     area: Rect,
     state: &DashboardState,
     avatar: Option<AvatarImage>,
+    emoji_images: &[EmojiReactionImage<'_>],
 ) {
     if !state.is_user_profile_popup_open() {
         return;
@@ -1018,7 +1020,7 @@ pub(super) fn render_user_profile_popup(
     );
     let text_area = user_profile_popup_text_area_inside(inner, has_avatar);
 
-    let popup_text = user_profile_popup_text_for_render(state, text_area.width);
+    let popup_text = user_profile_popup_text_for_render(state, text_area.width, emoji_images);
     let total_lines = popup_text.lines.len();
     let viewport = text_area.height as usize;
     let scroll_position = state
@@ -1032,6 +1034,25 @@ pub(super) fn render_user_profile_popup(
         .collect::<Vec<_>>();
     frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), text_area);
     render_vertical_scrollbar(frame, text_area, scroll_position, viewport, total_lines);
+
+    if state.show_custom_emoji() {
+        for (line_idx, url) in &popup_text.emoji_overlays {
+            let Some(image) = emoji_images.iter().find(|img| img.url == *url) else {
+                continue;
+            };
+            let Some(visible_offset) = line_idx.checked_sub(scroll_position) else {
+                continue;
+            };
+            if visible_offset >= viewport {
+                continue;
+            }
+            let y = text_area.y.saturating_add(visible_offset as u16);
+            frame.render_widget(
+                ratatui_image::Image::new(image.protocol),
+                Rect::new(text_area.x, y, 2, 1),
+            );
+        }
+    }
 
     if let Some(avatar) = avatar.filter(|_| has_avatar) {
         let avatar_area = Rect {
@@ -1094,7 +1115,11 @@ pub(super) fn user_profile_popup_text_geometry(area: Rect, has_avatar: bool) -> 
     (text_area.width, text_area.height)
 }
 
-fn user_profile_popup_text_for_render(state: &DashboardState, width: u16) -> UserProfilePopupText {
+fn user_profile_popup_text_for_render(
+    state: &DashboardState,
+    width: u16,
+    emoji_images: &[EmojiReactionImage<'_>],
+) -> UserProfilePopupText {
     if let Some(profile) = state.user_profile_popup_data() {
         user_profile_popup_text(
             profile,
@@ -1102,6 +1127,7 @@ fn user_profile_popup_text_for_render(state: &DashboardState, width: u16) -> Use
             width,
             state.user_profile_popup_status(),
             state.user_profile_popup_activities(),
+            emoji_images,
         )
     } else if let Some(message) = state.user_profile_popup_load_error() {
         UserProfilePopupText {
@@ -1109,6 +1135,7 @@ fn user_profile_popup_text_for_render(state: &DashboardState, width: u16) -> Use
                 truncate_display_width(&format!("Failed to load profile: {message}"), width.into()),
                 Style::default().fg(Color::Red),
             ))],
+            emoji_overlays: Vec::new(),
         }
     } else {
         UserProfilePopupText {
@@ -1116,6 +1143,7 @@ fn user_profile_popup_text_for_render(state: &DashboardState, width: u16) -> Use
                 "Loading profile...",
                 Style::default().fg(DIM),
             ))],
+            emoji_overlays: Vec::new(),
         }
     }
 }
@@ -1124,7 +1152,7 @@ fn user_profile_popup_text_for_render(state: &DashboardState, width: u16) -> Use
 /// `user_profile_popup_text_for_render` so the scroll-clamping pass in
 /// `sync_view_heights` matches the eventual render exactly.
 pub(super) fn user_profile_popup_total_lines(state: &DashboardState, width: u16) -> usize {
-    user_profile_popup_text_for_render(state, width).lines.len()
+    user_profile_popup_text_for_render(state, width, &[]).lines.len()
 }
 
 #[cfg(test)]
@@ -1134,7 +1162,7 @@ pub(super) fn user_profile_popup_lines(
     width: u16,
     status: PresenceStatus,
 ) -> Vec<Line<'static>> {
-    user_profile_popup_text(profile, state, width, status, &[]).lines
+    user_profile_popup_text(profile, state, width, status, &[], &[]).lines
 }
 
 #[cfg(test)]
@@ -1145,7 +1173,7 @@ pub(super) fn user_profile_popup_lines_with_activities(
     status: PresenceStatus,
     activities: &[ActivityInfo],
 ) -> Vec<Line<'static>> {
-    user_profile_popup_text(profile, state, width, status, activities).lines
+    user_profile_popup_text(profile, state, width, status, activities, &[]).lines
 }
 
 pub(super) fn user_profile_popup_text(
@@ -1154,6 +1182,7 @@ pub(super) fn user_profile_popup_text(
     width: u16,
     status: PresenceStatus,
     activities: &[ActivityInfo],
+    emoji_images: &[EmojiReactionImage<'_>],
 ) -> UserProfilePopupText {
     let is_self = state.current_user_id() == Some(profile.user_id);
 
@@ -1187,11 +1216,12 @@ pub(super) fn user_profile_popup_text(
         )));
     }
 
+    let mut emoji_overlays: Vec<(usize, String)> = Vec::new();
     if !activities.is_empty() {
         lines.push(Line::from(Span::raw(String::new())));
         push_section_header(&mut lines, "ACTIVITY");
         for activity in activities {
-            push_activity_lines(&mut lines, activity, inner_width);
+            push_activity_lines(&mut lines, &mut emoji_overlays, activity, inner_width, emoji_images);
         }
     }
 
@@ -1265,7 +1295,7 @@ pub(super) fn user_profile_popup_text(
         Style::default().fg(DIM),
     )));
 
-    UserProfilePopupText { lines }
+    UserProfilePopupText { lines, emoji_overlays }
 }
 
 pub(super) fn user_profile_display_name_style(status: PresenceStatus) -> Style {
@@ -1291,12 +1321,33 @@ fn push_section_header(lines: &mut Vec<Line<'static>>, label: &str) {
     )));
 }
 
-fn push_activity_lines(lines: &mut Vec<Line<'static>>, activity: &ActivityInfo, width: usize) {
-    let primary = activity_primary_line(activity);
-    if !primary.is_empty() {
-        lines.push(Line::from(Span::raw(truncate_display_width(
-            &primary, width,
-        ))));
+fn push_activity_lines(
+    lines: &mut Vec<Line<'static>>,
+    emoji_overlays: &mut Vec<(usize, String)>,
+    activity: &ActivityInfo,
+    width: usize,
+    emoji_images: &[EmojiReactionImage<'_>],
+) {
+    let (primary, image_url) = activity_primary_line(activity, emoji_images);
+    if !primary.is_empty() || image_url.is_some() {
+        let line_index = lines.len();
+        let line = if image_url.is_some() {
+            let body = primary.get(3..).unwrap_or("");
+            let body = truncate_display_width(body, width.saturating_sub(2));
+            Line::from(vec![
+                Span::raw("  "),
+                Span::styled(body, Style::default().fg(DIM)),
+            ])
+        } else {
+            Line::from(Span::styled(
+                truncate_display_width(&primary, width),
+                Style::default().fg(DIM),
+            ))
+        };
+        lines.push(line);
+        if let Some(url) = image_url {
+            emoji_overlays.push((line_index, url));
+        }
     }
     if let Some(secondary) = activity_secondary_line(activity) {
         lines.push(Line::from(Span::styled(
@@ -1312,34 +1363,48 @@ fn push_activity_lines(lines: &mut Vec<Line<'static>>, activity: &ActivityInfo, 
     }
 }
 
-fn activity_primary_line(activity: &ActivityInfo) -> String {
+fn activity_emoji_image_url(emoji: &ActivityEmoji) -> Option<String> {
+    let id = emoji.id?;
+    let ext = if emoji.animated { "gif" } else { "png" };
+    Some(format!("https://cdn.discordapp.com/emojis/{}.{}", id.get(), ext))
+}
+
+fn activity_primary_line(activity: &ActivityInfo, emoji_images: &[EmojiReactionImage<'_>]) -> (String, Option<String>) {
     match activity.kind {
         ActivityKind::Custom => {
+            let image_url = activity
+                .emoji
+                .as_ref()
+                .and_then(|e| activity_emoji_image_url(e))
+                .filter(|url| emoji_images.iter().any(|img| img.url == *url));
             let emoji = activity
                 .emoji
                 .as_ref()
                 .map(|emoji| {
-                    if emoji.id.is_some() {
-                        format!(":{}:", emoji.name)
+                    if image_url.is_some() {
+                        "  ".to_owned()
+                    } else if emoji.id.is_some() {
+                        String::new()
                     } else {
                         emoji.name.clone()
                     }
                 })
                 .unwrap_or_default();
             let body = activity.state.clone().unwrap_or_default();
-            match (emoji.is_empty(), body.is_empty()) {
+            let text = match (emoji.is_empty(), body.is_empty()) {
                 (true, true) => String::new(),
                 (false, true) => emoji,
                 (true, false) => body,
                 (false, false) => format!("{emoji} {body}"),
-            }
+            };
+            (text, image_url)
         }
-        ActivityKind::Playing => format!("Playing {}", activity.name),
-        ActivityKind::Streaming => format!("Streaming {}", activity.name),
-        ActivityKind::Listening => format!("Listening to {}", activity.name),
-        ActivityKind::Watching => format!("Watching {}", activity.name),
-        ActivityKind::Competing => format!("Competing in {}", activity.name),
-        ActivityKind::Unknown => activity.name.clone(),
+        ActivityKind::Playing => (format!("Playing {}", activity.name), None),
+        ActivityKind::Streaming => (format!("Streaming {}", activity.name), None),
+        ActivityKind::Listening => (format!("Listening to {}", activity.name), None),
+        ActivityKind::Watching => (format!("Watching {}", activity.name), None),
+        ActivityKind::Competing => (format!("Competing in {}", activity.name), None),
+        ActivityKind::Unknown => (activity.name.clone(), None),
     }
 }
 

--- a/src/tui/ui/popups.rs
+++ b/src/tui/ui/popups.rs
@@ -1393,7 +1393,7 @@ fn activity_primary_line(
             let image_url = activity
                 .emoji
                 .as_ref()
-                .and_then(|e| activity_emoji_image_url(e))
+                .and_then(activity_emoji_image_url)
                 .filter(|url| emoji_images.iter().any(|img| img.url == *url));
             let emoji = activity
                 .emoji

--- a/src/tui/ui/popups.rs
+++ b/src/tui/ui/popups.rs
@@ -786,7 +786,7 @@ pub(super) fn render_emoji_reaction_picker(
     frame: &mut Frame,
     area: Rect,
     state: &DashboardState,
-    emoji_images: Vec<EmojiReactionImage<'_>>,
+    emoji_images: Vec<EmojiImage<'_>>,
 ) {
     if !state.is_emoji_reaction_picker_open() {
         return;
@@ -998,7 +998,7 @@ pub(super) fn render_user_profile_popup(
     area: Rect,
     state: &DashboardState,
     avatar: Option<AvatarImage>,
-    emoji_images: &[EmojiReactionImage<'_>],
+    emoji_images: &[EmojiImage<'_>],
 ) {
     if !state.is_user_profile_popup_open() {
         return;
@@ -1118,7 +1118,7 @@ pub(super) fn user_profile_popup_text_geometry(area: Rect, has_avatar: bool) -> 
 fn user_profile_popup_text_for_render(
     state: &DashboardState,
     width: u16,
-    emoji_images: &[EmojiReactionImage<'_>],
+    emoji_images: &[EmojiImage<'_>],
 ) -> UserProfilePopupText {
     if let Some(profile) = state.user_profile_popup_data() {
         user_profile_popup_text(
@@ -1182,7 +1182,7 @@ pub(super) fn user_profile_popup_text(
     width: u16,
     status: PresenceStatus,
     activities: &[ActivityInfo],
-    emoji_images: &[EmojiReactionImage<'_>],
+    emoji_images: &[EmojiImage<'_>],
 ) -> UserProfilePopupText {
     let is_self = state.current_user_id() == Some(profile.user_id);
 
@@ -1326,7 +1326,7 @@ fn push_activity_lines(
     emoji_overlays: &mut Vec<(usize, String)>,
     activity: &ActivityInfo,
     width: usize,
-    emoji_images: &[EmojiReactionImage<'_>],
+    emoji_images: &[EmojiImage<'_>],
 ) {
     let (primary, image_url) = activity_primary_line(activity, emoji_images);
     if !primary.is_empty() || image_url.is_some() {
@@ -1369,7 +1369,7 @@ fn activity_emoji_image_url(emoji: &ActivityEmoji) -> Option<String> {
     Some(format!("https://cdn.discordapp.com/emojis/{}.{}", id.get(), ext))
 }
 
-fn activity_primary_line(activity: &ActivityInfo, emoji_images: &[EmojiReactionImage<'_>]) -> (String, Option<String>) {
+fn activity_primary_line(activity: &ActivityInfo, emoji_images: &[EmojiImage<'_>]) -> (String, Option<String>) {
     match activity.kind {
         ActivityKind::Custom => {
             let image_url = activity
@@ -1969,7 +1969,7 @@ fn render_emoji_reaction_images(
     reactions: &[EmojiReactionItem],
     selected: usize,
     visible_items: usize,
-    emoji_images: Vec<EmojiReactionImage<'_>>,
+    emoji_images: Vec<EmojiImage<'_>>,
 ) {
     if area.width <= EMOJI_REACTION_IMAGE_WIDTH || area.height == 0 {
         return;

--- a/src/tui/ui/popups.rs
+++ b/src/tui/ui/popups.rs
@@ -1,6 +1,7 @@
 use super::message_list::render_image_preview;
 use super::*;
-use crate::discord::ActivityEmoji;
+use crate::discord::{ActivityEmoji, ActivityKind};
+use crate::tui::format::sanitize_for_display_width;
 use crate::tui::state::MuteActionDurationItem;
 use ratatui::layout::Position;
 
@@ -1222,7 +1223,14 @@ pub(super) fn user_profile_popup_text(
     if !activities.is_empty() {
         lines.push(Line::from(Span::raw(String::new())));
         push_section_header(&mut lines, "ACTIVITY");
-        for activity in activities {
+        let mut sorted_activities: Vec<&ActivityInfo> = activities.iter().collect();
+        sorted_activities.sort_by_key(|a| activity_priority(a.kind));
+        let mut first = true;
+        for activity in sorted_activities {
+            if !first {
+                lines.push(Line::from(Span::raw(String::new())));
+            }
+            first = false;
             push_activity_lines(
                 &mut lines,
                 &mut emoji_overlays,
@@ -1349,6 +1357,19 @@ fn push_activity_lines(
                 Span::raw("  "),
                 Span::styled(body, Style::default().fg(DIM)),
             ])
+        } else if let Some(icon) = primary
+            .chars()
+            .next()
+            .filter(|c| matches!(c, '▶' | '◉' | '♪' | '▷'))
+        {
+            let icon_len = icon.len_utf8();
+            let body = primary.get(icon_len + 1..).unwrap_or("");
+            let body = truncate_display_width(body, width.saturating_sub(2));
+            Line::from(vec![
+                Span::styled(icon.to_string(), Style::default().fg(Color::Green)),
+                Span::raw(" "),
+                Span::styled(body, Style::default().fg(DIM)),
+            ])
         } else {
             Line::from(Span::styled(
                 truncate_display_width(&primary, width),
@@ -1384,6 +1405,18 @@ fn activity_emoji_image_url(emoji: &ActivityEmoji) -> Option<String> {
     ))
 }
 
+fn activity_priority(kind: ActivityKind) -> u8 {
+    match kind {
+        ActivityKind::Custom => 0,
+        ActivityKind::Streaming => 1,
+        ActivityKind::Playing => 2,
+        ActivityKind::Listening => 3,
+        ActivityKind::Watching => 4,
+        ActivityKind::Competing => 5,
+        ActivityKind::Unknown => 6,
+    }
+}
+
 fn activity_primary_line(
     activity: &ActivityInfo,
     emoji_images: &[EmojiImage<'_>],
@@ -1417,12 +1450,30 @@ fn activity_primary_line(
             };
             (text, image_url)
         }
-        ActivityKind::Playing => (format!("Playing {}", activity.name), None),
-        ActivityKind::Streaming => (format!("Streaming {}", activity.name), None),
-        ActivityKind::Listening => (format!("Listening to {}", activity.name), None),
-        ActivityKind::Watching => (format!("Watching {}", activity.name), None),
-        ActivityKind::Competing => (format!("Competing in {}", activity.name), None),
-        ActivityKind::Unknown => (activity.name.clone(), None),
+        ActivityKind::Playing => (
+            format!("▶ {}", sanitize_for_display_width(&activity.name)),
+            None,
+        ),
+        ActivityKind::Streaming => (
+            format!("◉ {}", sanitize_for_display_width(&activity.name)),
+            None,
+        ),
+        ActivityKind::Listening => (
+            format!("♪ {}", sanitize_for_display_width(&activity.name)),
+            None,
+        ),
+        ActivityKind::Watching => (
+            format!("▷ {}", sanitize_for_display_width(&activity.name)),
+            None,
+        ),
+        ActivityKind::Competing => (
+            format!(
+                "Competing in {}",
+                sanitize_for_display_width(&activity.name)
+            ),
+            None,
+        ),
+        ActivityKind::Unknown => (sanitize_for_display_width(&activity.name), None),
     }
 }
 

--- a/src/tui/ui/popups.rs
+++ b/src/tui/ui/popups.rs
@@ -1152,7 +1152,9 @@ fn user_profile_popup_text_for_render(
 /// `user_profile_popup_text_for_render` so the scroll-clamping pass in
 /// `sync_view_heights` matches the eventual render exactly.
 pub(super) fn user_profile_popup_total_lines(state: &DashboardState, width: u16) -> usize {
-    user_profile_popup_text_for_render(state, width, &[]).lines.len()
+    user_profile_popup_text_for_render(state, width, &[])
+        .lines
+        .len()
 }
 
 #[cfg(test)]
@@ -1221,7 +1223,13 @@ pub(super) fn user_profile_popup_text(
         lines.push(Line::from(Span::raw(String::new())));
         push_section_header(&mut lines, "ACTIVITY");
         for activity in activities {
-            push_activity_lines(&mut lines, &mut emoji_overlays, activity, inner_width, emoji_images);
+            push_activity_lines(
+                &mut lines,
+                &mut emoji_overlays,
+                activity,
+                inner_width,
+                emoji_images,
+            );
         }
     }
 
@@ -1295,7 +1303,10 @@ pub(super) fn user_profile_popup_text(
         Style::default().fg(DIM),
     )));
 
-    UserProfilePopupText { lines, emoji_overlays }
+    UserProfilePopupText {
+        lines,
+        emoji_overlays,
+    }
 }
 
 pub(super) fn user_profile_display_name_style(status: PresenceStatus) -> Style {
@@ -1366,10 +1377,17 @@ fn push_activity_lines(
 fn activity_emoji_image_url(emoji: &ActivityEmoji) -> Option<String> {
     let id = emoji.id?;
     let ext = if emoji.animated { "gif" } else { "png" };
-    Some(format!("https://cdn.discordapp.com/emojis/{}.{}", id.get(), ext))
+    Some(format!(
+        "https://cdn.discordapp.com/emojis/{}.{}",
+        id.get(),
+        ext
+    ))
 }
 
-fn activity_primary_line(activity: &ActivityInfo, emoji_images: &[EmojiImage<'_>]) -> (String, Option<String>) {
+fn activity_primary_line(
+    activity: &ActivityInfo,
+    emoji_images: &[EmojiImage<'_>],
+) -> (String, Option<String>) {
     match activity.kind {
         ActivityKind::Custom => {
             let image_url = activity

--- a/src/tui/ui/tests.rs
+++ b/src/tui/ui/tests.rs
@@ -1661,7 +1661,7 @@ fn primary_activity_summary_picks_custom_status_first() {
     ];
 
     assert_eq!(
-        primary_activity_summary(&activities),
+        primary_activity_summary(&activities, &[]).map(|(t, _)| t),
         Some("🦀 Coding hard".to_owned())
     );
 }
@@ -1678,7 +1678,7 @@ fn primary_activity_summary_listening_includes_track_and_artist() {
         emoji: None,
     }];
     assert_eq!(
-        primary_activity_summary(&activities),
+        primary_activity_summary(&activities, &[]).map(|(t, _)| t),
         Some("Listening to Spotify — Bohemian Rhapsody by Queen".to_owned())
     );
 }

--- a/src/tui/ui/tests.rs
+++ b/src/tui/ui/tests.rs
@@ -1627,10 +1627,10 @@ fn user_profile_popup_renders_activity_section() {
 
     assert!(texts.iter().any(|line| line == "ACTIVITY"));
     assert!(texts.iter().any(|line| line == "🦀 Coding hard"));
-    assert!(texts.iter().any(|line| line == "Listening to Spotify"));
+    assert!(texts.iter().any(|line| line == "♪ Spotify"));
     assert!(texts.iter().any(|line| line == "Bohemian Rhapsody"));
     assert!(texts.iter().any(|line| line == "by Queen"));
-    assert!(texts.iter().any(|line| line == "Playing Concord"));
+    assert!(texts.iter().any(|line| line == "▶ Concord"));
 }
 
 #[test]
@@ -1662,7 +1662,7 @@ fn primary_activity_summary_prefers_game_over_custom_status() {
 
     assert_eq!(
         primary_activity_summary(&activities, &[]).map(|(t, _)| t),
-        Some("Playing Concord".to_owned())
+        Some("▶ Concord".to_owned())
     );
 }
 
@@ -1679,7 +1679,7 @@ fn primary_activity_summary_listening_includes_track_and_artist() {
     }];
     assert_eq!(
         primary_activity_summary(&activities, &[]).map(|(t, _)| t),
-        Some("Listening to Spotify — Bohemian Rhapsody by Queen".to_owned())
+        Some("♪ Spotify — Bohemian Rhapsody by Queen".to_owned())
     );
 }
 

--- a/src/tui/ui/tests.rs
+++ b/src/tui/ui/tests.rs
@@ -1634,7 +1634,7 @@ fn user_profile_popup_renders_activity_section() {
 }
 
 #[test]
-fn primary_activity_summary_picks_custom_status_first() {
+fn primary_activity_summary_prefers_game_over_custom_status() {
     let activities = vec![
         ActivityInfo {
             kind: ActivityKind::Playing,
@@ -1662,7 +1662,7 @@ fn primary_activity_summary_picks_custom_status_first() {
 
     assert_eq!(
         primary_activity_summary(&activities, &[]).map(|(t, _)| t),
-        Some("🦀 Coding hard".to_owned())
+        Some("Playing Concord".to_owned())
     );
 }
 

--- a/src/tui/ui/types.rs
+++ b/src/tui/ui/types.rs
@@ -40,7 +40,7 @@ pub struct AvatarImage {
     pub protocol: Protocol,
 }
 
-pub struct EmojiReactionImage<'a> {
+pub struct EmojiImage<'a> {
     pub url: String,
     pub protocol: &'a Protocol,
 }

--- a/src/tui/ui/types.rs
+++ b/src/tui/ui/types.rs
@@ -114,4 +114,5 @@ pub(crate) enum ActionMenuTarget {
 
 pub(super) struct UserProfilePopupText {
     pub(super) lines: Vec<Line<'static>>,
+    pub(super) emoji_overlays: Vec<(usize, String)>,
 }


### PR DESCRIPTION
- replaces emoji placeholders `:emoji:` with their actually rendered image
- does this in member pane and in profile pop up

before:
<img width="1382" height="826" alt="image" src="https://github.com/user-attachments/assets/c9f633bb-5c3d-49ac-8fae-353c2f79b25c" />

after:
<img width="1380" height="821" alt="image" src="https://github.com/user-attachments/assets/e5694cdb-9ef0-43fa-821c-06476696006e" />
