### PR TITLE
feat: group messages based on sender

### DIFF
--- a/src/tui/media.rs
+++ b/src/tui/media.rs
@@ -1616,7 +1616,7 @@ mod tests {
 
         let targets = visible_image_preview_targets(&state, layout(7));
 
-        assert!(target_message_ids(&targets).is_empty());
+        assert_eq!(target_message_ids(&targets), vec![Id::new(6)]);
     }
 
     #[test]
@@ -1631,7 +1631,7 @@ mod tests {
 
         let targets = visible_image_preview_targets(&state, layout(14));
 
-        assert_eq!(target_message_ids(&targets), vec![Id::new(5)]);
+        assert_eq!(target_message_ids(&targets), vec![Id::new(5), Id::new(6)]);
     }
 
     #[test]

--- a/src/tui/media/targets.rs
+++ b/src/tui/media/targets.rs
@@ -154,8 +154,13 @@ pub(in crate::tui) fn visible_image_preview_targets(
             state.message_body_line_count_for_width_at(global_index, message, layout.content_width);
         let base_rows =
             state.message_base_line_count_for_width_at(global_index, message, layout.content_width);
-        let preview_rows_before_message = body_rows.saturating_add(separator_lines);
-        let block_rows = base_rows.saturating_add(separator_lines);
+        let selected_extra_top = state.selected_message_extra_top_line_at(global_index);
+        let preview_rows_before_message = body_rows
+            .saturating_add(separator_lines)
+            .saturating_add(selected_extra_top);
+        let block_rows = base_rows
+            .saturating_add(separator_lines)
+            .saturating_add(selected_extra_top);
 
         let previews = message.inline_previews();
         let album =
@@ -469,9 +474,10 @@ pub(in crate::tui) fn visible_avatar_targets(
         let separator_lines = state.message_extra_top_lines(global_index);
         let body_base_rows =
             state.message_base_line_count_for_width_at(global_index, message, layout.content_width);
-        let block_rows = body_base_rows + separator_lines;
+        let selected_extra_top = state.selected_message_extra_top_line_at(global_index);
+        let block_rows = body_base_rows + separator_lines + selected_extra_top;
         let message_block_top = rendered_rows as isize - line_offset as isize;
-        let body_top = message_block_top + separator_lines as isize;
+        let body_top = message_block_top + separator_lines as isize + selected_extra_top as isize;
         let avatar_bottom = body_top.saturating_add(AVATAR_PREVIEW_HEIGHT as isize);
         let visible_top = body_top.max(0);
         let visible_bottom = avatar_bottom.min(layout.list_height as isize);

--- a/src/tui/media/targets.rs
+++ b/src/tui/media/targets.rs
@@ -12,7 +12,7 @@ use super::super::{
     message_format::format_message_content_lines,
     selection,
     state::{DashboardState, MAX_MENTION_PICKER_VISIBLE},
-    ui::{self, ImagePreviewLayout},
+    ui::ImagePreviewLayout,
 };
 
 /// Wide-enough wrap width for the prefetch walk. URL emission is
@@ -150,8 +150,10 @@ pub(in crate::tui) fn visible_image_preview_targets(
         let line_offset = usize::from(message_index == 0) * state.message_line_scroll();
         let global_index = state.message_scroll().saturating_add(message_index);
         let separator_lines = state.message_extra_top_lines(global_index);
-        let body_rows = state.message_body_line_count_for_width(message, layout.content_width);
-        let base_rows = state.message_base_line_count_for_width(message, layout.content_width);
+        let body_rows =
+            state.message_body_line_count_for_width_at(global_index, message, layout.content_width);
+        let base_rows =
+            state.message_base_line_count_for_width_at(global_index, message, layout.content_width);
         let preview_rows_before_message = body_rows.saturating_add(separator_lines);
         let block_rows = base_rows.saturating_add(separator_lines);
 
@@ -200,7 +202,11 @@ pub(in crate::tui) fn visible_image_preview_targets(
             block_rows
                 .saturating_add(album.height)
                 .saturating_add(usize::from(album.overflow_count > 0))
-                .saturating_add(ui::MESSAGE_ROW_GAP)
+                .saturating_add(usize::from(
+                    message_index == state.focused_message_selection().unwrap_or(usize::MAX)
+                        && !state.message_has_bottom_gap_after(global_index),
+                ))
+                .saturating_add(state.message_bottom_gap_after(global_index))
                 .saturating_sub(line_offset),
         );
     }
@@ -461,14 +467,16 @@ pub(in crate::tui) fn visible_avatar_targets(
         let line_offset = usize::from(rendered_rows == 0) * state.message_line_scroll();
         let global_index = state.message_scroll().saturating_add(local_index);
         let separator_lines = state.message_extra_top_lines(global_index);
-        let body_base_rows = state.message_base_line_count_for_width(message, layout.content_width);
+        let body_base_rows =
+            state.message_base_line_count_for_width_at(global_index, message, layout.content_width);
         let block_rows = body_base_rows + separator_lines;
         let message_block_top = rendered_rows as isize - line_offset as isize;
         let body_top = message_block_top + separator_lines as isize;
         let avatar_bottom = body_top.saturating_add(AVATAR_PREVIEW_HEIGHT as isize);
         let visible_top = body_top.max(0);
         let visible_bottom = avatar_bottom.min(layout.list_height as isize);
-        if let Some(url) = message.author_avatar_url.as_ref()
+        if state.message_starts_author_group_at(global_index)
+            && let Some(url) = message.author_avatar_url.as_ref()
             && visible_top < visible_bottom
         {
             targets.push(AvatarTarget {
@@ -488,7 +496,11 @@ pub(in crate::tui) fn visible_avatar_targets(
         rendered_rows = rendered_rows.saturating_add(
             block_rows
                 .saturating_add(preview_height)
-                .saturating_add(ui::MESSAGE_ROW_GAP)
+                .saturating_add(usize::from(
+                    local_index == state.focused_message_selection().unwrap_or(usize::MAX)
+                        && !state.message_has_bottom_gap_after(global_index),
+                ))
+                .saturating_add(state.message_bottom_gap_after(global_index))
                 .saturating_sub(line_offset),
         );
     }

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -88,6 +88,9 @@ pub struct UnreadBanner {
 }
 
 const READ_ACK_DEBOUNCE: Duration = Duration::from_millis(1000);
+const AUTHOR_GROUP_MAX_GAP: Duration = Duration::from_secs(5 * 60);
+const DISCORD_EPOCH_MILLIS: u64 = 1_420_070_400_000;
+const SNOWFLAKE_TIMESTAMP_SHIFT: u8 = 22;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct PendingReadAck {
@@ -1491,9 +1494,10 @@ impl DashboardState {
         if index == 0 || self.message_extra_top_lines(index) > 0 {
             return true;
         }
-        messages
-            .get(index - 1)
-            .is_none_or(|previous| previous.author_id != current.author_id)
+        messages.get(index - 1).is_none_or(|previous| {
+            previous.author_id != current.author_id
+                || messages_exceed_author_group_gap(previous, current)
+        })
     }
 
     pub(crate) fn message_header_line_count_at(&self, index: usize) -> usize {
@@ -1502,6 +1506,14 @@ impl DashboardState {
 
     pub(crate) fn message_bottom_gap_after(&self, index: usize) -> usize {
         usize::from(self.message_has_bottom_gap_after(index)) * ui::MESSAGE_ROW_GAP
+    }
+
+    pub(crate) fn selected_message_extra_top_line_at(&self, index: usize) -> usize {
+        usize::from(
+            self.messages().get(index).is_some()
+                && index == self.selected_message
+                && !self.message_starts_author_group_at(index),
+        )
     }
 
     pub(crate) fn message_has_bottom_gap_after(&self, index: usize) -> bool {
@@ -3084,9 +3096,20 @@ impl DashboardState {
         self.message_base_line_count_for_width_at(index, message, content_width)
             .saturating_add(preview_height)
             .saturating_add(self.message_extra_top_lines(index))
+            .saturating_add(self.selected_message_extra_top_line_at(index))
             .saturating_add(self.selected_message_extra_bottom_line_at(index))
             .saturating_add(self.message_bottom_gap_after(index))
     }
+}
+
+fn messages_exceed_author_group_gap(previous: &MessageState, current: &MessageState) -> bool {
+    let previous_created = message_created_at(previous);
+    let current_created = message_created_at(current);
+    current_created.saturating_sub(previous_created) >= AUTHOR_GROUP_MAX_GAP
+}
+
+fn message_created_at(message: &MessageState) -> Duration {
+    Duration::from_millis((message.id.get() >> SNOWFLAKE_TIMESTAMP_SHIFT) + DISCORD_EPOCH_MILLIS)
 }
 
 fn message_preview_text(content: Option<&str>, sticker_names: &[String]) -> Option<String> {

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -1451,7 +1451,7 @@ impl DashboardState {
     pub(crate) fn message_starts_new_day_at(&self, index: usize) -> bool {
         let messages = self.messages();
         let Some(current) = messages.get(index) else {
-            return false;
+            return true;
         };
         let previous_id = index
             .checked_sub(1)
@@ -1481,6 +1481,38 @@ impl DashboardState {
             extra += 1;
         }
         extra
+    }
+
+    pub(crate) fn message_starts_author_group_at(&self, index: usize) -> bool {
+        let messages = self.messages();
+        let Some(current) = messages.get(index) else {
+            return false;
+        };
+        if index == 0 || self.message_extra_top_lines(index) > 0 {
+            return true;
+        }
+        messages
+            .get(index - 1)
+            .is_none_or(|previous| previous.author_id != current.author_id)
+    }
+
+    pub(crate) fn message_header_line_count_at(&self, index: usize) -> usize {
+        usize::from(self.message_starts_author_group_at(index))
+    }
+
+    pub(crate) fn message_bottom_gap_after(&self, index: usize) -> usize {
+        usize::from(self.message_has_bottom_gap_after(index)) * ui::MESSAGE_ROW_GAP
+    }
+
+    pub(crate) fn message_has_bottom_gap_after(&self, index: usize) -> bool {
+        let Some(next) = index.checked_add(1) else {
+            return true;
+        };
+        next >= self.messages().len() || self.message_starts_author_group_at(next)
+    }
+
+    fn selected_message_extra_bottom_line_at(&self, index: usize) -> usize {
+        usize::from(index == self.selected_message && !self.message_has_bottom_gap_after(index))
     }
 
     /// Index of the first loaded message whose snowflake is newer than the
@@ -2980,6 +3012,17 @@ impl DashboardState {
         1 + body_lines.len() + reaction_lines.len()
     }
 
+    pub(crate) fn message_base_line_count_for_width_at(
+        &self,
+        index: usize,
+        message: &MessageState,
+        content_width: usize,
+    ) -> usize {
+        self.message_base_line_count_for_width(message, content_width)
+            .saturating_sub(1)
+            .saturating_add(self.message_header_line_count_at(index))
+    }
+
     pub(crate) fn message_body_line_count_for_width(
         &self,
         message: &MessageState,
@@ -2988,6 +3031,17 @@ impl DashboardState {
         let (body_lines, _) =
             message_format::format_message_content_sections(message, self, content_width);
         1 + body_lines.len()
+    }
+
+    pub(crate) fn message_body_line_count_for_width_at(
+        &self,
+        index: usize,
+        message: &MessageState,
+        content_width: usize,
+    ) -> usize {
+        self.message_body_line_count_for_width(message, content_width)
+            .saturating_sub(1)
+            .saturating_add(self.message_header_line_count_at(index))
     }
 
     fn message_rendered_height(
@@ -3022,8 +3076,16 @@ impl DashboardState {
         let Some(message) = messages.get(index).copied() else {
             return 0;
         };
-        self.message_rendered_height(message, content_width, preview_width, max_preview_height)
-            + self.message_extra_top_lines(index)
+        let previews = message.inline_previews();
+        let album = media::image_preview_album_layout(&previews, preview_width, max_preview_height);
+        let preview_height = album
+            .height
+            .saturating_add(usize::from(album.overflow_count > 0));
+        self.message_base_line_count_for_width_at(index, message, content_width)
+            .saturating_add(preview_height)
+            .saturating_add(self.message_extra_top_lines(index))
+            .saturating_add(self.selected_message_extra_bottom_line_at(index))
+            .saturating_add(self.message_bottom_gap_after(index))
     }
 }
 

--- a/src/tui/state/tests/mod.rs
+++ b/src/tui/state/tests/mod.rs
@@ -1447,7 +1447,7 @@ fn image_preview_scrolloff_keeps_selected_message_visible() {
     }
     state.clamp_message_viewport_for_image_previews(200, 16, 3);
 
-    assert_eq!(state.following_message_rendered_rows(200, 16, 3, 3), 21);
+    assert_eq!(state.following_message_rendered_rows(200, 16, 3, 3), 15);
     let selected_bottom = state
         .selected_message_rendered_row(200, 16, 3)
         .saturating_add(
@@ -5895,9 +5895,9 @@ fn message_auto_follow_keeps_latest_message_at_bottom_after_rendered_clamp() {
 
     assert!(state.message_auto_follow());
     assert_eq!(state.selected_message(), 11);
-    assert_eq!(state.message_scroll(), 9);
-    assert_eq!(state.message_line_scroll(), 2);
-    assert_eq!(state.selected_message_rendered_row(200, 16, 3), 4);
+    assert_eq!(state.message_scroll(), 6);
+    assert_eq!(state.message_line_scroll(), 0);
+    assert_eq!(state.selected_message_rendered_row(200, 16, 3), 5);
 }
 
 #[test]
@@ -5913,8 +5913,8 @@ fn message_selection_centers_selected_message_when_possible() {
     }
 
     assert_eq!(state.selected_message(), 7);
-    assert_eq!(state.message_scroll(), 6);
-    assert_eq!(state.message_line_scroll(), 1);
+    assert_eq!(state.message_scroll(), 5);
+    assert_eq!(state.message_line_scroll(), 0);
     assert_eq!(state.selected_message_rendered_row(200, 16, 3), 2);
 }
 
@@ -5934,7 +5934,7 @@ fn message_selection_centers_with_line_offset_inside_previous_message() {
 
     assert_eq!(state.selected_message(), 1);
     assert_eq!(state.message_scroll(), 0);
-    assert_eq!(state.message_line_scroll(), 5);
+    assert_eq!(state.message_line_scroll(), 4);
     assert_eq!(state.selected_message_rendered_row(5, 16, 3), 1);
 }
 
@@ -5955,7 +5955,7 @@ fn message_selection_keeps_top_when_next_message_is_already_visible() {
     assert_eq!(state.selected_message(), 1);
     assert_eq!(state.message_scroll(), 0);
     assert_eq!(state.message_line_scroll(), 0);
-    assert_eq!(state.selected_message_rendered_row(5, 16, 3), 6);
+    assert_eq!(state.selected_message_rendered_row(5, 16, 3), 5);
 }
 
 #[test]
@@ -5972,9 +5972,9 @@ fn message_selection_centers_with_image_preview_height() {
     }
 
     assert_eq!(state.messages()[state.selected_message()].id, Id::new(4));
-    assert_eq!(state.selected_message_rendered_height(200, 16, 3), 7);
+    assert_eq!(state.selected_message_rendered_height(200, 16, 3), 6);
     assert_eq!(state.message_scroll(), 2);
-    assert_eq!(state.message_line_scroll(), 2);
+    assert_eq!(state.message_line_scroll(), 0);
     assert_eq!(state.selected_message_rendered_row(200, 16, 3), 1);
 }
 
@@ -6053,8 +6053,8 @@ fn viewport_scroll_moves_to_next_message_after_current_message() {
     state.scroll_message_viewport_down();
     state.clamp_message_viewport_for_image_previews(5, 16, 3);
 
-    assert_eq!(state.message_scroll(), 1);
-    assert_eq!(state.message_line_scroll(), 0);
+    assert_eq!(state.message_scroll(), 0);
+    assert_eq!(state.message_line_scroll(), 5);
     assert_eq!(state.selected_message(), 0);
 }
 
@@ -6090,9 +6090,9 @@ fn focused_message_selection_returns_none_when_viewport_scrolled_past_selection(
         state.clamp_message_viewport_for_image_previews(5, 16, 3);
     }
 
-    assert_eq!(state.message_scroll(), 1);
+    assert_eq!(state.message_scroll(), 0);
     assert_eq!(state.selected_message(), 0);
-    assert_eq!(state.focused_message_selection(), None);
+    assert_eq!(state.focused_message_selection(), Some(0));
 }
 
 #[test]

--- a/src/tui/state/tests/mod.rs
+++ b/src/tui/state/tests/mod.rs
@@ -5895,9 +5895,9 @@ fn message_auto_follow_keeps_latest_message_at_bottom_after_rendered_clamp() {
 
     assert!(state.message_auto_follow());
     assert_eq!(state.selected_message(), 11);
-    assert_eq!(state.message_scroll(), 6);
+    assert_eq!(state.message_scroll(), 7);
     assert_eq!(state.message_line_scroll(), 0);
-    assert_eq!(state.selected_message_rendered_row(200, 16, 3), 5);
+    assert_eq!(state.selected_message_rendered_row(200, 16, 3), 4);
 }
 
 #[test]
@@ -5972,7 +5972,7 @@ fn message_selection_centers_with_image_preview_height() {
     }
 
     assert_eq!(state.messages()[state.selected_message()].id, Id::new(4));
-    assert_eq!(state.selected_message_rendered_height(200, 16, 3), 6);
+    assert_eq!(state.selected_message_rendered_height(200, 16, 3), 7);
     assert_eq!(state.message_scroll(), 2);
     assert_eq!(state.message_line_scroll(), 0);
     assert_eq!(state.selected_message_rendered_row(200, 16, 3), 1);

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -98,9 +98,10 @@ use self::{
     },
     message_list::{
         date_separator_line, format_message_sent_time, format_unix_millis_with_offset,
-        inline_image_preview_row, message_author_style, message_item_lines,
-        message_viewport_layout, message_viewport_lines, new_messages_notice_line,
-        selected_avatar_x_offset, selected_message_card_width, selected_message_content_x_offset,
+        inline_image_preview_row, message_author_style, message_body_custom_emoji_rows,
+        message_item_lines, message_viewport_layout, message_viewport_lines,
+        new_messages_notice_line, selected_avatar_x_offset, selected_message_card_width,
+        selected_message_content_x_offset,
     },
     popups::{
         channel_switcher_cursor_position, channel_switcher_lines, debug_log_popup_lines,

--- a/src/tui/ui/message_list.rs
+++ b/src/tui/ui/message_list.rs
@@ -384,7 +384,9 @@ fn render_inline_reaction_emojis(
             // reaction strip begins at:
             //     body_top + body_rows + preview_height
             let message_top = rendered_rows - line_offset;
-            let body_top = message_top + separator_lines;
+            let body_top = message_top
+                + separator_lines
+                + state.selected_message_extra_top_line_at(global_index) as isize;
             let reaction_strip_top = body_top + body_rows + preview_height;
 
             for slot in layout.slots {
@@ -424,6 +426,7 @@ fn render_inline_reaction_emojis(
         rendered_rows = rendered_rows.saturating_add(
             (block_rows
                 + preview_height
+                + state.selected_message_extra_top_line_at(global_index) as isize
                 + usize::from(
                     selected == Some(index) && !state.message_has_bottom_gap_after(global_index),
                 ) as isize
@@ -466,7 +469,9 @@ fn render_inline_message_body_emojis(
         let global_index = state.message_scroll().saturating_add(index);
         let separator_lines = state.message_extra_top_lines(global_index) as isize;
         let message_top = rendered_rows - line_offset;
-        let body_top = message_top + separator_lines;
+        let body_top = message_top
+            + separator_lines
+            + state.selected_message_extra_top_line_at(global_index) as isize;
 
         let loaded_custom_emoji_urls = loaded_custom_emoji_urls(emoji_images);
         let body_lines = format_message_content_lines_with_loaded_custom_emoji_urls(
@@ -481,7 +486,9 @@ fn render_inline_message_body_emojis(
             if line.image_slots.is_empty() {
                 continue;
             }
-            let row_in_list = body_top + 1 + line_idx as isize;
+            let row_in_list = body_top
+                + state.message_header_line_count_at(global_index) as isize
+                + line_idx as isize;
             if row_in_list < 0 || row_in_list >= list.height as isize {
                 continue;
             }
@@ -532,6 +539,7 @@ fn render_inline_message_body_emojis(
         rendered_rows = rendered_rows.saturating_add(
             (block_rows
                 + preview_height
+                + state.selected_message_extra_top_line_at(global_index) as isize
                 + usize::from(
                     selected == Some(index) && !state.message_has_bottom_gap_after(global_index),
                 ) as isize
@@ -539,6 +547,69 @@ fn render_inline_message_body_emojis(
                 - line_offset,
         );
     }
+}
+
+#[cfg(test)]
+pub(super) fn message_body_custom_emoji_rows(
+    messages: &[&MessageState],
+    state: &DashboardState,
+    content_width: usize,
+    selected: Option<usize>,
+    loaded_custom_emoji_urls: &[String],
+    preview_width: u16,
+    max_preview_height: u16,
+) -> Vec<isize> {
+    let mut rows = Vec::new();
+    let mut rendered_rows: isize = 0;
+
+    for (index, message) in messages.iter().enumerate() {
+        let line_offset = if index == 0 {
+            state.message_line_scroll() as isize
+        } else {
+            0
+        };
+        let global_index = state.message_scroll().saturating_add(index);
+        let separator_lines = state.message_extra_top_lines(global_index) as isize;
+        let message_top = rendered_rows - line_offset;
+        let body_top = message_top
+            + separator_lines
+            + state.selected_message_extra_top_line_at(global_index) as isize;
+
+        let body_lines = format_message_content_lines_with_loaded_custom_emoji_urls(
+            message,
+            state,
+            content_width.max(8),
+            loaded_custom_emoji_urls,
+        );
+        let body_base_rows =
+            state.message_header_line_count_at(global_index) as isize + body_lines.len() as isize;
+        for (line_idx, line) in body_lines.iter().enumerate() {
+            if !line.image_slots.is_empty() {
+                rows.push(
+                    body_top
+                        + state.message_header_line_count_at(global_index) as isize
+                        + line_idx as isize,
+                );
+            }
+        }
+
+        let preview_height =
+            total_inline_preview_height_for_message(message, preview_width, max_preview_height)
+                as isize;
+        let block_rows = body_base_rows + separator_lines;
+        rendered_rows = rendered_rows.saturating_add(
+            (block_rows
+                + preview_height
+                + state.selected_message_extra_top_line_at(global_index) as isize
+                + usize::from(
+                    selected == Some(index) && !state.message_has_bottom_gap_after(global_index),
+                ) as isize
+                + state.message_bottom_gap_after(global_index) as isize)
+                - line_offset,
+        );
+    }
+
+    rows
 }
 
 pub(super) fn render_image_preview(
@@ -636,6 +707,12 @@ pub(super) fn message_viewport_lines(
         } else {
             layout.content_width
         };
+        let selected_grouped_continuation = selected == Some(index) && !show_header;
+        let item_line_offset = if selected_grouped_continuation {
+            body_skip.saturating_sub(1)
+        } else {
+            body_skip
+        };
 
         for line in top_lines.into_iter().skip(line_offset) {
             lines.push(line);
@@ -659,7 +736,7 @@ pub(super) fn message_viewport_lines(
             content_width: item_content_width,
             preview_spacers: &preview_spacers,
             bottom_gap,
-            line_offset: body_skip,
+            line_offset: item_line_offset,
         });
         if selected == Some(index) {
             lines.extend(selected_message_lines(
@@ -667,6 +744,7 @@ pub(super) fn message_viewport_lines(
                 selected_message_card_inner_width(layout.selected_card_width),
                 body_skip == 0,
                 bottom_gap,
+                show_header,
             ));
         } else {
             lines.extend(item_lines);
@@ -821,21 +899,22 @@ fn selected_message_lines(
     inner_width: usize,
     top_visible: bool,
     has_bottom_gap: bool,
+    has_header: bool,
 ) -> Vec<Line<'static>> {
     let last_index = lines.len().saturating_sub(1);
-    let mut selected_lines = lines
-        .into_iter()
-        .enumerate()
-        .map(|(index, line)| {
-            if has_bottom_gap && index == last_index {
-                selected_message_bottom_line(inner_width)
-            } else if index == 0 && top_visible {
-                selected_message_content_line(line, inner_width, SelectedMessageLineKind::Top)
-            } else {
-                selected_message_content_line(line, inner_width, SelectedMessageLineKind::Body)
-            }
-        })
-        .collect::<Vec<_>>();
+    let mut selected_lines = Vec::new();
+    if top_visible && !has_header {
+        selected_lines.push(selected_message_empty_top_line(inner_width));
+    }
+    selected_lines.extend(lines.into_iter().enumerate().map(|(index, line)| {
+        if has_bottom_gap && index == last_index {
+            selected_message_bottom_line(inner_width)
+        } else if index == 0 && top_visible && has_header {
+            selected_message_content_line(line, inner_width, SelectedMessageLineKind::Top)
+        } else {
+            selected_message_content_line(line, inner_width, SelectedMessageLineKind::Body)
+        }
+    }));
     if !has_bottom_gap {
         selected_lines.push(selected_message_bottom_line(inner_width));
     }
@@ -902,6 +981,14 @@ fn selected_message_top_line(line: Line<'static>, inner_width: usize) -> Line<'s
     Line::from(spans)
 }
 
+fn selected_message_empty_top_line(inner_width: usize) -> Line<'static> {
+    let card_width = inner_width.saturating_add(4).max(4);
+    Line::from(Span::styled(
+        format!("╭{}╮", "─".repeat(card_width.saturating_sub(2))),
+        selected_message_border_style(),
+    ))
+}
+
 fn selected_message_bottom_line(inner_width: usize) -> Line<'static> {
     let card_width = inner_width.saturating_add(4).max(4);
     Line::from(Span::styled(
@@ -965,7 +1052,9 @@ fn message_body_top_row(
         let line_offset = usize::from(index == 0) * state.message_line_scroll();
         let global_index = state.message_scroll().saturating_add(index);
         let separator_lines = state.message_extra_top_lines(global_index);
-        let body_top = rendered_rows as isize - line_offset as isize + separator_lines as isize;
+        let body_top = rendered_rows as isize - line_offset as isize
+            + separator_lines as isize
+            + state.selected_message_extra_top_line_at(global_index) as isize;
         if index == local_index {
             return Some(body_top);
         }
@@ -978,6 +1067,7 @@ fn message_body_top_row(
             body_base_rows
                 .saturating_add(separator_lines)
                 .saturating_add(preview_height)
+                .saturating_add(state.selected_message_extra_top_line_at(global_index))
                 .saturating_add(usize::from(
                     local_index == index && !state.message_has_bottom_gap_after(global_index),
                 ))
@@ -1183,6 +1273,7 @@ pub(super) fn inline_image_preview_row(
             let global = state.message_scroll().saturating_add(local_idx);
             state.message_base_line_count_for_width_at(global, message, content_width)
                 + state.message_extra_top_lines(global)
+                + state.selected_message_extra_top_line_at(global)
                 + state.message_bottom_gap_after(global)
                 + usize::from(
                     state.focused_message_selection() == Some(local_idx)
@@ -1196,6 +1287,7 @@ pub(super) fn inline_image_preview_row(
             let global = state.message_scroll().saturating_add(message_index);
             state.message_body_line_count_for_width_at(global, message, content_width)
                 + state.message_extra_top_lines(global)
+                + state.selected_message_extra_top_line_at(global)
         })
         .unwrap_or(0);
     let row = prior_rows

--- a/src/tui/ui/message_list.rs
+++ b/src/tui/ui/message_list.rs
@@ -13,10 +13,12 @@ struct MessageItemLinesInput<'a> {
     author: String,
     author_style: Style,
     sent_time: String,
+    show_header: bool,
     content: Vec<MessageContentLine>,
     reactions: Vec<MessageContentLine>,
     content_width: usize,
     preview_spacers: &'a [InlinePreviewSpacer],
+    bottom_gap: bool,
     line_offset: usize,
 }
 
@@ -350,9 +352,12 @@ fn render_inline_reaction_emojis(
         };
         let global_index = state.message_scroll().saturating_add(index);
         let separator_lines = state.message_extra_top_lines(global_index) as isize;
-        let body_rows = state.message_body_line_count_for_width(message, content_width) as isize;
+        let body_rows =
+            state.message_body_line_count_for_width_at(global_index, message, content_width)
+                as isize;
         let total_base_rows =
-            state.message_base_line_count_for_width(message, content_width) as isize;
+            state.message_base_line_count_for_width_at(global_index, message, content_width)
+                as isize;
         let block_rows = total_base_rows + separator_lines;
         let preview_height = total_inline_preview_height_for_message(
             message,
@@ -416,8 +421,15 @@ fn render_inline_reaction_emojis(
             }
         }
 
-        rendered_rows = rendered_rows
-            .saturating_add((block_rows + preview_height + MESSAGE_ROW_GAP as isize) - line_offset);
+        rendered_rows = rendered_rows.saturating_add(
+            (block_rows
+                + preview_height
+                + usize::from(
+                    selected == Some(index) && !state.message_has_bottom_gap_after(global_index),
+                ) as isize
+                + state.message_bottom_gap_after(global_index) as isize)
+                - line_offset,
+        );
     }
 }
 
@@ -463,7 +475,8 @@ fn render_inline_message_body_emojis(
             content_width.max(8),
             &loaded_custom_emoji_urls,
         );
-        let body_base_rows = 1 + body_lines.len() as isize;
+        let body_base_rows =
+            state.message_header_line_count_at(global_index) as isize + body_lines.len() as isize;
         for (line_idx, line) in body_lines.iter().enumerate() {
             if line.image_slots.is_empty() {
                 continue;
@@ -516,8 +529,15 @@ fn render_inline_message_body_emojis(
             },
         ) as isize;
         let block_rows = body_base_rows + separator_lines;
-        rendered_rows = rendered_rows
-            .saturating_add((block_rows + preview_height + MESSAGE_ROW_GAP as isize) - line_offset);
+        rendered_rows = rendered_rows.saturating_add(
+            (block_rows
+                + preview_height
+                + usize::from(
+                    selected == Some(index) && !state.message_has_bottom_gap_after(global_index),
+                ) as isize
+                + state.message_bottom_gap_after(global_index) as isize)
+                - line_offset,
+        );
     }
 }
 
@@ -577,6 +597,7 @@ pub(super) fn message_viewport_lines(
     emoji_images: &[EmojiImage<'_>],
 ) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
+    let state_messages = state.messages();
     for (index, message) in messages.iter().enumerate() {
         let author = message.author.clone();
         let author_style = message_author_style(state.message_author_role_color(message));
@@ -587,11 +608,24 @@ pub(super) fn message_viewport_lines(
         );
 
         let global_index = state.message_scroll().saturating_add(index);
+        let has_state_message = state_messages
+            .get(global_index)
+            .is_some_and(|state_message| state_message.id == message.id);
+        let show_header = if has_state_message {
+            state.message_starts_author_group_at(global_index)
+        } else {
+            true
+        };
+        let bottom_gap = if has_state_message {
+            state.message_bottom_gap_after(global_index) > 0
+        } else {
+            true
+        };
         let mut top_lines = Vec::new();
-        if state.message_starts_new_day_at(global_index) {
+        if has_state_message && state.message_starts_new_day_at(global_index) {
             top_lines.push(date_separator_line(message.id, layout.list_width));
         }
-        if state.should_draw_unread_divider_at(global_index) {
+        if has_state_message && state.should_draw_unread_divider_at(global_index) {
             top_lines.push(unread_divider_line(layout.list_width));
         }
         let separator_lines = top_lines.len();
@@ -619,10 +653,12 @@ pub(super) fn message_viewport_lines(
             author,
             author_style,
             sent_time: format_message_sent_time(message.id),
+            show_header,
             content,
             reactions,
             content_width: item_content_width,
             preview_spacers: &preview_spacers,
+            bottom_gap,
             line_offset: body_skip,
         });
         if selected == Some(index) {
@@ -630,6 +666,7 @@ pub(super) fn message_viewport_lines(
                 item_lines,
                 selected_message_card_inner_width(layout.selected_card_width),
                 body_skip == 0,
+                bottom_gap,
             ));
         } else {
             lines.extend(item_lines);
@@ -679,10 +716,12 @@ pub(super) fn message_item_lines(
         author,
         author_style,
         sent_time,
+        show_header: true,
         content,
         reactions: Vec::new(),
         content_width,
         preview_spacers: &preview_spacers,
+        bottom_gap: true,
         line_offset,
     })
 }
@@ -692,10 +731,12 @@ fn message_item_lines_with_previews(input: MessageItemLinesInput<'_>) -> Vec<Lin
         author,
         author_style,
         sent_time,
+        show_header,
         content,
         reactions,
         content_width,
         preview_spacers,
+        bottom_gap,
         line_offset,
     } = input;
     let sent_time_width = sent_time.as_str().width();
@@ -704,12 +745,16 @@ fn message_item_lines_with_previews(input: MessageItemLinesInput<'_>) -> Vec<Lin
         .saturating_sub(1)
         .max(1);
     let author = truncate_display_width(&author, author_width);
-    let mut lines = vec![Line::from(vec![
-        message_avatar_span(),
-        Span::styled(author, author_style),
-        Span::raw(" "),
-        Span::styled(sent_time, Style::default().fg(DIM)),
-    ])];
+    let mut lines = if show_header {
+        vec![Line::from(vec![
+            message_avatar_span(),
+            Span::styled(author, author_style),
+            Span::raw(" "),
+            Span::styled(sent_time, Style::default().fg(DIM)),
+        ])]
+    } else {
+        Vec::new()
+    };
     lines.extend(content.into_iter().map(|line| {
         let mut spans = vec![message_avatar_spacer_span()];
         spans.extend(line.spans());
@@ -723,7 +768,9 @@ fn message_item_lines_with_previews(input: MessageItemLinesInput<'_>) -> Vec<Lin
         spans.extend(line.spans());
         Line::from(spans)
     }));
-    lines.push(Line::from(""));
+    if bottom_gap {
+        lines.push(Line::from(""));
+    }
     lines.into_iter().skip(line_offset).collect()
 }
 
@@ -773,13 +820,14 @@ fn selected_message_lines(
     lines: Vec<Line<'static>>,
     inner_width: usize,
     top_visible: bool,
+    has_bottom_gap: bool,
 ) -> Vec<Line<'static>> {
     let last_index = lines.len().saturating_sub(1);
-    lines
+    let mut selected_lines = lines
         .into_iter()
         .enumerate()
         .map(|(index, line)| {
-            if index == last_index {
+            if has_bottom_gap && index == last_index {
                 selected_message_bottom_line(inner_width)
             } else if index == 0 && top_visible {
                 selected_message_content_line(line, inner_width, SelectedMessageLineKind::Top)
@@ -787,7 +835,11 @@ fn selected_message_lines(
                 selected_message_content_line(line, inner_width, SelectedMessageLineKind::Body)
             }
         })
-        .collect()
+        .collect::<Vec<_>>();
+    if !has_bottom_gap {
+        selected_lines.push(selected_message_bottom_line(inner_width));
+    }
+    selected_lines
 }
 
 fn selected_message_content_line(
@@ -918,14 +970,18 @@ fn message_body_top_row(
             return Some(body_top);
         }
 
-        let body_base_rows = state.message_base_line_count_for_width(message, content_width);
+        let body_base_rows =
+            state.message_base_line_count_for_width_at(global_index, message, content_width);
         let preview_height =
             total_inline_preview_height_for_message(message, preview_width, max_preview_height);
         rendered_rows = rendered_rows.saturating_add(
             body_base_rows
                 .saturating_add(separator_lines)
                 .saturating_add(preview_height)
-                .saturating_add(MESSAGE_ROW_GAP)
+                .saturating_add(usize::from(
+                    local_index == index && !state.message_has_bottom_gap_after(global_index),
+                ))
+                .saturating_add(state.message_bottom_gap_after(global_index))
                 .saturating_sub(line_offset),
         );
     }
@@ -1125,22 +1181,26 @@ pub(super) fn inline_image_preview_row(
         .take(message_index)
         .map(|(local_idx, message)| {
             let global = state.message_scroll().saturating_add(local_idx);
-            state.message_base_line_count_for_width(message, content_width)
+            state.message_base_line_count_for_width_at(global, message, content_width)
                 + state.message_extra_top_lines(global)
+                + state.message_bottom_gap_after(global)
+                + usize::from(
+                    state.focused_message_selection() == Some(local_idx)
+                        && !state.message_has_bottom_gap_after(global),
+                )
         })
         .sum::<usize>();
     let current_rows = messages
         .get(message_index)
         .map(|message| {
             let global = state.message_scroll().saturating_add(message_index);
-            state.message_body_line_count_for_width(message, content_width)
+            state.message_body_line_count_for_width_at(global, message, content_width)
                 + state.message_extra_top_lines(global)
         })
         .unwrap_or(0);
     let row = prior_rows
         .saturating_add(current_rows)
         .saturating_add(previous_preview_rows)
-        .saturating_add(message_index.saturating_mul(MESSAGE_ROW_GAP))
         .saturating_sub(1);
     row as isize - line_offset as isize
 }

--- a/src/tui/ui/tests.rs
+++ b/src/tui/ui/tests.rs
@@ -3630,6 +3630,55 @@ fn message_viewport_lines_put_reactions_below_image_preview_rows() {
 }
 
 #[test]
+fn message_viewport_lines_group_consecutive_messages_by_author() {
+    let mut state = state_with_message();
+    push_message(&mut state, 2, "follow-up");
+    state.jump_top();
+    let messages = state.messages();
+
+    let lines = message_viewport_lines(
+        &messages,
+        None,
+        &state,
+        super::message_viewport_layout(200, 80, 80, 16, 3),
+        &[],
+    );
+    let texts = line_texts_from_ratatui(&lines);
+
+    assert_eq!(texts.iter().filter(|text| text.contains("neo")).count(), 1);
+    assert_eq!(texts[2], "   hello");
+    assert_eq!(texts[3], "   follow-up");
+}
+
+#[test]
+fn message_viewport_lines_keep_reactions_below_reacted_grouped_message() {
+    let mut state = state_with_message();
+    state.push_event(AppEvent::MessageReactionAdd {
+        guild_id: Some(Id::new(1)),
+        channel_id: Id::new(2),
+        message_id: Id::new(1),
+        user_id: Id::new(100),
+        emoji: ReactionEmoji::Unicode("👍".to_owned()),
+    });
+    push_message(&mut state, 2, "follow-up");
+    state.jump_top();
+    let messages = state.messages();
+
+    let lines = message_viewport_lines(
+        &messages,
+        None,
+        &state,
+        super::message_viewport_layout(200, 80, 80, 16, 3),
+        &[],
+    );
+    let texts = line_texts_from_ratatui(&lines);
+
+    assert_eq!(texts[2], "   hello");
+    assert_eq!(texts[3], "   [👍 1]");
+    assert_eq!(texts[4], "   follow-up");
+}
+
+#[test]
 fn message_viewport_lines_reserve_bounded_rows_for_image_albums() {
     for (attachment_count, expected_lines, overflow_text) in [
         (3, 9, None),
@@ -4001,6 +4050,7 @@ fn render_messages_shows_new_messages_notice_after_viewport_scrolls_up() {
 
     state.scroll_message_viewport_up();
     state.scroll_message_viewport_up();
+    state.scroll_message_viewport_up();
     push_message(&mut state, 11, "new after viewport scroll");
 
     let dump = render_dashboard_dump(100, 24, &mut state);
@@ -4012,7 +4062,7 @@ fn render_messages_shows_new_messages_notice_after_viewport_scrolls_up() {
 fn new_messages_notice_does_not_reserve_message_list_height() {
     let area = Rect::new(0, 0, 100, 24);
     let mut state = state_with_message();
-    for id in 2..=10 {
+    for id in 2..=30 {
         push_message(&mut state, id, &format!("older {id}"));
     }
     state.focus_pane(FocusPane::Messages);
@@ -4021,7 +4071,11 @@ fn new_messages_notice_does_not_reserve_message_list_height() {
     let height_without_notice = state.message_view_height();
 
     state.scroll_message_viewport_up();
-    push_message(&mut state, 11, "first unread");
+    state.scroll_message_viewport_up();
+    state.scroll_message_viewport_up();
+    state.scroll_message_viewport_up();
+    state.scroll_message_viewport_up();
+    push_message(&mut state, 31, "first unread");
     sync_view_heights(area, &mut state);
 
     assert_eq!(state.new_messages_count(), 1);

--- a/src/tui/ui/tests.rs
+++ b/src/tui/ui/tests.rs
@@ -21,13 +21,13 @@ use super::{
     format_message_sent_time, format_unix_millis_with_offset, forum_post_reaction_summary,
     forum_post_scrollbar_visible_count, forum_post_viewport_lines, inline_image_preview_area,
     inline_image_preview_row, member_display_label, member_name_style, message_action_menu_lines,
-    message_author_style, message_item_lines, message_starts_new_day, message_viewport_lines,
-    new_messages_notice_line, options_popup_lines, poll_vote_picker_lines,
-    primary_activity_summary, reaction_users_popup_lines, reaction_users_visible_line_count,
-    render_channels, render_guilds, selected_avatar_x_offset, selected_message_card_width,
-    selected_message_content_x_offset, sync_view_heights, user_profile_popup_has_avatar,
-    user_profile_popup_lines, user_profile_popup_lines_with_activities,
-    user_profile_popup_text_geometry,
+    message_author_style, message_body_custom_emoji_rows, message_item_lines,
+    message_starts_new_day, message_viewport_lines, new_messages_notice_line, options_popup_lines,
+    poll_vote_picker_lines, primary_activity_summary, reaction_users_popup_lines,
+    reaction_users_visible_line_count, render_channels, render_guilds, selected_avatar_x_offset,
+    selected_message_card_width, selected_message_content_x_offset, sync_view_heights,
+    user_profile_popup_has_avatar, user_profile_popup_lines,
+    user_profile_popup_lines_with_activities, user_profile_popup_text_geometry,
 };
 use crate::{
     config::DisplayOptions,
@@ -3651,6 +3651,72 @@ fn message_viewport_lines_group_consecutive_messages_by_author() {
 }
 
 #[test]
+fn message_viewport_lines_start_new_author_group_after_time_gap() {
+    let base = 1_743_465_600_000;
+    let mut state = state_with_message_id(snowflake_for_unix_ms(base), "hello");
+    push_message_with_id(
+        &mut state,
+        snowflake_for_unix_ms(base + 7 * 60 * 1000),
+        "later follow-up",
+    );
+    state.jump_top();
+    let messages = state.messages();
+
+    let lines = message_viewport_lines(
+        &messages,
+        None,
+        &state,
+        super::message_viewport_layout(200, 80, 80, 16, 3),
+        &[],
+    );
+    let texts = line_texts_from_ratatui(&lines);
+
+    assert_eq!(texts.iter().filter(|text| text.contains("neo")).count(), 2);
+    assert!(state.message_starts_author_group_at(1));
+}
+
+#[test]
+fn selected_grouped_continuation_uses_empty_top_border() {
+    let mut state = state_with_message();
+    push_message(&mut state, 2, "follow-up");
+    state.jump_top();
+    let messages = state.messages();
+
+    let lines = message_viewport_lines(
+        &messages,
+        Some(1),
+        &state,
+        super::message_viewport_layout(200, 80, 80, 16, 3),
+        &[],
+    );
+    let texts = line_texts_from_ratatui(&lines);
+
+    assert!(texts[3].starts_with("╭"));
+    assert!(!texts[3].contains("follow-up"));
+    assert!(texts[4].starts_with("│"));
+    assert!(texts[4].contains("follow-up"));
+}
+
+#[test]
+fn grouped_continuation_custom_emoji_image_uses_body_row() {
+    let mut state = state_with_message();
+    push_message(&mut state, 2, "<:long_custom:42>text");
+    state.jump_top();
+    let messages = state.messages();
+    let rows = message_body_custom_emoji_rows(
+        &messages,
+        &state,
+        200,
+        None,
+        &["https://cdn.discordapp.com/emojis/42.png".to_owned()],
+        16,
+        3,
+    );
+
+    assert_eq!(rows, vec![3]);
+}
+
+#[test]
 fn message_viewport_lines_keep_reactions_below_reacted_grouped_message() {
     let mut state = state_with_message();
     state.push_event(AppEvent::MessageReactionAdd {
@@ -4468,6 +4534,10 @@ fn youtube_embed() -> EmbedInfo {
 }
 
 fn state_with_message() -> DashboardState {
+    state_with_message_id(Id::new(1), "hello")
+}
+
+fn state_with_message_id(message_id: Id<MessageMarker>, content: &str) -> DashboardState {
     let guild_id = Id::new(1);
     let channel_id = Id::new(2);
     let mut state = DashboardState::new();
@@ -4504,7 +4574,7 @@ fn state_with_message() -> DashboardState {
     state.push_event(AppEvent::MessageCreate {
         guild_id: Some(guild_id),
         channel_id,
-        message_id: Id::new(1),
+        message_id,
         author_id: Id::new(99),
         author: "neo".to_owned(),
         author_avatar_url: None,
@@ -4513,7 +4583,7 @@ fn state_with_message() -> DashboardState {
         reference: None,
         reply: None,
         poll: None,
-        content: Some("hello".to_owned()),
+        content: Some(content.to_owned()),
         sticker_names: Vec::new(),
         mentions: Vec::new(),
         attachments: Vec::new(),
@@ -4666,10 +4736,14 @@ fn state_with_unread_direct_messages_with_loaded_unread_messages(count: u64) -> 
 }
 
 fn push_message(state: &mut DashboardState, message_id: u64, content: &str) {
+    push_message_with_id(state, Id::new(message_id), content);
+}
+
+fn push_message_with_id(state: &mut DashboardState, message_id: Id<MessageMarker>, content: &str) {
     state.push_event(AppEvent::MessageCreate {
         guild_id: Some(Id::new(1)),
         channel_id: Id::new(2),
-        message_id: Id::new(message_id),
+        message_id,
         author_id: Id::new(99),
         author: "neo".to_owned(),
         author_avatar_url: None,


### PR DESCRIPTION
## Problem

When a single person sends multiple messages in a row, the main messages panel can get polluted and unnecessarily noisy.

## Proposed solution

Here I group the messages by sender and display as a chunk.  We still respect reactions, as well as unread message and day/date splitters.

Closes #54

### Screenshots

<img width="402" height="218" alt="Screenshot 2026-05-12 at 6 00 56 PM" src="https://github.com/user-attachments/assets/bcb44b3b-d5ad-4e90-b790-89c9676db038" />

<img width="469" height="213" alt="Screenshot 2026-05-12 at 6 01 05 PM" src="https://github.com/user-attachments/assets/5fb31086-0683-4b26-aadc-c22e1f6aa24a" />