### PR TITLE
feat: support all emojis for reactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,6 +580,7 @@ dependencies = [
  "chrono",
  "crossterm",
  "dirs",
+ "emojis",
  "futures",
  "image",
  "mime_guess",
@@ -756,7 +757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
- "phf",
+ "phf 0.11.3",
 ]
 
 [[package]]
@@ -914,6 +915,15 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "emojis"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a4d5d50b0b58df5173d8ff1192b4d1422ceae5d981b30d4b6f8ed1d673a2bc4"
+dependencies = [
+ "phf 0.13.1",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -2375,7 +2385,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -2385,7 +2404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -2394,7 +2413,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand 0.8.6",
 ]
 
@@ -2405,7 +2424,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2416,6 +2435,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -3490,7 +3518,7 @@ checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
  "nom 7.1.3",
- "phf",
+ "phf 0.11.3",
  "phf_codegen",
 ]
 
@@ -3527,7 +3555,7 @@ dependencies = [
  "ordered-float 4.6.0",
  "pest",
  "pest_derive",
- "phf",
+ "phf 0.11.3",
  "sha2",
  "signal-hook",
  "siphasher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ base64 = "0.22"
 chrono = { version = "0.4.44", default-features = false, features = ["clock"] }
 crossterm = { version = "0.29.0", features = ["event-stream"] }
 dirs = "6.0.0"
+emojis = "0.8.2"
 futures = "0.3.32"
 image = "0.25.10"
 mime_guess = "2.0"

--- a/src/tui/input/tests.rs
+++ b/src/tui/input/tests.rs
@@ -1998,7 +1998,28 @@ fn emoji_picker_filter_treats_vim_keys_as_text() {
     handle_key(&mut state, char_key('j'));
 
     assert_eq!(state.emoji_reaction_filter(), Some("j"));
-    assert_eq!(state.selected_emoji_reaction(), None);
+    assert_ne!(
+        state.selected_emoji_reaction().map(|item| item.emoji),
+        Some(ReactionEmoji::Unicode("❤️".to_owned()))
+    );
+}
+
+#[test]
+fn emoji_picker_filter_matches_remaining_unicode_emojis() {
+    let mut state = state_with_messages(1);
+    state.focus_pane(FocusPane::Messages);
+    open_emoji_picker(&mut state);
+
+    handle_key(&mut state, char_key('/'));
+    for value in "rocket".chars() {
+        handle_key(&mut state, char_key(value));
+    }
+
+    assert_eq!(state.emoji_reaction_filter(), Some("rocket"));
+    assert_eq!(
+        state.selected_emoji_reaction().map(|item| item.emoji),
+        Some(ReactionEmoji::Unicode("🚀".to_owned()))
+    );
 }
 
 #[test]

--- a/src/tui/state/emoji.rs
+++ b/src/tui/state/emoji.rs
@@ -1,5 +1,7 @@
 use crate::discord::{CustomEmojiInfo, ReactionEmoji};
 
+use std::collections::HashSet;
+
 use super::EmojiReactionItem;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -43,7 +45,7 @@ const EMOJI_REACTION_ITEMS: &[UnicodeEmojiReactionItem] = &[
     },
 ];
 
-pub(super) fn unicode_emoji_reaction_items() -> Vec<EmojiReactionItem> {
+pub(super) fn quick_unicode_emoji_reaction_items() -> Vec<EmojiReactionItem> {
     EMOJI_REACTION_ITEMS
         .iter()
         .map(|item| EmojiReactionItem {
@@ -51,6 +53,23 @@ pub(super) fn unicode_emoji_reaction_items() -> Vec<EmojiReactionItem> {
             label: item.label.to_owned(),
         })
         .collect()
+}
+
+pub(super) fn remaining_unicode_emoji_reaction_items() -> Vec<EmojiReactionItem> {
+    let quick_emojis: HashSet<&'static str> =
+        EMOJI_REACTION_ITEMS.iter().map(|item| item.emoji).collect();
+
+    emojis::iter()
+        .filter(|emoji| !quick_emojis.contains(emoji.as_str()))
+        .map(|emoji| EmojiReactionItem {
+            emoji: ReactionEmoji::Unicode(emoji.as_str().to_owned()),
+            label: unicode_emoji_label(emoji),
+        })
+        .collect()
+}
+
+pub(super) fn is_quick_unicode_emoji(value: &str) -> bool {
+    EMOJI_REACTION_ITEMS.iter().any(|item| item.emoji == value)
 }
 
 pub(super) fn custom_emoji_reaction_item(emoji: &CustomEmojiInfo) -> EmojiReactionItem {
@@ -65,8 +84,15 @@ pub(super) fn custom_emoji_reaction_item(emoji: &CustomEmojiInfo) -> EmojiReacti
 }
 
 fn custom_emoji_label(name: &str) -> String {
-    let words: Vec<String> = name
-        .split('_')
+    title_case_words(name.split('_'))
+}
+
+fn unicode_emoji_label(emoji: &emojis::Emoji) -> String {
+    title_case_words(emoji.name().split_whitespace())
+}
+
+fn title_case_words<'a>(words: impl Iterator<Item = &'a str>) -> String {
+    let words: Vec<String> = words
         .filter(|word| !word.is_empty())
         .map(|word| {
             let mut chars = word.chars();
@@ -78,7 +104,7 @@ fn custom_emoji_label(name: &str) -> String {
         .collect();
 
     if words.is_empty() {
-        name.to_owned()
+        String::new()
     } else {
         words.join(" ")
     }

--- a/src/tui/state/reactions.rs
+++ b/src/tui/state/reactions.rs
@@ -2,7 +2,10 @@ use crate::discord::AppCommand;
 use crate::discord::ids::{Id, marker::GuildMarker};
 
 use super::super::fuzzy::fuzzy_text_score;
-use super::emoji::{custom_emoji_reaction_item, unicode_emoji_reaction_items};
+use super::emoji::{
+    custom_emoji_reaction_item, is_quick_unicode_emoji, quick_unicode_emoji_reaction_items,
+    remaining_unicode_emoji_reaction_items,
+};
 use super::scroll::{clamp_selected_index, move_index_down, move_index_up};
 use super::{
     DashboardState, EmojiReactionItem, EmojiReactionPickerState, ReactionUsersPopupState,
@@ -34,7 +37,7 @@ impl DashboardState {
         &self,
         guild_id: Option<Id<GuildMarker>>,
     ) -> Vec<EmojiReactionItem> {
-        let mut items = unicode_emoji_reaction_items();
+        let mut items = quick_unicode_emoji_reaction_items();
 
         if let Some(guild_id) = guild_id {
             items.extend(
@@ -45,6 +48,8 @@ impl DashboardState {
                     .map(custom_emoji_reaction_item),
             );
         }
+
+        items.extend(remaining_unicode_emoji_reaction_items());
 
         items
     }
@@ -259,16 +264,29 @@ fn filter_emoji_reaction_items_from_slice(
         return items.to_vec();
     }
 
-    let mut scored: Vec<(usize, usize, EmojiReactionItem)> = items
+    let mut scored: Vec<(usize, usize, usize, EmojiReactionItem)> = items
         .iter()
         .enumerate()
         .filter_map(|(index, item)| {
-            emoji_reaction_filter_score(item, filter).map(|score| (score, index, item.clone()))
+            emoji_reaction_filter_score(item, filter).map(|score| {
+                (
+                    usize::from(emoji_reaction_is_remaining_unicode(item)),
+                    score,
+                    index,
+                    item.clone(),
+                )
+            })
         })
         .collect();
 
-    scored.sort_by_key(|(score, index, _)| (*score, *index));
-    scored.into_iter().map(|(_, _, item)| item).collect()
+    scored.sort_by_key(|(is_remaining_unicode, score, index, _)| {
+        (*is_remaining_unicode, *score, *index)
+    });
+    scored.into_iter().map(|(_, _, _, item)| item).collect()
+}
+
+fn emoji_reaction_is_remaining_unicode(item: &EmojiReactionItem) -> bool {
+    matches!(&item.emoji, crate::discord::ReactionEmoji::Unicode(emoji) if !is_quick_unicode_emoji(emoji))
 }
 
 fn emoji_reaction_filter_score(item: &EmojiReactionItem, filter: &str) -> Option<usize> {

--- a/src/tui/state/tests/mod.rs
+++ b/src/tui/state/tests/mod.rs
@@ -1113,8 +1113,23 @@ fn emoji_picker_items_include_available_custom_emojis_for_selected_message_guild
 
     let items = state.emoji_reaction_items();
 
-    assert_eq!(items.len(), 9);
-    assert_eq!(items[0].emoji, ReactionEmoji::Unicode("👍".to_owned()));
+    assert!(items.len() > 9);
+    assert_eq!(
+        items[..8]
+            .iter()
+            .map(|item| item.emoji.clone())
+            .collect::<Vec<_>>(),
+        vec![
+            ReactionEmoji::Unicode("👍".to_owned()),
+            ReactionEmoji::Unicode("❤️".to_owned()),
+            ReactionEmoji::Unicode("😂".to_owned()),
+            ReactionEmoji::Unicode("🎉".to_owned()),
+            ReactionEmoji::Unicode("😮".to_owned()),
+            ReactionEmoji::Unicode("😢".to_owned()),
+            ReactionEmoji::Unicode("🙏".to_owned()),
+            ReactionEmoji::Unicode("👀".to_owned()),
+        ]
+    );
     assert_eq!(items[8].label, "Party Time");
     assert_eq!(
         items[8].emoji,
@@ -1124,6 +1139,7 @@ fn emoji_picker_items_include_available_custom_emojis_for_selected_message_guild
             animated: true,
         }
     );
+    assert!(matches!(items[9].emoji, ReactionEmoji::Unicode(_)));
 }
 
 #[test]
@@ -1156,7 +1172,7 @@ fn emoji_picker_items_include_custom_emojis_from_update_event() {
 
     let items = state.emoji_reaction_items();
 
-    assert_eq!(items.len(), 9);
+    assert!(items.len() > 9);
     assert_eq!(items[8].label, "Wave");
     assert_eq!(
         items[8].emoji,
@@ -1194,7 +1210,7 @@ fn emoji_picker_uses_channel_guild_when_selected_message_lacks_guild_id() {
 
     let items = state.emoji_reaction_items();
 
-    assert_eq!(items.len(), 9);
+    assert!(items.len() > 9);
     assert_eq!(items[8].label, "Party Time");
 }
 
@@ -1240,7 +1256,13 @@ fn emoji_picker_items_stay_unicode_only_for_direct_messages() {
         forwarded_snapshots: Vec::new(),
     });
 
-    assert_eq!(state.emoji_reaction_items().len(), 8);
+    let items = state.emoji_reaction_items();
+    assert!(items.len() > 8);
+    assert!(
+        items
+            .iter()
+            .all(|item| matches!(item.emoji, ReactionEmoji::Unicode(_)))
+    );
 }
 
 #[test]

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -102,10 +102,11 @@ use self::{
     },
     popups::{
         channel_action_menu_lines, channel_switcher_cursor_position, channel_switcher_lines,
-        debug_log_popup_lines, emoji_reaction_picker_lines, filtered_emoji_reaction_picker_lines,
-        guild_action_menu_lines, member_action_menu_lines, message_action_menu_lines,
-        options_popup_lines, poll_vote_picker_lines, reaction_users_popup_lines,
-        user_profile_popup_lines, user_profile_popup_lines_with_activities,
+        debug_log_popup_lines, emoji_reaction_picker_lines, emoji_reaction_picker_lines_for_width,
+        filtered_emoji_reaction_picker_lines, guild_action_menu_lines, member_action_menu_lines,
+        message_action_menu_lines, options_popup_lines, poll_vote_picker_lines,
+        reaction_users_popup_lines, user_profile_popup_lines,
+        user_profile_popup_lines_with_activities,
     },
 };
 

--- a/src/tui/ui/popups.rs
+++ b/src/tui/ui/popups.rs
@@ -773,6 +773,7 @@ pub(super) fn render_emoji_reaction_picker(
             &ready_urls,
             state.show_custom_emoji(),
             filter,
+            usize::from(content.width),
         ))
         .block(block)
         .wrap(Wrap { trim: false }),
@@ -1696,6 +1697,26 @@ pub(super) fn emoji_reaction_picker_lines(
         thumbnail_urls,
         true,
         None,
+        usize::MAX,
+    )
+}
+
+#[cfg(test)]
+pub(super) fn emoji_reaction_picker_lines_for_width(
+    reactions: &[EmojiReactionItem],
+    selected: usize,
+    max_visible_items: usize,
+    thumbnail_urls: &[String],
+    width: usize,
+) -> Vec<Line<'static>> {
+    emoji_reaction_picker_lines_with_custom_emoji_images(
+        reactions,
+        selected,
+        max_visible_items,
+        thumbnail_urls,
+        true,
+        None,
+        width,
     )
 }
 
@@ -1714,6 +1735,7 @@ pub(super) fn filtered_emoji_reaction_picker_lines(
         thumbnail_urls,
         true,
         Some(filter),
+        usize::MAX,
     )
 }
 
@@ -1724,6 +1746,7 @@ fn emoji_reaction_picker_lines_with_custom_emoji_images(
     thumbnail_urls: &[String],
     show_custom_emoji: bool,
     filter: Option<&str>,
+    max_width: usize,
 ) -> Vec<Line<'static>> {
     let selected = selected.min(reactions.len().saturating_sub(1));
     let visible_items = max_visible_items.max(1).min(reactions.len().max(1));
@@ -1778,7 +1801,14 @@ fn emoji_reaction_picker_lines_with_custom_emoji_images(
             ),
         ]));
     }
-    lines
+    if max_width == usize::MAX {
+        lines
+    } else {
+        lines
+            .into_iter()
+            .map(|line| truncate_line_to_display_width(line, max_width))
+            .collect()
+    }
 }
 
 fn shortcut_prefix(shortcut: Option<char>) -> String {

--- a/src/tui/ui/tests.rs
+++ b/src/tui/ui/tests.rs
@@ -16,18 +16,18 @@ use super::{
     channel_switcher_cursor_position, channel_switcher_lines, channel_unread_decoration,
     composer_content_line_count, composer_cursor_position, composer_lines,
     composer_prompt_line_count, composer_text, date_separator_line, debug_log_popup_lines,
-    dm_presence_dot_span, emoji_reaction_picker_lines, filtered_emoji_reaction_picker_lines,
-    focus_pane_at, footer_hint, format_message_sent_time, format_unix_millis_with_offset,
-    forum_post_reaction_summary, forum_post_scrollbar_visible_count, forum_post_viewport_lines,
-    guild_action_menu_lines, inline_image_preview_area, inline_image_preview_row,
-    member_action_menu_lines, member_display_label, member_name_style, message_action_menu_lines,
-    message_author_style, message_item_lines, message_starts_new_day, message_viewport_lines,
-    new_messages_notice_line, options_popup_lines, poll_vote_picker_lines,
-    primary_activity_summary, reaction_users_popup_lines, reaction_users_visible_line_count,
-    render_channels, render_guilds, selected_avatar_x_offset, selected_message_card_width,
-    selected_message_content_x_offset, sync_view_heights, user_profile_popup_has_avatar,
-    user_profile_popup_lines, user_profile_popup_lines_with_activities,
-    user_profile_popup_text_geometry,
+    dm_presence_dot_span, emoji_reaction_picker_lines, emoji_reaction_picker_lines_for_width,
+    filtered_emoji_reaction_picker_lines, focus_pane_at, footer_hint, format_message_sent_time,
+    format_unix_millis_with_offset, forum_post_reaction_summary,
+    forum_post_scrollbar_visible_count, forum_post_viewport_lines, guild_action_menu_lines,
+    inline_image_preview_area, inline_image_preview_row, member_action_menu_lines,
+    member_display_label, member_name_style, message_action_menu_lines, message_author_style,
+    message_item_lines, message_starts_new_day, message_viewport_lines, new_messages_notice_line,
+    options_popup_lines, poll_vote_picker_lines, primary_activity_summary,
+    reaction_users_popup_lines, reaction_users_visible_line_count, render_channels, render_guilds,
+    selected_avatar_x_offset, selected_message_card_width, selected_message_content_x_offset,
+    sync_view_heights, user_profile_popup_has_avatar, user_profile_popup_lines,
+    user_profile_popup_lines_with_activities, user_profile_popup_text_geometry,
 };
 use crate::{
     config::DisplayOptions,
@@ -2839,6 +2839,32 @@ fn emoji_reaction_picker_reserves_space_for_loaded_custom_image() {
             "› [1]    Party",
             "Shortcut/Enter/Space react · / filter · Esc close"
         ]
+    );
+}
+
+#[test]
+fn emoji_reaction_picker_truncates_long_rows_to_inner_width() {
+    let reactions = vec![EmojiReactionItem {
+        emoji: ReactionEmoji::Custom {
+            id: Id::new(42),
+            name: Some("this_is_a_very_long_server_emoji_name_that_would_wrap".to_owned()),
+            animated: false,
+        },
+        label: "This Is A Very Long Server Emoji Name That Would Wrap".to_owned(),
+    }];
+
+    let lines = emoji_reaction_picker_lines_for_width(&reactions, 0, 10, &[], 24);
+
+    for line in &lines {
+        assert!(
+            line.width() <= 24,
+            "line {:?} exceeded picker width",
+            line_texts_from_ratatui(std::slice::from_ref(line))
+        );
+    }
+    assert_eq!(
+        line_texts_from_ratatui(&lines)[0].trim_end(),
+        "› [1] :this_is_a_very..."
     );
 }
 


### PR DESCRIPTION
## Problem

I want to be able to react to messages with the green heart emoji. Currently, I only have access to 8 originally selected emojis and the server-specific emojis.

## Proposed solution

I have added the rest of the emojis while leaving the original 8 in their original location to prevent someone from having to relearn the defaults.  The list now goes: ORIGINAL 8 - SERVER EMOJIS - REST OF UNICODE EMOJI LIST  Searching also works for these new ones as it uses their CLDR data to search them.

## Notes

In my testing, I noticed that some server emoji names are so long that their names wrap inside the picker and cause display issues, so I also added a small truncation bit to fix that.

Screenshot
<img width="341" height="413" alt="Screenshot 2026-05-10 at 9 57 47 PM" src="https://github.com/user-attachments/assets/2fa20315-3cf1-431c-adf0-72e5f8cbd9a3" />
