### PR TITLE
Add configurable keybindings, editor compose, and pane search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,6 +595,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ tokio-tungstenite = { version = "0.27", default-features = false, features = [
   "handshake",
   "rustls-tls-webpki-roots",
 ] }
+tempfile = "3"
 toml = "1.1.2"
 unicode-segmentation = "1.12.0"
 unicode-width = "0.2.2"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     fs,
     path::{Path, PathBuf},
 };
@@ -84,79 +85,25 @@ impl DisplayOptions {
     }
 }
 
-/// Raw key-binding strings from the config file, e.g. `"ctrl+e"`.
+/// Raw key-binding overrides from the config file, as a map of action name →
+/// key spec string (e.g. `"ctrl+e"`).  Only entries that differ from the
+/// built-in defaults need to be present; absent entries use the defaults
+/// defined in `Action::default_binding`.
 ///
-/// Each field accepts a key spec of the form `[modifier+]key` where modifier
+/// Each value accepts a key spec of the form `[modifier+]key` where modifier
 /// is one of `ctrl`, `alt`, `shift` and key is a single character, `space`,
-/// or a special name (`enter`, `esc`, `tab`, `f1`–`f12`, `pageup`, etc.).
+/// or a special name (`enter`, `esc`, `tab`, `backtab`, `f1`–`f12`, …).
 /// Unrecognised specs silently fall back to the built-in default.
 ///
 /// Example `~/.config/concord/config.toml`:
 /// ```toml
 /// [keybindings]
-/// move_down       = "ctrl+n"
-/// move_up         = "ctrl+p"
-/// open_composer   = "a"
+/// move_down     = "ctrl+n"
+/// move_up       = "ctrl+p"
+/// open_composer = "a"
 /// ```
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(default)]
-pub struct KeyBindingsConfig {
-    /// Open the current composer buffer in `$EDITOR`. Default: `ctrl+e`.
-    pub open_in_editor: String,
-    /// Quit the application. Default: `q`.
-    pub quit: String,
-    /// Open the message composer. Default: `i`.
-    pub open_composer: String,
-    /// Open the leader menu. Default: `space`.
-    pub open_leader: String,
-    /// Open the keybinding help popup. Default: `?`.
-    pub open_keymap: String,
-    /// Open the pane search/filter bar. Default: `/`.
-    pub pane_search: String,
-    /// Move selection down. Arrow-down always works as an alternate. Default: `j`.
-    pub move_down: String,
-    /// Move selection up. Arrow-up always works as an alternate. Default: `k`.
-    pub move_up: String,
-    /// Jump to the top of the list. Default: `g`.
-    pub jump_top: String,
-    /// Jump to the bottom of the list. Default: `shift+g` (G).
-    pub jump_bottom: String,
-    /// Scroll down by half a page. PageDown always works as an alternate. Default: `ctrl+d`.
-    pub half_page_down: String,
-    /// Scroll up by half a page. PageUp always works as an alternate. Default: `ctrl+u`.
-    pub half_page_up: String,
-    /// Scroll the message viewport down (Messages pane only). Default: `shift+j` (J).
-    pub scroll_viewport_down: String,
-    /// Scroll the message viewport up (Messages pane only). Default: `shift+k` (K).
-    pub scroll_viewport_up: String,
-    /// Scroll the focused pane horizontally left. Default: `shift+h` (H).
-    pub scroll_pane_left: String,
-    /// Scroll the focused pane horizontally right. Default: `shift+l` (L).
-    pub scroll_pane_right: String,
-}
-
-impl Default for KeyBindingsConfig {
-    fn default() -> Self {
-        Self {
-            open_in_editor: "ctrl+e".to_owned(),
-            quit: "q".to_owned(),
-            open_composer: "i".to_owned(),
-            open_leader: "space".to_owned(),
-            open_keymap: "?".to_owned(),
-            pane_search: "/".to_owned(),
-            move_down: "j".to_owned(),
-            move_up: "k".to_owned(),
-            jump_top: "g".to_owned(),
-            jump_bottom: "shift+g".to_owned(),
-            half_page_down: "ctrl+d".to_owned(),
-            half_page_up: "ctrl+u".to_owned(),
-            scroll_viewport_down: "shift+j".to_owned(),
-            scroll_viewport_up: "shift+k".to_owned(),
-            scroll_pane_left: "shift+h".to_owned(),
-            scroll_pane_right: "shift+l".to_owned(),
-        }
-    }
-}
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct KeyBindingsConfig(pub HashMap<String, String>);
 
 #[derive(Debug, Default, Deserialize, Serialize)]
 #[serde(default)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -81,15 +81,101 @@ impl DisplayOptions {
     }
 }
 
+/// Raw key-binding strings from the config file, e.g. `"ctrl+e"`.
+///
+/// Each field accepts a key spec of the form `[modifier+]key` where modifier
+/// is one of `ctrl`, `alt`, `shift` and key is a single character, `space`,
+/// or a special name (`enter`, `esc`, `tab`, `f1`–`f12`, `pageup`, etc.).
+/// Unrecognised specs silently fall back to the built-in default.
+///
+/// Example `~/.config/concord/config.toml`:
+/// ```toml
+/// [keybindings]
+/// move_down       = "ctrl+n"
+/// move_up         = "ctrl+p"
+/// open_composer   = "a"
+/// ```
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(default)]
+pub struct KeyBindingsConfig {
+    /// Open the current composer buffer in `$EDITOR`. Default: `ctrl+e`.
+    pub open_in_editor: String,
+    /// Quit the application. Default: `q`.
+    pub quit: String,
+    /// Open the message composer. Default: `i`.
+    pub open_composer: String,
+    /// Open the leader menu. Default: `space`.
+    pub open_leader: String,
+    /// Open the keybinding help popup. Default: `?`.
+    pub open_keymap: String,
+    /// Open the pane search/filter bar. Default: `/`.
+    pub pane_search: String,
+    /// Move selection down. Arrow-down always works as an alternate. Default: `j`.
+    pub move_down: String,
+    /// Move selection up. Arrow-up always works as an alternate. Default: `k`.
+    pub move_up: String,
+    /// Jump to the top of the list. Default: `g`.
+    pub jump_top: String,
+    /// Jump to the bottom of the list. Default: `shift+g` (G).
+    pub jump_bottom: String,
+    /// Scroll down by half a page. PageDown always works as an alternate. Default: `ctrl+d`.
+    pub half_page_down: String,
+    /// Scroll up by half a page. PageUp always works as an alternate. Default: `ctrl+u`.
+    pub half_page_up: String,
+    /// Scroll the message viewport down (Messages pane only). Default: `shift+j` (J).
+    pub scroll_viewport_down: String,
+    /// Scroll the message viewport up (Messages pane only). Default: `shift+k` (K).
+    pub scroll_viewport_up: String,
+    /// Scroll the focused pane horizontally left. Default: `shift+h` (H).
+    pub scroll_pane_left: String,
+    /// Scroll the focused pane horizontally right. Default: `shift+l` (L).
+    pub scroll_pane_right: String,
+}
+
+impl Default for KeyBindingsConfig {
+    fn default() -> Self {
+        Self {
+            open_in_editor: "ctrl+e".to_owned(),
+            quit: "q".to_owned(),
+            open_composer: "i".to_owned(),
+            open_leader: "space".to_owned(),
+            open_keymap: "?".to_owned(),
+            pane_search: "/".to_owned(),
+            move_down: "j".to_owned(),
+            move_up: "k".to_owned(),
+            jump_top: "g".to_owned(),
+            jump_bottom: "shift+g".to_owned(),
+            half_page_down: "ctrl+d".to_owned(),
+            half_page_up: "ctrl+u".to_owned(),
+            scroll_viewport_down: "shift+j".to_owned(),
+            scroll_viewport_up: "shift+k".to_owned(),
+            scroll_pane_left: "shift+h".to_owned(),
+            scroll_pane_right: "shift+l".to_owned(),
+        }
+    }
+}
+
 #[derive(Debug, Default, Deserialize, Serialize)]
 #[serde(default)]
 struct AppConfig {
     display: DisplayOptions,
+    keybindings: KeyBindingsConfig,
 }
 
 pub fn load_display_options() -> Result<DisplayOptions> {
     let path = config_path()?;
     load_display_options_from_path(&path)
+}
+
+pub fn load_key_bindings_config() -> Result<KeyBindingsConfig> {
+    let path = config_path()?;
+    match std::fs::read_to_string(&path) {
+        Ok(content) => Ok(toml::from_str::<AppConfig>(&content)?.keybindings),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            Ok(KeyBindingsConfig::default())
+        }
+        Err(error) => Err(error.into()),
+    }
 }
 
 /// User-facing description of where config lives, e.g. for help text. Falls
@@ -121,7 +207,13 @@ fn save_display_options_to_path(path: &Path, options: &DisplayOptions) -> Result
         set_private_dir_permissions(parent)?;
     }
 
-    let config = AppConfig { display: *options };
+    // Load the existing config so other sections (e.g. [keybindings]) are
+    // preserved. Fall back to defaults when the file is missing or unparseable.
+    let mut config = match fs::read_to_string(path) {
+        Ok(content) => toml::from_str::<AppConfig>(&content).unwrap_or_default(),
+        Err(_) => AppConfig::default(),
+    };
+    config.display = *options;
     write_private_file(path, &toml::to_string_pretty(&config)?)
 }
 
@@ -185,8 +277,8 @@ mod tests {
     };
 
     use super::{
-        AppConfig, DisplayOptions, ImagePreviewQualityPreset, load_display_options_from_path,
-        save_display_options_to_path,
+        AppConfig, DisplayOptions, ImagePreviewQualityPreset, KeyBindingsConfig,
+        load_display_options_from_path, save_display_options_to_path,
     };
 
     #[test]
@@ -269,6 +361,54 @@ mod tests {
         let loaded = load_display_options_from_path(&path).expect("config should load");
 
         assert_eq!(loaded, options);
+        let _ = fs::remove_file(&path);
+        if let Some(parent) = path.parent() {
+            let _ = fs::remove_dir_all(parent);
+        }
+    }
+
+    #[test]
+    fn keybindings_default_to_ctrl_e() {
+        let config = KeyBindingsConfig::default();
+        assert_eq!(config.open_in_editor, "ctrl+e");
+    }
+
+    #[test]
+    fn keybindings_config_parses_from_toml() {
+        let toml = "[keybindings]\nopen_in_editor = \"ctrl+o\"\n";
+        let config: AppConfig = toml::from_str(toml).expect("should parse");
+        assert_eq!(config.keybindings.open_in_editor, "ctrl+o");
+    }
+
+    #[test]
+    fn keybindings_config_defaults_when_section_absent() {
+        let toml = "[display]\ndisable_image_preview = true\n";
+        let config: AppConfig = toml::from_str(toml).expect("should parse");
+        assert_eq!(config.keybindings.open_in_editor, "ctrl+e");
+    }
+
+    #[test]
+    fn save_display_options_preserves_keybindings() {
+        let path = test_config_path();
+
+        // Write a config that has a custom keybinding.
+        let initial = "[keybindings]\nopen_in_editor = \"alt+e\"\n";
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("should create dir");
+        }
+        fs::write(&path, initial).expect("should write initial config");
+
+        // Save display options — must not clobber the keybinding.
+        let options = DisplayOptions::default();
+        save_display_options_to_path(&path, &options).expect("should save");
+
+        let content = fs::read_to_string(&path).expect("should read back");
+        let config: AppConfig = toml::from_str(&content).expect("should parse back");
+        assert_eq!(
+            config.keybindings.open_in_editor, "alt+e",
+            "keybinding should survive a display-options save"
+        );
+
         let _ = fs::remove_file(&path);
         if let Some(parent) = path.parent() {
             let _ = fs::remove_dir_all(parent);

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,13 +29,16 @@ pub enum ImagePreviewQualityPreset {
     Balanced,
     High,
     Original,
+    /// Alias for `balanced`; accepted so configs that say `"auto"` still load.
+    #[serde(rename = "auto")]
+    Auto,
 }
 
 impl ImagePreviewQualityPreset {
     pub fn label(self) -> &'static str {
         match self {
             Self::Efficient => "efficient",
-            Self::Balanced => "balanced",
+            Self::Balanced | Self::Auto => "balanced",
             Self::High => "high",
             Self::Original => "original",
         }
@@ -44,7 +47,7 @@ impl ImagePreviewQualityPreset {
     pub fn next(self) -> Self {
         match self {
             Self::Efficient => Self::Balanced,
-            Self::Balanced => Self::High,
+            Self::Balanced | Self::Auto => Self::High,
             Self::High => Self::Original,
             Self::Original => Self::Efficient,
         }
@@ -170,7 +173,7 @@ pub fn load_display_options() -> Result<DisplayOptions> {
 pub fn load_key_bindings_config() -> Result<KeyBindingsConfig> {
     let path = config_path()?;
     match std::fs::read_to_string(&path) {
-        Ok(content) => Ok(toml::from_str::<AppConfig>(&content)?.keybindings),
+        Ok(content) => Ok(section_from_toml::<KeyBindingsConfig>(&content, "keybindings")?),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
             Ok(KeyBindingsConfig::default())
         }
@@ -190,9 +193,25 @@ pub fn config_path_display() -> String {
 
 fn load_display_options_from_path(path: &Path) -> Result<DisplayOptions> {
     match fs::read_to_string(path) {
-        Ok(content) => Ok(toml::from_str::<AppConfig>(&content)?.display),
+        Ok(content) => Ok(section_from_toml::<DisplayOptions>(&content, "display")?),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(DisplayOptions::default()),
         Err(error) => Err(error.into()),
+    }
+}
+
+/// Parse a named top-level section from a TOML string, returning the section's
+/// value deserialized as `T`. If the section is absent, the `Default` is used.
+/// Parsing only the requested section means a bad value in another section
+/// (e.g. an unknown enum variant in `[display]`) won't prevent `[keybindings]`
+/// from loading, and vice versa.
+fn section_from_toml<T>(content: &str, section: &str) -> Result<T>
+where
+    T: Default + serde::de::DeserializeOwned,
+{
+    let mut table: toml::Table = toml::from_str(content)?;
+    match table.remove(section) {
+        Some(value) => Ok(T::deserialize(value)?),
+        None => Ok(T::default()),
     }
 }
 
@@ -368,23 +387,28 @@ mod tests {
     }
 
     #[test]
-    fn keybindings_default_to_ctrl_e() {
+    fn keybindings_default_is_empty_map() {
+        // Default config has no overrides; defaults come from Action::default_binding.
         let config = KeyBindingsConfig::default();
-        assert_eq!(config.open_in_editor, "ctrl+e");
+        assert!(config.0.is_empty());
     }
 
     #[test]
     fn keybindings_config_parses_from_toml() {
         let toml = "[keybindings]\nopen_in_editor = \"ctrl+o\"\n";
         let config: AppConfig = toml::from_str(toml).expect("should parse");
-        assert_eq!(config.keybindings.open_in_editor, "ctrl+o");
+        assert_eq!(
+            config.keybindings.0.get("open_in_editor").map(String::as_str),
+            Some("ctrl+o")
+        );
     }
 
     #[test]
-    fn keybindings_config_defaults_when_section_absent() {
+    fn keybindings_config_empty_when_section_absent() {
         let toml = "[display]\ndisable_image_preview = true\n";
         let config: AppConfig = toml::from_str(toml).expect("should parse");
-        assert_eq!(config.keybindings.open_in_editor, "ctrl+e");
+        // No overrides present — defaults handled by ActiveKeyBindings::from_config.
+        assert!(config.keybindings.0.is_empty());
     }
 
     #[test]
@@ -405,7 +429,8 @@ mod tests {
         let content = fs::read_to_string(&path).expect("should read back");
         let config: AppConfig = toml::from_str(&content).expect("should parse back");
         assert_eq!(
-            config.keybindings.open_in_editor, "alt+e",
+            config.keybindings.0.get("open_in_editor").map(String::as_str),
+            Some("alt+e"),
             "keybinding should survive a display-options save"
         );
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -120,7 +120,10 @@ pub fn load_display_options() -> Result<DisplayOptions> {
 pub fn load_key_bindings_config() -> Result<KeyBindingsConfig> {
     let path = config_path()?;
     match std::fs::read_to_string(&path) {
-        Ok(content) => Ok(section_from_toml::<KeyBindingsConfig>(&content, "keybindings")?),
+        Ok(content) => Ok(section_from_toml::<KeyBindingsConfig>(
+            &content,
+            "keybindings",
+        )?),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
             Ok(KeyBindingsConfig::default())
         }
@@ -345,7 +348,11 @@ mod tests {
         let toml = "[keybindings]\nopen_in_editor = \"ctrl+o\"\n";
         let config: AppConfig = toml::from_str(toml).expect("should parse");
         assert_eq!(
-            config.keybindings.0.get("open_in_editor").map(String::as_str),
+            config
+                .keybindings
+                .0
+                .get("open_in_editor")
+                .map(String::as_str),
             Some("ctrl+o")
         );
     }
@@ -376,7 +383,11 @@ mod tests {
         let content = fs::read_to_string(&path).expect("should read back");
         let config: AppConfig = toml::from_str(&content).expect("should parse back");
         assert_eq!(
-            config.keybindings.0.get("open_in_editor").map(String::as_str),
+            config
+                .keybindings
+                .0
+                .get("open_in_editor")
+                .map(String::as_str),
             Some("alt+e"),
             "keybinding should survive a display-options save"
         );

--- a/src/tui/input/keyboard.rs
+++ b/src/tui/input/keyboard.rs
@@ -64,6 +64,12 @@ pub fn handle_key(state: &mut DashboardState, key: KeyEvent) -> Option<AppComman
         return handle_user_profile_popup_key(state, key);
     }
 
+    if state.is_guild_pane_filter_active() || state.is_channel_pane_filter_active() {
+        if let Some(command) = handle_pane_filter_key(state, key) {
+            return command;
+        }
+    }
+
     let focus = state.focus();
     let kb = state.key_bindings().clone();
 
@@ -133,6 +139,14 @@ pub fn handle_key(state: &mut DashboardState, key: KeyEvent) -> Option<AppComman
         state.cycle_focus_backward();
     } else if key.code == KeyCode::Tab {
         state.cycle_focus();
+    } else if kb.pane_search.matches(key) {
+        // Tree headers act like a small tree: Enter toggles, Right
+        // opens, and Left closes. Anywhere else these keys are no-ops.
+        match focus {
+            FocusPane::Guilds => state.open_guild_pane_filter(),
+            FocusPane::Channels => state.open_channel_pane_filter(),
+            _ => {}
+        }
     } else if key.code == KeyCode::Enter && focus == FocusPane::Guilds {
         state.confirm_selected_guild();
     } else if key.code == KeyCode::Enter && focus == FocusPane::Channels {
@@ -439,6 +453,78 @@ fn handle_user_profile_popup_key(state: &mut DashboardState, key: KeyEvent) -> O
         _ => {}
     }
     None
+}
+
+/// Returns `Some(command)` when the filter handler has fully handled the key
+/// and the caller should return that command. Returns `None` when the key
+/// should fall through to normal navigation (e.g. j/k to scroll the list).
+fn handle_pane_filter_key(
+    state: &mut DashboardState,
+    key: KeyEvent,
+) -> Option<Option<AppCommand>> {
+    match key.code {
+        KeyCode::Esc => {
+            if state.is_guild_pane_filter_active() {
+                state.close_guild_pane_filter();
+            } else {
+                state.close_channel_pane_filter();
+            }
+            Some(None)
+        }
+        KeyCode::Enter => {
+            if state.is_guild_pane_filter_active() {
+                state.confirm_guild_pane_filter();
+                Some(None)
+            } else {
+                Some(state.confirm_channel_pane_filter())
+            }
+        }
+        KeyCode::Backspace => {
+            if state.is_guild_pane_filter_active() {
+                state.pop_guild_pane_filter_char();
+            } else {
+                state.pop_channel_pane_filter_char();
+            }
+            Some(None)
+        }
+        KeyCode::Left => {
+            if state.is_guild_pane_filter_active() {
+                state.move_guild_pane_filter_cursor_left();
+            } else {
+                state.move_channel_pane_filter_cursor_left();
+            }
+            Some(None)
+        }
+        KeyCode::Right => {
+            if state.is_guild_pane_filter_active() {
+                state.move_guild_pane_filter_cursor_right();
+            } else {
+                state.move_channel_pane_filter_cursor_right();
+            }
+            Some(None)
+        }
+        KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            state.quit();
+            Some(None)
+        }
+        KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            state.move_down();
+            Some(None)
+        }
+        KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            state.move_up();
+            Some(None)
+        }
+        KeyCode::Char(value) if is_shortcut_key(key) => {
+            if state.is_guild_pane_filter_active() {
+                state.push_guild_pane_filter_char(value);
+            } else {
+                state.push_channel_pane_filter_char(value);
+            }
+            Some(None)
+        }
+        _ => None, // fall through to normal navigation (arrows, j/k etc.)
+    }
 }
 
 fn handle_emoji_reaction_picker_key(

--- a/src/tui/input/keyboard.rs
+++ b/src/tui/input/keyboard.rs
@@ -247,6 +247,12 @@ fn dispatch_action(
             }
             None
         }
+        Action::React => {
+            if focus == FocusPane::Messages {
+                state.open_emoji_reaction_picker();
+            }
+            None
+        }
     }
 }
 

--- a/src/tui/input/keyboard.rs
+++ b/src/tui/input/keyboard.rs
@@ -576,6 +576,13 @@ fn handle_composer_key(state: &mut DashboardState, key: KeyEvent) -> Option<AppC
     {
         return command;
     }
+
+    // Check configurable bindings before the fixed-key match below.
+    if state.key_bindings().open_in_editor.matches(key) {
+        state.request_open_composer_in_editor();
+        return None;
+    }
+
     match key.code {
         KeyCode::Enter if key.modifiers.contains(KeyModifiers::SHIFT) => {
             state.push_composer_char('\n');

--- a/src/tui/input/keyboard.rs
+++ b/src/tui/input/keyboard.rs
@@ -4,6 +4,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 
 use crate::discord::{AppCommand, MessageAttachmentUpload};
 
+use super::super::keybinding::Action;
 use super::super::state::{DashboardState, FocusPane};
 
 pub fn handle_key(state: &mut DashboardState, key: KeyEvent) -> Option<AppCommand> {
@@ -31,7 +32,11 @@ pub fn handle_key(state: &mut DashboardState, key: KeyEvent) -> Option<AppComman
         return handle_composer_key(state, key);
     }
 
-    if key.code == KeyCode::Char('`') {
+    let action = state.key_bindings().lookup(key);
+
+    // ToggleDebugLog fires before any modal or filter — accessible from anywhere
+    // except while composing or with a popup already open.
+    if action == Some(Action::ToggleDebugLog) {
         state.toggle_debug_log_popup();
         return None;
     }
@@ -65,7 +70,6 @@ pub fn handle_key(state: &mut DashboardState, key: KeyEvent) -> Option<AppComman
     }
 
     let focus = state.focus();
-    let kb = state.key_bindings().clone();
 
     // Only intercept filter input when the pane that owns the filter is still
     // focused. Moving the mouse to another pane should let normal keybinds
@@ -73,76 +77,177 @@ pub fn handle_key(state: &mut DashboardState, key: KeyEvent) -> Option<AppComman
     if (state.is_guild_pane_filter_active() && focus == FocusPane::Guilds)
         || (state.is_channel_pane_filter_active() && focus == FocusPane::Channels)
     {
-        state.adjust_focused_pane_width(-1);
-    } else if (key.code == KeyCode::Char('l') || key.code == KeyCode::Right)
-        && key.modifiers.contains(KeyModifiers::ALT)
-    {
-        state.adjust_focused_pane_width(1);
-    } else if kb.move_down.matches(key) || key.code == KeyCode::Down {
-        state.move_down();
-    } else if kb.scroll_viewport_down.matches(key) && focus == FocusPane::Messages {
-        state.scroll_message_viewport_down();
-    } else if kb.scroll_pane_right.matches(key) {
-        state.scroll_focused_pane_horizontal_right();
-    } else if kb.move_up.matches(key) || key.code == KeyCode::Up {
-        state.move_up();
-        return state.next_older_history_command();
-    } else if kb.scroll_viewport_up.matches(key) && focus == FocusPane::Messages {
-        state.scroll_message_viewport_up();
-    } else if kb.scroll_pane_left.matches(key) {
-        state.scroll_focused_pane_horizontal_left();
-    } else if kb.half_page_down.matches(key) || key.code == KeyCode::PageDown {
-        state.half_page_down();
-    } else if kb.half_page_up.matches(key) || key.code == KeyCode::PageUp {
-        state.half_page_up();
-        return state.next_older_history_command();
-    } else if kb.jump_top.matches(key) {
-        state.jump_top();
-    } else if key.code == KeyCode::Home {
-        if focus == FocusPane::Messages {
-            state.scroll_message_viewport_top();
-        } else {
-            state.jump_top();
+        if let Some(command) = handle_pane_filter_key(state, key, focus) {
+            return command;
         }
-    } else if kb.jump_bottom.matches(key) {
-        state.jump_bottom();
-    } else if key.code == KeyCode::End {
-        if focus == FocusPane::Messages {
-            state.scroll_message_viewport_bottom();
-        } else {
-            state.jump_bottom();
-        }
-    } else if key.code == KeyCode::BackTab {
-        state.cycle_focus_backward();
-    } else if key.code == KeyCode::Tab {
-        state.cycle_focus();
-    } else if kb.pane_search.matches(key) {
-        // Tree headers act like a small tree: Enter toggles, Right
-        // opens, and Left closes. Anywhere else these keys are no-ops.
-        match focus {
-            FocusPane::Guilds => state.open_guild_pane_filter(),
-            FocusPane::Channels => state.open_channel_pane_filter(),
-            _ => {}
-        }
-    } else if key.code == KeyCode::Enter && focus == FocusPane::Guilds {
-        state.confirm_selected_guild();
-    } else if key.code == KeyCode::Enter && focus == FocusPane::Channels {
-        return state.confirm_selected_channel_command();
-    } else if key.code == KeyCode::Enter && focus == FocusPane::Members {
-        return state.show_selected_member_profile();
-    } else if key.code == KeyCode::Enter && focus == FocusPane::Messages {
-        return state.activate_selected_message_pane_item();
-    } else if is_right_key(key.code) && focus == FocusPane::Guilds {
-        state.open_selected_folder();
-    } else if is_left_key(key.code) && focus == FocusPane::Guilds {
-        state.close_selected_folder();
-    } else if is_right_key(key.code) && focus == FocusPane::Channels {
-        state.open_selected_channel_category();
-    } else if is_left_key(key.code) && focus == FocusPane::Channels {
-        state.close_selected_channel_category();
     }
 
-    None
+    if let Some(action) = action {
+        dispatch_action(state, action, focus)
+    } else {
+        None
+    }
+}
+
+fn dispatch_action(
+    state: &mut DashboardState,
+    action: Action,
+    focus: FocusPane,
+) -> Option<AppCommand> {
+    match action {
+        Action::Quit => {
+            state.quit();
+            None
+        }
+        Action::Return => {
+            if !state.return_from_pinned_message_view() {
+                state.return_from_opened_thread();
+            }
+            None
+        }
+        Action::ToggleDebugLog => {
+            state.toggle_debug_log_popup();
+            None
+        }
+        Action::FocusGuilds => {
+            state.show_and_focus_pane(FocusPane::Guilds);
+            None
+        }
+        Action::FocusChannels => {
+            state.show_and_focus_pane(FocusPane::Channels);
+            None
+        }
+        Action::FocusMessages => {
+            state.show_and_focus_pane(FocusPane::Messages);
+            None
+        }
+        Action::FocusMembers => {
+            state.show_and_focus_pane(FocusPane::Members);
+            None
+        }
+        Action::CycleFocusForward => {
+            state.cycle_focus();
+            None
+        }
+        Action::CycleFocusBackward => {
+            state.cycle_focus_backward();
+            None
+        }
+        Action::OpenComposer => {
+            state.start_composer();
+            None
+        }
+        Action::OpenInEditor => None, // only valid inside the composer context
+        Action::OpenKeymap => {
+            state.open_keymap_popup();
+            None
+        }
+        Action::OpenLeader => {
+            state.open_leader();
+            None
+        }
+        Action::PaneSearch => {
+            match focus {
+                FocusPane::Guilds => state.open_guild_pane_filter(),
+                FocusPane::Channels => state.open_channel_pane_filter(),
+                _ => {}
+            }
+            None
+        }
+        Action::MoveDown => {
+            state.move_down();
+            None
+        }
+        Action::MoveUp => {
+            state.move_up();
+            state.next_older_history_command()
+        }
+        Action::HalfPageDown => {
+            state.half_page_down();
+            None
+        }
+        Action::HalfPageUp => {
+            state.half_page_up();
+            state.next_older_history_command()
+        }
+        Action::JumpTop => {
+            state.jump_top();
+            None
+        }
+        Action::JumpBottom => {
+            state.jump_bottom();
+            None
+        }
+        Action::ScrollTop => {
+            if focus == FocusPane::Messages {
+                state.scroll_message_viewport_top();
+            } else {
+                state.jump_top();
+            }
+            None
+        }
+        Action::ScrollBottom => {
+            if focus == FocusPane::Messages {
+                state.scroll_message_viewport_bottom();
+            } else {
+                state.jump_bottom();
+            }
+            None
+        }
+        Action::ScrollViewportDown => {
+            if focus == FocusPane::Messages {
+                state.scroll_message_viewport_down();
+            }
+            None
+        }
+        Action::ScrollViewportUp => {
+            if focus == FocusPane::Messages {
+                state.scroll_message_viewport_up();
+            }
+            None
+        }
+        Action::ScrollPaneLeft => {
+            state.scroll_focused_pane_horizontal_left();
+            None
+        }
+        Action::ScrollPaneRight => {
+            state.scroll_focused_pane_horizontal_right();
+            None
+        }
+        Action::NarrowPane => {
+            state.adjust_focused_pane_width(-1);
+            None
+        }
+        Action::WidenPane => {
+            state.adjust_focused_pane_width(1);
+            None
+        }
+        Action::Confirm => match focus {
+            FocusPane::Guilds => {
+                state.confirm_selected_guild();
+                None
+            }
+            FocusPane::Channels => state.confirm_selected_channel_command(),
+            FocusPane::Members => state.show_selected_member_profile(),
+            FocusPane::Messages => state.activate_selected_message_pane_item(),
+        },
+        Action::ExpandRight => {
+            match focus {
+                FocusPane::Guilds => state.open_selected_folder(),
+                FocusPane::Channels => state.open_selected_channel_category(),
+                _ => {}
+            }
+            None
+        }
+        Action::CollapseLeft => {
+            match focus {
+                FocusPane::Guilds => state.close_selected_folder(),
+                FocusPane::Channels => state.close_selected_channel_category(),
+                _ => {}
+            }
+            None
+        }
+    }
 }
 
 fn handle_leader_key(state: &mut DashboardState, key: KeyEvent) -> Option<AppCommand> {
@@ -643,7 +748,7 @@ fn handle_composer_key(state: &mut DashboardState, key: KeyEvent) -> Option<AppC
     }
 
     // Check configurable bindings before the fixed-key match below.
-    if state.key_bindings().open_in_editor.matches(key) {
+    if state.key_bindings().lookup(key) == Some(Action::OpenInEditor) {
         state.request_open_composer_in_editor();
         return None;
     }

--- a/src/tui/input/keyboard.rs
+++ b/src/tui/input/keyboard.rs
@@ -458,10 +458,7 @@ fn handle_user_profile_popup_key(state: &mut DashboardState, key: KeyEvent) -> O
 /// Returns `Some(command)` when the filter handler has fully handled the key
 /// and the caller should return that command. Returns `None` when the key
 /// should fall through to normal navigation (e.g. j/k to scroll the list).
-fn handle_pane_filter_key(
-    state: &mut DashboardState,
-    key: KeyEvent,
-) -> Option<Option<AppCommand>> {
+fn handle_pane_filter_key(state: &mut DashboardState, key: KeyEvent) -> Option<Option<AppCommand>> {
     match key.code {
         KeyCode::Esc => {
             if state.is_guild_pane_filter_active() {

--- a/src/tui/input/keyboard.rs
+++ b/src/tui/input/keyboard.rs
@@ -11,6 +11,10 @@ pub fn handle_key(state: &mut DashboardState, key: KeyEvent) -> Option<AppComman
         return None;
     }
 
+    if state.is_keymap_popup_open() {
+        return handle_keymap_popup_key(state, key);
+    }
+
     if state.is_debug_log_popup_open() {
         return handle_debug_log_popup_key(state, key);
     }
@@ -61,85 +65,90 @@ pub fn handle_key(state: &mut DashboardState, key: KeyEvent) -> Option<AppComman
     }
 
     let focus = state.focus();
-    match key.code {
-        KeyCode::Esc if !state.return_from_pinned_message_view() => {
-            state.return_from_opened_thread();
-        }
-        KeyCode::Char('q') => state.quit(),
-        KeyCode::Char('i') => state.start_composer(),
-        KeyCode::Char(' ') if is_shortcut_key(key) => state.open_leader(),
-        KeyCode::Char('1') => state.show_and_focus_pane(FocusPane::Guilds),
-        KeyCode::Char('2') => state.show_and_focus_pane(FocusPane::Channels),
-        KeyCode::Char('3') => state.show_and_focus_pane(FocusPane::Messages),
-        KeyCode::Char('4') => state.show_and_focus_pane(FocusPane::Members),
-        KeyCode::Char('h') | KeyCode::Left if key.modifiers.contains(KeyModifiers::ALT) => {
-            state.adjust_focused_pane_width(-1)
-        }
-        KeyCode::Char('l') | KeyCode::Right if key.modifiers.contains(KeyModifiers::ALT) => {
-            state.adjust_focused_pane_width(1)
-        }
-        KeyCode::Char('j') | KeyCode::Down => state.move_down(),
-        KeyCode::Char('J') if focus == FocusPane::Messages => state.scroll_message_viewport_down(),
-        KeyCode::Char('L') => state.scroll_focused_pane_horizontal_right(),
-        KeyCode::Char('k') | KeyCode::Up => {
-            state.move_up();
-            return state.next_older_history_command();
-        }
-        KeyCode::Char('K') if focus == FocusPane::Messages => state.scroll_message_viewport_up(),
-        KeyCode::Char('H') => state.scroll_focused_pane_horizontal_left(),
-        KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-            state.half_page_down()
-        }
-        KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-            state.half_page_up();
-            return state.next_older_history_command();
-        }
-        KeyCode::PageDown => state.half_page_down(),
-        KeyCode::PageUp => {
-            state.half_page_up();
-            return state.next_older_history_command();
-        }
-        KeyCode::Char('g') => {
+    let kb = state.key_bindings().clone();
+
+    if key.code == KeyCode::Esc && !state.return_from_pinned_message_view() {
+        state.return_from_opened_thread();
+    } else if kb.quit.matches(key) {
+        state.quit();
+    } else if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+        state.quit();
+    } else if kb.open_composer.matches(key) {
+        state.start_composer();
+    } else if kb.open_keymap.matches(key) {
+        state.open_keymap_popup();
+    } else if kb.open_leader.matches(key) {
+        state.open_leader();
+    } else if key.code == KeyCode::Char('1') {
+        state.show_and_focus_pane(FocusPane::Guilds);
+    } else if key.code == KeyCode::Char('2') {
+        state.show_and_focus_pane(FocusPane::Channels);
+    } else if key.code == KeyCode::Char('3') {
+        state.show_and_focus_pane(FocusPane::Messages);
+    } else if key.code == KeyCode::Char('4') {
+        state.show_and_focus_pane(FocusPane::Members);
+    } else if (key.code == KeyCode::Char('h') || key.code == KeyCode::Left)
+        && key.modifiers.contains(KeyModifiers::ALT)
+    {
+        state.adjust_focused_pane_width(-1);
+    } else if (key.code == KeyCode::Char('l') || key.code == KeyCode::Right)
+        && key.modifiers.contains(KeyModifiers::ALT)
+    {
+        state.adjust_focused_pane_width(1);
+    } else if kb.move_down.matches(key) || key.code == KeyCode::Down {
+        state.move_down();
+    } else if kb.scroll_viewport_down.matches(key) && focus == FocusPane::Messages {
+        state.scroll_message_viewport_down();
+    } else if kb.scroll_pane_right.matches(key) {
+        state.scroll_focused_pane_horizontal_right();
+    } else if kb.move_up.matches(key) || key.code == KeyCode::Up {
+        state.move_up();
+        return state.next_older_history_command();
+    } else if kb.scroll_viewport_up.matches(key) && focus == FocusPane::Messages {
+        state.scroll_message_viewport_up();
+    } else if kb.scroll_pane_left.matches(key) {
+        state.scroll_focused_pane_horizontal_left();
+    } else if kb.half_page_down.matches(key) || key.code == KeyCode::PageDown {
+        state.half_page_down();
+    } else if kb.half_page_up.matches(key) || key.code == KeyCode::PageUp {
+        state.half_page_up();
+        return state.next_older_history_command();
+    } else if kb.jump_top.matches(key) {
+        state.jump_top();
+    } else if key.code == KeyCode::Home {
+        if focus == FocusPane::Messages {
+            state.scroll_message_viewport_top();
+        } else {
             state.jump_top();
         }
-        KeyCode::Home => {
-            if focus == FocusPane::Messages {
-                state.scroll_message_viewport_top();
-            } else {
-                state.jump_top();
-            }
+    } else if kb.jump_bottom.matches(key) {
+        state.jump_bottom();
+    } else if key.code == KeyCode::End {
+        if focus == FocusPane::Messages {
+            state.scroll_message_viewport_bottom();
+        } else {
+            state.jump_bottom();
         }
-        KeyCode::Char('G') => state.jump_bottom(),
-        KeyCode::End => {
-            if focus == FocusPane::Messages {
-                state.scroll_message_viewport_bottom();
-            } else {
-                state.jump_bottom();
-            }
-        }
-        KeyCode::BackTab => state.cycle_focus_backward(),
-        KeyCode::Tab => state.cycle_focus(),
-        // Tree headers act like a small tree: Enter toggles, Right
-        // opens, and Left closes. Anywhere else these keys are no-ops.
-        KeyCode::Enter if focus == FocusPane::Guilds => state.confirm_selected_guild(),
-        KeyCode::Enter if focus == FocusPane::Channels => {
-            return state.confirm_selected_channel_command();
-        }
-        KeyCode::Enter if focus == FocusPane::Members => {
-            return state.show_selected_member_profile();
-        }
-        KeyCode::Enter if focus == FocusPane::Messages => {
-            return state.activate_selected_message_pane_item();
-        }
-        code if is_right_key(code) && focus == FocusPane::Guilds => state.open_selected_folder(),
-        code if is_left_key(code) && focus == FocusPane::Guilds => state.close_selected_folder(),
-        code if is_right_key(code) && focus == FocusPane::Channels => {
-            state.open_selected_channel_category()
-        }
-        code if is_left_key(code) && focus == FocusPane::Channels => {
-            state.close_selected_channel_category()
-        }
-        _ => {}
+    } else if key.code == KeyCode::BackTab {
+        state.cycle_focus_backward();
+    } else if key.code == KeyCode::Tab {
+        state.cycle_focus();
+    } else if key.code == KeyCode::Enter && focus == FocusPane::Guilds {
+        state.confirm_selected_guild();
+    } else if key.code == KeyCode::Enter && focus == FocusPane::Channels {
+        return state.confirm_selected_channel_command();
+    } else if key.code == KeyCode::Enter && focus == FocusPane::Members {
+        return state.show_selected_member_profile();
+    } else if key.code == KeyCode::Enter && focus == FocusPane::Messages {
+        return state.activate_selected_message_pane_item();
+    } else if is_right_key(key.code) && focus == FocusPane::Guilds {
+        state.open_selected_folder();
+    } else if is_left_key(key.code) && focus == FocusPane::Guilds {
+        state.close_selected_folder();
+    } else if is_right_key(key.code) && focus == FocusPane::Channels {
+        state.open_selected_channel_category();
+    } else if is_left_key(key.code) && focus == FocusPane::Channels {
+        state.close_selected_channel_category();
     }
 
     None
@@ -494,6 +503,14 @@ fn handle_reaction_users_popup_key(
         _ => {}
     }
 
+    None
+}
+
+fn handle_keymap_popup_key(state: &mut DashboardState, key: KeyEvent) -> Option<AppCommand> {
+    match key.code {
+        KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('?') => state.close_keymap_popup(),
+        _ => {}
+    }
     None
 }
 

--- a/src/tui/input/keyboard.rs
+++ b/src/tui/input/keyboard.rs
@@ -64,37 +64,14 @@ pub fn handle_key(state: &mut DashboardState, key: KeyEvent) -> Option<AppComman
         return handle_user_profile_popup_key(state, key);
     }
 
-    if state.is_guild_pane_filter_active() || state.is_channel_pane_filter_active() {
-        if let Some(command) = handle_pane_filter_key(state, key) {
-            return command;
-        }
-    }
-
     let focus = state.focus();
     let kb = state.key_bindings().clone();
 
-    if key.code == KeyCode::Esc && !state.return_from_pinned_message_view() {
-        state.return_from_opened_thread();
-    } else if kb.quit.matches(key) {
-        state.quit();
-    } else if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
-        state.quit();
-    } else if kb.open_composer.matches(key) {
-        state.start_composer();
-    } else if kb.open_keymap.matches(key) {
-        state.open_keymap_popup();
-    } else if kb.open_leader.matches(key) {
-        state.open_leader();
-    } else if key.code == KeyCode::Char('1') {
-        state.show_and_focus_pane(FocusPane::Guilds);
-    } else if key.code == KeyCode::Char('2') {
-        state.show_and_focus_pane(FocusPane::Channels);
-    } else if key.code == KeyCode::Char('3') {
-        state.show_and_focus_pane(FocusPane::Messages);
-    } else if key.code == KeyCode::Char('4') {
-        state.show_and_focus_pane(FocusPane::Members);
-    } else if (key.code == KeyCode::Char('h') || key.code == KeyCode::Left)
-        && key.modifiers.contains(KeyModifiers::ALT)
+    // Only intercept filter input when the pane that owns the filter is still
+    // focused. Moving the mouse to another pane should let normal keybinds
+    // work (e.g. pressing the open_composer key after clicking Messages).
+    if (state.is_guild_pane_filter_active() && focus == FocusPane::Guilds)
+        || (state.is_channel_pane_filter_active() && focus == FocusPane::Channels)
     {
         state.adjust_focused_pane_width(-1);
     } else if (key.code == KeyCode::Char('l') || key.code == KeyCode::Right)
@@ -458,10 +435,15 @@ fn handle_user_profile_popup_key(state: &mut DashboardState, key: KeyEvent) -> O
 /// Returns `Some(command)` when the filter handler has fully handled the key
 /// and the caller should return that command. Returns `None` when the key
 /// should fall through to normal navigation (e.g. j/k to scroll the list).
-fn handle_pane_filter_key(state: &mut DashboardState, key: KeyEvent) -> Option<Option<AppCommand>> {
+fn handle_pane_filter_key(
+    state: &mut DashboardState,
+    key: KeyEvent,
+    focus: FocusPane,
+) -> Option<Option<AppCommand>> {
+    let guild_focused = focus == FocusPane::Guilds;
     match key.code {
         KeyCode::Esc => {
-            if state.is_guild_pane_filter_active() {
+            if guild_focused {
                 state.close_guild_pane_filter();
             } else {
                 state.close_channel_pane_filter();
@@ -469,7 +451,7 @@ fn handle_pane_filter_key(state: &mut DashboardState, key: KeyEvent) -> Option<O
             Some(None)
         }
         KeyCode::Enter => {
-            if state.is_guild_pane_filter_active() {
+            if guild_focused {
                 state.confirm_guild_pane_filter();
                 Some(None)
             } else {
@@ -477,7 +459,7 @@ fn handle_pane_filter_key(state: &mut DashboardState, key: KeyEvent) -> Option<O
             }
         }
         KeyCode::Backspace => {
-            if state.is_guild_pane_filter_active() {
+            if guild_focused {
                 state.pop_guild_pane_filter_char();
             } else {
                 state.pop_channel_pane_filter_char();
@@ -485,7 +467,7 @@ fn handle_pane_filter_key(state: &mut DashboardState, key: KeyEvent) -> Option<O
             Some(None)
         }
         KeyCode::Left => {
-            if state.is_guild_pane_filter_active() {
+            if guild_focused {
                 state.move_guild_pane_filter_cursor_left();
             } else {
                 state.move_channel_pane_filter_cursor_left();
@@ -493,7 +475,7 @@ fn handle_pane_filter_key(state: &mut DashboardState, key: KeyEvent) -> Option<O
             Some(None)
         }
         KeyCode::Right => {
-            if state.is_guild_pane_filter_active() {
+            if guild_focused {
                 state.move_guild_pane_filter_cursor_right();
             } else {
                 state.move_channel_pane_filter_cursor_right();
@@ -513,7 +495,7 @@ fn handle_pane_filter_key(state: &mut DashboardState, key: KeyEvent) -> Option<O
             Some(None)
         }
         KeyCode::Char(value) if is_shortcut_key(key) => {
-            if state.is_guild_pane_filter_active() {
+            if guild_focused {
                 state.push_guild_pane_filter_char(value);
             } else {
                 state.push_channel_pane_filter_char(value);

--- a/src/tui/keybinding.rs
+++ b/src/tui/keybinding.rs
@@ -382,13 +382,18 @@ impl ActiveKeyBindings {
                 .get(action.name())
                 .map(String::as_str)
                 .unwrap_or(default_spec);
-            let binding = KeyBinding::parse(spec)
-                .unwrap_or_else(|| KeyBinding::parse(default_spec).expect("default is always valid"));
+            let binding = KeyBinding::parse(spec).unwrap_or_else(|| {
+                KeyBinding::parse(default_spec).expect("default is always valid")
+            });
             named.insert(binding.clone(), action);
             reverse.insert(action, binding);
         }
 
-        Self { named, reverse, fixed }
+        Self {
+            named,
+            reverse,
+            fixed,
+        }
     }
 
     /// Look up which action the given key event triggers, if any.
@@ -534,40 +539,85 @@ mod tests {
     fn shift_binding_matches_all_three_terminal_styles() {
         let b = KeyBinding::parse("shift+j").expect("should parse");
         // (a) crossterm canonical: lowercase + SHIFT modifier
-        assert_eq!(b, KeyBinding::from_event(press(KeyCode::Char('j'), KeyModifiers::SHIFT)));
+        assert_eq!(
+            b,
+            KeyBinding::from_event(press(KeyCode::Char('j'), KeyModifiers::SHIFT))
+        );
         // (b) legacy: uppercase + no modifier
-        assert_eq!(b, KeyBinding::from_event(press(KeyCode::Char('J'), KeyModifiers::empty())));
+        assert_eq!(
+            b,
+            KeyBinding::from_event(press(KeyCode::Char('J'), KeyModifiers::empty()))
+        );
         // (c) uppercase WITH SHIFT still set (some terminals)
-        assert_eq!(b, KeyBinding::from_event(press(KeyCode::Char('J'), KeyModifiers::SHIFT)));
+        assert_eq!(
+            b,
+            KeyBinding::from_event(press(KeyCode::Char('J'), KeyModifiers::SHIFT))
+        );
         // must NOT match plain lowercase
-        assert_ne!(b, KeyBinding::from_event(press(KeyCode::Char('j'), KeyModifiers::empty())));
+        assert_ne!(
+            b,
+            KeyBinding::from_event(press(KeyCode::Char('j'), KeyModifiers::empty()))
+        );
     }
 
     #[test]
     fn jump_bottom_matches_capital_g() {
         let b = KeyBinding::parse("shift+g").expect("should parse");
-        assert_eq!(b, KeyBinding::from_event(press(KeyCode::Char('g'), KeyModifiers::SHIFT)));
-        assert_eq!(b, KeyBinding::from_event(press(KeyCode::Char('G'), KeyModifiers::empty())));
-        assert_eq!(b, KeyBinding::from_event(press(KeyCode::Char('G'), KeyModifiers::SHIFT)));
-        assert_ne!(b, KeyBinding::from_event(press(KeyCode::Char('g'), KeyModifiers::empty())));
+        assert_eq!(
+            b,
+            KeyBinding::from_event(press(KeyCode::Char('g'), KeyModifiers::SHIFT))
+        );
+        assert_eq!(
+            b,
+            KeyBinding::from_event(press(KeyCode::Char('G'), KeyModifiers::empty()))
+        );
+        assert_eq!(
+            b,
+            KeyBinding::from_event(press(KeyCode::Char('G'), KeyModifiers::SHIFT))
+        );
+        assert_ne!(
+            b,
+            KeyBinding::from_event(press(KeyCode::Char('g'), KeyModifiers::empty()))
+        );
     }
 
     #[test]
     fn default_bindings_look_up_correctly() {
         let kb = ActiveKeyBindings::default();
-        assert_eq!(kb.lookup(press(KeyCode::Char('q'), KeyModifiers::empty())), Some(Action::Quit));
-        assert_eq!(kb.lookup(press(KeyCode::Char('j'), KeyModifiers::empty())), Some(Action::MoveDown));
-        assert_eq!(kb.lookup(press(KeyCode::Down, KeyModifiers::empty())), Some(Action::MoveDown));
-        assert_eq!(kb.lookup(press(KeyCode::Tab, KeyModifiers::empty())), Some(Action::CycleFocusForward));
-        assert_eq!(kb.lookup(press(KeyCode::BackTab, KeyModifiers::empty())), Some(Action::CycleFocusBackward));
-        assert_eq!(kb.lookup(press(KeyCode::Enter, KeyModifiers::empty())), Some(Action::Confirm));
-        assert_eq!(kb.lookup(press(KeyCode::Esc, KeyModifiers::empty())), Some(Action::Return));
+        assert_eq!(
+            kb.lookup(press(KeyCode::Char('q'), KeyModifiers::empty())),
+            Some(Action::Quit)
+        );
+        assert_eq!(
+            kb.lookup(press(KeyCode::Char('j'), KeyModifiers::empty())),
+            Some(Action::MoveDown)
+        );
+        assert_eq!(
+            kb.lookup(press(KeyCode::Down, KeyModifiers::empty())),
+            Some(Action::MoveDown)
+        );
+        assert_eq!(
+            kb.lookup(press(KeyCode::Tab, KeyModifiers::empty())),
+            Some(Action::CycleFocusForward)
+        );
+        assert_eq!(
+            kb.lookup(press(KeyCode::BackTab, KeyModifiers::empty())),
+            Some(Action::CycleFocusBackward)
+        );
+        assert_eq!(
+            kb.lookup(press(KeyCode::Enter, KeyModifiers::empty())),
+            Some(Action::Confirm)
+        );
+        assert_eq!(
+            kb.lookup(press(KeyCode::Esc, KeyModifiers::empty())),
+            Some(Action::Return)
+        );
     }
 
     #[test]
     fn from_config_falls_back_on_bad_spec() {
-        use std::collections::HashMap;
         use crate::config::KeyBindingsConfig;
+        use std::collections::HashMap;
         let mut map = HashMap::new();
         map.insert("open_in_editor".to_owned(), "notakey".to_owned());
         let cfg = KeyBindingsConfig(map);
@@ -581,8 +631,8 @@ mod tests {
 
     #[test]
     fn custom_binding_overrides_default() {
-        use std::collections::HashMap;
         use crate::config::KeyBindingsConfig;
+        use std::collections::HashMap;
         let mut map = HashMap::new();
         map.insert("open_composer".to_owned(), "e".to_owned());
         let cfg = KeyBindingsConfig(map);

--- a/src/tui/keybinding.rs
+++ b/src/tui/keybinding.rs
@@ -178,6 +178,8 @@ pub enum Action {
     ScrollTop,
     /// End key: scroll to bottom of viewport (Messages) or jump to last item.
     ScrollBottom,
+    /// Open the emoji reaction picker for the selected message.
+    React,
 }
 
 impl Action {
@@ -214,6 +216,7 @@ impl Action {
             Self::CollapseLeft => "collapse_left",
             Self::ScrollTop => "scroll_top",
             Self::ScrollBottom => "scroll_bottom",
+            Self::React => "react",
         }
     }
 
@@ -251,6 +254,7 @@ impl Action {
             "collapse_left" => Some(Self::CollapseLeft),
             "scroll_top" => Some(Self::ScrollTop),
             "scroll_bottom" => Some(Self::ScrollBottom),
+            "react" => Some(Self::React),
             _ => None,
         }
     }
@@ -288,6 +292,7 @@ impl Action {
             Self::ExpandRight => Some("l"),
             Self::CollapseLeft => Some("h"),
             Self::ScrollTop | Self::ScrollBottom => None,
+            Self::React => Some("r"),
         }
     }
 }
@@ -323,6 +328,7 @@ const CONFIGURABLE_ACTIONS: &[Action] = &[
     Action::Confirm,
     Action::ExpandRight,
     Action::CollapseLeft,
+    Action::React,
 ];
 
 /// Fixed aliases that are always present and cannot be overridden by config.

--- a/src/tui/keybinding.rs
+++ b/src/tui/keybinding.rs
@@ -1,0 +1,317 @@
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use crate::config::KeyBindingsConfig;
+
+#[derive(Clone, Debug)]
+pub struct KeyBinding {
+    code: KeyCode,
+    modifiers: KeyModifiers,
+}
+
+impl KeyBinding {
+    pub fn matches(&self, key: KeyEvent) -> bool {
+        if key.code == self.code && key.modifiers == self.modifiers {
+            return true;
+        }
+        // Many terminals report Shift+<letter> as uppercase letter with either
+        // no SHIFT modifier or with SHIFT still set. Accept all three forms so
+        // bindings like "shift+j" match capital-J from any terminal style:
+        //   (a) Char('j') + SHIFT  — crossterm canonical
+        //   (b) Char('J') + empty  — legacy no-modifier uppercase
+        //   (c) Char('J') + SHIFT  — uppercase WITH shift still set
+        if self.modifiers == KeyModifiers::SHIFT {
+            if let KeyCode::Char(c) = self.code {
+                let upper = c.to_uppercase().next().unwrap_or(c);
+                if upper != c
+                    && key.code == KeyCode::Char(upper)
+                    && (key.modifiers.is_empty() || key.modifiers == KeyModifiers::SHIFT)
+                {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Human-readable label for display in the keymap popup, e.g. `"Ctrl+E"`.
+    pub fn label(&self) -> String {
+        let mut parts: Vec<&str> = Vec::new();
+        if self.modifiers.contains(KeyModifiers::CONTROL) {
+            parts.push("Ctrl");
+        }
+        if self.modifiers.contains(KeyModifiers::ALT) {
+            parts.push("Alt");
+        }
+        if self.modifiers.contains(KeyModifiers::SHIFT) {
+            parts.push("Shift");
+        }
+        let key_buf;
+        let key: &str = match self.code {
+            KeyCode::Char(' ') => "Space",
+            KeyCode::Char(c) => {
+                // Bare characters (no modifier) display as-is so "j" shows as
+                // "j" not "J". Characters with any modifier display uppercase
+                // ("Ctrl+E", "Shift+J") matching conventional notation.
+                key_buf = if self.modifiers.is_empty() {
+                    c.to_string()
+                } else {
+                    c.to_uppercase().to_string()
+                };
+                &key_buf
+            }
+            KeyCode::Enter => "Enter",
+            KeyCode::Esc => "Esc",
+            KeyCode::Backspace => "Backspace",
+            KeyCode::Delete => "Delete",
+            KeyCode::Tab => "Tab",
+            KeyCode::Home => "Home",
+            KeyCode::End => "End",
+            KeyCode::PageUp => "PageUp",
+            KeyCode::PageDown => "PageDown",
+            KeyCode::Up => "Up",
+            KeyCode::Down => "Down",
+            KeyCode::Left => "Left",
+            KeyCode::Right => "Right",
+            KeyCode::F(n) => {
+                key_buf = format!("F{n}");
+                &key_buf
+            }
+            _ => "?",
+        };
+        parts.push(key);
+        parts.join("+")
+    }
+
+    /// Parse a key spec like `"ctrl+e"`, `"alt+shift+f1"`, `"enter"`.
+    pub fn parse(spec: &str) -> Option<Self> {
+        let spec = spec.trim().to_lowercase();
+        let parts: Vec<&str> = spec.split('+').collect();
+        // split_last returns (last_element, rest_of_slice)
+        let (key_part, modifier_parts) = parts.split_last()?;
+
+        let mut modifiers = KeyModifiers::empty();
+        for part in modifier_parts {
+            match *part {
+                "ctrl" | "control" => modifiers |= KeyModifiers::CONTROL,
+                "alt" | "meta" | "option" => modifiers |= KeyModifiers::ALT,
+                "shift" => modifiers |= KeyModifiers::SHIFT,
+                _ => return None,
+            }
+        }
+
+        let code = match *key_part {
+            "enter" | "return" => KeyCode::Enter,
+            "esc" | "escape" => KeyCode::Esc,
+            "backspace" => KeyCode::Backspace,
+            "delete" | "del" => KeyCode::Delete,
+            "tab" => KeyCode::Tab,
+            "space" | "spc" => KeyCode::Char(' '),
+            "home" => KeyCode::Home,
+            "end" => KeyCode::End,
+            "pageup" => KeyCode::PageUp,
+            "pagedown" => KeyCode::PageDown,
+            "up" => KeyCode::Up,
+            "down" => KeyCode::Down,
+            "left" => KeyCode::Left,
+            "right" => KeyCode::Right,
+            s if s.starts_with('f') && s.len() > 1 => {
+                let n: u8 = s[1..].parse().ok()?;
+                KeyCode::F(n)
+            }
+            s if s.len() == 1 => KeyCode::Char(s.chars().next()?),
+            _ => return None,
+        };
+
+        Some(Self { code, modifiers })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ActiveKeyBindings {
+    pub open_in_editor: KeyBinding,
+    pub quit: KeyBinding,
+    pub open_composer: KeyBinding,
+    pub open_leader: KeyBinding,
+    pub open_keymap: KeyBinding,
+    pub pane_search: KeyBinding,
+    pub move_down: KeyBinding,
+    pub move_up: KeyBinding,
+    pub jump_top: KeyBinding,
+    pub jump_bottom: KeyBinding,
+    pub half_page_down: KeyBinding,
+    pub half_page_up: KeyBinding,
+    pub scroll_viewport_down: KeyBinding,
+    pub scroll_viewport_up: KeyBinding,
+    pub scroll_pane_left: KeyBinding,
+    pub scroll_pane_right: KeyBinding,
+}
+
+fn parse_binding(spec: &str, fallback: &str) -> KeyBinding {
+    KeyBinding::parse(spec).unwrap_or_else(|| {
+        KeyBinding::parse(fallback).expect("fallback binding is always valid")
+    })
+}
+
+impl Default for ActiveKeyBindings {
+    fn default() -> Self {
+        Self {
+            open_in_editor: KeyBinding::parse("ctrl+e").expect("default binding is valid"),
+            quit: KeyBinding::parse("q").expect("default binding is valid"),
+            open_composer: KeyBinding::parse("i").expect("default binding is valid"),
+            open_leader: KeyBinding::parse("space").expect("default binding is valid"),
+            open_keymap: KeyBinding::parse("?").expect("default binding is valid"),
+            pane_search: KeyBinding::parse("/").expect("default binding is valid"),
+            move_down: KeyBinding::parse("j").expect("default binding is valid"),
+            move_up: KeyBinding::parse("k").expect("default binding is valid"),
+            jump_top: KeyBinding::parse("g").expect("default binding is valid"),
+            jump_bottom: KeyBinding::parse("shift+g").expect("default binding is valid"),
+            half_page_down: KeyBinding::parse("ctrl+d").expect("default binding is valid"),
+            half_page_up: KeyBinding::parse("ctrl+u").expect("default binding is valid"),
+            scroll_viewport_down: KeyBinding::parse("shift+j").expect("default binding is valid"),
+            scroll_viewport_up: KeyBinding::parse("shift+k").expect("default binding is valid"),
+            scroll_pane_left: KeyBinding::parse("shift+h").expect("default binding is valid"),
+            scroll_pane_right: KeyBinding::parse("shift+l").expect("default binding is valid"),
+        }
+    }
+}
+
+impl ActiveKeyBindings {
+    pub fn from_config(config: &KeyBindingsConfig) -> Self {
+        Self {
+            open_in_editor: parse_binding(&config.open_in_editor, "ctrl+e"),
+            quit: parse_binding(&config.quit, "q"),
+            open_composer: parse_binding(&config.open_composer, "i"),
+            open_leader: parse_binding(&config.open_leader, "space"),
+            open_keymap: parse_binding(&config.open_keymap, "?"),
+            pane_search: parse_binding(&config.pane_search, "/"),
+            move_down: parse_binding(&config.move_down, "j"),
+            move_up: parse_binding(&config.move_up, "k"),
+            jump_top: parse_binding(&config.jump_top, "g"),
+            jump_bottom: parse_binding(&config.jump_bottom, "shift+g"),
+            half_page_down: parse_binding(&config.half_page_down, "ctrl+d"),
+            half_page_up: parse_binding(&config.half_page_up, "ctrl+u"),
+            scroll_viewport_down: parse_binding(&config.scroll_viewport_down, "shift+j"),
+            scroll_viewport_up: parse_binding(&config.scroll_viewport_up, "shift+k"),
+            scroll_pane_left: parse_binding(&config.scroll_pane_left, "shift+h"),
+            scroll_pane_right: parse_binding(&config.scroll_pane_right, "shift+l"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crossterm::event::{KeyEventKind, KeyEventState};
+
+    use super::*;
+
+    fn press(code: KeyCode, modifiers: KeyModifiers) -> KeyEvent {
+        KeyEvent {
+            code,
+            modifiers,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::empty(),
+        }
+    }
+
+    #[test]
+    fn parse_ctrl_e() {
+        let b = KeyBinding::parse("ctrl+e").expect("should parse");
+        assert!(b.matches(press(KeyCode::Char('e'), KeyModifiers::CONTROL)));
+        assert!(!b.matches(press(KeyCode::Char('e'), KeyModifiers::empty())));
+        assert!(!b.matches(press(KeyCode::Char('o'), KeyModifiers::CONTROL)));
+    }
+
+    #[test]
+    fn parse_is_case_insensitive() {
+        let b = KeyBinding::parse("Ctrl+E").expect("should parse");
+        assert!(b.matches(press(KeyCode::Char('e'), KeyModifiers::CONTROL)));
+    }
+
+    #[test]
+    fn parse_alt_modifier() {
+        let b = KeyBinding::parse("alt+e").expect("should parse");
+        assert!(b.matches(press(KeyCode::Char('e'), KeyModifiers::ALT)));
+    }
+
+    #[test]
+    fn parse_option_alias_for_alt() {
+        let b = KeyBinding::parse("option+e").expect("should parse");
+        assert!(b.matches(press(KeyCode::Char('e'), KeyModifiers::ALT)));
+    }
+
+    #[test]
+    fn parse_function_key() {
+        let b = KeyBinding::parse("f12").expect("should parse");
+        assert!(b.matches(press(KeyCode::F(12), KeyModifiers::empty())));
+    }
+
+    #[test]
+    fn parse_special_keys() {
+        assert!(KeyBinding::parse("enter").is_some());
+        assert!(KeyBinding::parse("esc").is_some());
+        assert!(KeyBinding::parse("ctrl+backspace").is_some());
+    }
+
+    #[test]
+    fn parse_invalid_returns_none() {
+        assert!(KeyBinding::parse("").is_none());
+        assert!(KeyBinding::parse("ctrl+badkey").is_none());
+        assert!(KeyBinding::parse("supermod+e").is_none());
+    }
+
+    #[test]
+    fn label_ctrl_e() {
+        let b = KeyBinding::parse("ctrl+e").expect("should parse");
+        assert_eq!(b.label(), "Ctrl+E");
+    }
+
+    #[test]
+    fn label_bare_char_is_lowercase() {
+        assert_eq!(KeyBinding::parse("j").unwrap().label(), "j");
+        assert_eq!(KeyBinding::parse("g").unwrap().label(), "g");
+        assert_eq!(KeyBinding::parse("q").unwrap().label(), "q");
+        assert_eq!(KeyBinding::parse("?").unwrap().label(), "?");
+    }
+
+    #[test]
+    fn label_alt_shift_f1() {
+        let b = KeyBinding::parse("alt+shift+f1").expect("should parse");
+        assert_eq!(b.label(), "Alt+Shift+F1");
+    }
+
+    #[test]
+    fn shift_binding_matches_all_three_terminal_styles() {
+        let b = KeyBinding::parse("shift+j").expect("should parse");
+        // (a) crossterm canonical: lowercase + SHIFT modifier
+        assert!(b.matches(press(KeyCode::Char('j'), KeyModifiers::SHIFT)));
+        // (b) legacy: uppercase + no modifier
+        assert!(b.matches(press(KeyCode::Char('J'), KeyModifiers::empty())));
+        // (c) uppercase WITH SHIFT still set (some terminals)
+        assert!(b.matches(press(KeyCode::Char('J'), KeyModifiers::SHIFT)));
+        // must NOT match plain lowercase
+        assert!(!b.matches(press(KeyCode::Char('j'), KeyModifiers::empty())));
+    }
+
+    #[test]
+    fn jump_bottom_matches_capital_g() {
+        let b = KeyBinding::parse("shift+g").expect("should parse");
+        assert!(b.matches(press(KeyCode::Char('g'), KeyModifiers::SHIFT)));
+        assert!(b.matches(press(KeyCode::Char('G'), KeyModifiers::empty())));
+        assert!(b.matches(press(KeyCode::Char('G'), KeyModifiers::SHIFT)));
+        assert!(!b.matches(press(KeyCode::Char('g'), KeyModifiers::empty())));
+    }
+
+    #[test]
+    fn from_config_falls_back_on_bad_spec() {
+        use crate::config::KeyBindingsConfig;
+        let cfg = KeyBindingsConfig {
+            open_in_editor: "notakey".to_owned(),
+            ..KeyBindingsConfig::default()
+        };
+        let bindings = ActiveKeyBindings::from_config(&cfg);
+        // Should have fallen back to ctrl+e
+        assert!(bindings
+            .open_in_editor
+            .matches(press(KeyCode::Char('e'), KeyModifiers::CONTROL)));
+    }
+}

--- a/src/tui/keybinding.rs
+++ b/src/tui/keybinding.rs
@@ -336,7 +336,6 @@ const CONFIGURABLE_ACTIONS: &[Action] = &[
 fn fixed_table() -> HashMap<KeyBinding, Action> {
     let mut m = HashMap::new();
     let entries: &[(&str, Action)] = &[
-        ("ctrl+c", Action::Quit),
         ("down", Action::MoveDown),
         ("up", Action::MoveUp),
         ("pagedown", Action::HalfPageDown),

--- a/src/tui/keybinding.rs
+++ b/src/tui/keybinding.rs
@@ -147,9 +147,8 @@ pub struct ActiveKeyBindings {
 }
 
 fn parse_binding(spec: &str, fallback: &str) -> KeyBinding {
-    KeyBinding::parse(spec).unwrap_or_else(|| {
-        KeyBinding::parse(fallback).expect("fallback binding is always valid")
-    })
+    KeyBinding::parse(spec)
+        .unwrap_or_else(|| KeyBinding::parse(fallback).expect("fallback binding is always valid"))
 }
 
 impl Default for ActiveKeyBindings {
@@ -310,8 +309,10 @@ mod tests {
         };
         let bindings = ActiveKeyBindings::from_config(&cfg);
         // Should have fallen back to ctrl+e
-        assert!(bindings
-            .open_in_editor
-            .matches(press(KeyCode::Char('e'), KeyModifiers::CONTROL)));
+        assert!(
+            bindings
+                .open_in_editor
+                .matches(press(KeyCode::Char('e'), KeyModifiers::CONTROL))
+        );
     }
 }

--- a/src/tui/keybinding.rs
+++ b/src/tui/keybinding.rs
@@ -1,36 +1,50 @@
+use std::collections::HashMap;
+
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::config::KeyBindingsConfig;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct KeyBinding {
     code: KeyCode,
     modifiers: KeyModifiers,
 }
 
 impl KeyBinding {
-    pub fn matches(&self, key: KeyEvent) -> bool {
-        if key.code == self.code && key.modifiers == self.modifiers {
-            return true;
+    /// Normalise a raw key-event into a canonical `KeyBinding` for HashMap lookup.
+    ///
+    /// Crossterm / terminals report Shift+letter in three different styles:
+    ///   (a) Char('j') + SHIFT     — crossterm canonical
+    ///   (b) Char('J') + empty     — legacy no-modifier uppercase
+    ///   (c) Char('J') + SHIFT     — uppercase WITH shift still set
+    ///
+    /// All three are normalised to form (a): lowercase char + SHIFT.
+    /// `BackTab` (Shift+Tab) is normalised to `Tab + SHIFT`.
+    fn from_event(key: KeyEvent) -> Self {
+        if key.code == KeyCode::BackTab {
+            return Self {
+                code: KeyCode::Tab,
+                modifiers: KeyModifiers::SHIFT,
+            };
         }
-        // Many terminals report Shift+<letter> as uppercase letter with either
-        // no SHIFT modifier or with SHIFT still set. Accept all three forms so
-        // bindings like "shift+j" match capital-J from any terminal style:
-        //   (a) Char('j') + SHIFT  — crossterm canonical
-        //   (b) Char('J') + empty  — legacy no-modifier uppercase
-        //   (c) Char('J') + SHIFT  — uppercase WITH shift still set
-        if self.modifiers == KeyModifiers::SHIFT {
-            if let KeyCode::Char(c) = self.code {
-                let upper = c.to_uppercase().next().unwrap_or(c);
-                if upper != c
-                    && key.code == KeyCode::Char(upper)
-                    && (key.modifiers.is_empty() || key.modifiers == KeyModifiers::SHIFT)
-                {
-                    return true;
+        if key.modifiers.is_empty() || key.modifiers == KeyModifiers::SHIFT {
+            if let KeyCode::Char(c) = key.code {
+                if c.is_uppercase() {
+                    if let Some(lower) = c.to_lowercase().next() {
+                        if lower != c {
+                            return Self {
+                                code: KeyCode::Char(lower),
+                                modifiers: KeyModifiers::SHIFT,
+                            };
+                        }
+                    }
                 }
             }
         }
-        false
+        Self {
+            code: key.code,
+            modifiers: key.modifiers,
+        }
     }
 
     /// Human-readable label for display in the keymap popup, e.g. `"Ctrl+E"`.
@@ -49,9 +63,6 @@ impl KeyBinding {
         let key: &str = match self.code {
             KeyCode::Char(' ') => "Space",
             KeyCode::Char(c) => {
-                // Bare characters (no modifier) display as-is so "j" shows as
-                // "j" not "J". Characters with any modifier display uppercase
-                // ("Ctrl+E", "Shift+J") matching conventional notation.
                 key_buf = if self.modifiers.is_empty() {
                     c.to_string()
                 } else {
@@ -82,11 +93,10 @@ impl KeyBinding {
         parts.join("+")
     }
 
-    /// Parse a key spec like `"ctrl+e"`, `"alt+shift+f1"`, `"enter"`.
+    /// Parse a key spec like `"ctrl+e"`, `"alt+shift+f1"`, `"backtab"`, `"enter"`.
     pub fn parse(spec: &str) -> Option<Self> {
         let spec = spec.trim().to_lowercase();
         let parts: Vec<&str> = spec.split('+').collect();
-        // split_last returns (last_element, rest_of_slice)
         let (key_part, modifier_parts) = parts.split_last()?;
 
         let mut modifiers = KeyModifiers::empty();
@@ -104,6 +114,12 @@ impl KeyBinding {
             "esc" | "escape" => KeyCode::Esc,
             "backspace" => KeyCode::Backspace,
             "delete" | "del" => KeyCode::Delete,
+            // "backtab" and "shift+tab" both normalise to Tab+SHIFT so they
+            // hash-match the BackTab event produced by from_event.
+            "backtab" => {
+                modifiers |= KeyModifiers::SHIFT;
+                KeyCode::Tab
+            }
             "tab" => KeyCode::Tab,
             "space" | "spc" => KeyCode::Char(' '),
             "home" => KeyCode::Home,
@@ -126,74 +142,284 @@ impl KeyBinding {
     }
 }
 
-#[derive(Clone, Debug)]
-pub struct ActiveKeyBindings {
-    pub open_in_editor: KeyBinding,
-    pub quit: KeyBinding,
-    pub open_composer: KeyBinding,
-    pub open_leader: KeyBinding,
-    pub open_keymap: KeyBinding,
-    pub pane_search: KeyBinding,
-    pub move_down: KeyBinding,
-    pub move_up: KeyBinding,
-    pub jump_top: KeyBinding,
-    pub jump_bottom: KeyBinding,
-    pub half_page_down: KeyBinding,
-    pub half_page_up: KeyBinding,
-    pub scroll_viewport_down: KeyBinding,
-    pub scroll_viewport_up: KeyBinding,
-    pub scroll_pane_left: KeyBinding,
-    pub scroll_pane_right: KeyBinding,
+/// Every action that a key-press can trigger in normal (non-composer) mode.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Action {
+    Quit,
+    Return,
+    ToggleDebugLog,
+    FocusGuilds,
+    FocusChannels,
+    FocusMessages,
+    FocusMembers,
+    CycleFocusForward,
+    CycleFocusBackward,
+    OpenComposer,
+    OpenInEditor,
+    OpenKeymap,
+    OpenLeader,
+    PaneSearch,
+    MoveDown,
+    MoveUp,
+    HalfPageDown,
+    HalfPageUp,
+    JumpTop,
+    JumpBottom,
+    ScrollViewportDown,
+    ScrollViewportUp,
+    ScrollPaneLeft,
+    ScrollPaneRight,
+    NarrowPane,
+    WidenPane,
+    Confirm,
+    ExpandRight,
+    CollapseLeft,
+    /// Home key: scroll to top of viewport (Messages) or jump to first item.
+    ScrollTop,
+    /// End key: scroll to bottom of viewport (Messages) or jump to last item.
+    ScrollBottom,
 }
 
-fn parse_binding(spec: &str, fallback: &str) -> KeyBinding {
-    KeyBinding::parse(spec)
-        .unwrap_or_else(|| KeyBinding::parse(fallback).expect("fallback binding is always valid"))
-}
+impl Action {
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Quit => "quit",
+            Self::Return => "return",
+            Self::ToggleDebugLog => "toggle_debug_log",
+            Self::FocusGuilds => "focus_guilds",
+            Self::FocusChannels => "focus_channels",
+            Self::FocusMessages => "focus_messages",
+            Self::FocusMembers => "focus_members",
+            Self::CycleFocusForward => "cycle_focus_forward",
+            Self::CycleFocusBackward => "cycle_focus_backward",
+            Self::OpenComposer => "open_composer",
+            Self::OpenInEditor => "open_in_editor",
+            Self::OpenKeymap => "open_keymap",
+            Self::OpenLeader => "open_leader",
+            Self::PaneSearch => "pane_search",
+            Self::MoveDown => "move_down",
+            Self::MoveUp => "move_up",
+            Self::HalfPageDown => "half_page_down",
+            Self::HalfPageUp => "half_page_up",
+            Self::JumpTop => "jump_top",
+            Self::JumpBottom => "jump_bottom",
+            Self::ScrollViewportDown => "scroll_viewport_down",
+            Self::ScrollViewportUp => "scroll_viewport_up",
+            Self::ScrollPaneLeft => "scroll_pane_left",
+            Self::ScrollPaneRight => "scroll_pane_right",
+            Self::NarrowPane => "narrow_pane",
+            Self::WidenPane => "widen_pane",
+            Self::Confirm => "confirm",
+            Self::ExpandRight => "expand_right",
+            Self::CollapseLeft => "collapse_left",
+            Self::ScrollTop => "scroll_top",
+            Self::ScrollBottom => "scroll_bottom",
+        }
+    }
 
-impl Default for ActiveKeyBindings {
-    fn default() -> Self {
-        Self {
-            open_in_editor: KeyBinding::parse("ctrl+e").expect("default binding is valid"),
-            quit: KeyBinding::parse("q").expect("default binding is valid"),
-            open_composer: KeyBinding::parse("i").expect("default binding is valid"),
-            open_leader: KeyBinding::parse("space").expect("default binding is valid"),
-            open_keymap: KeyBinding::parse("?").expect("default binding is valid"),
-            pane_search: KeyBinding::parse("/").expect("default binding is valid"),
-            move_down: KeyBinding::parse("j").expect("default binding is valid"),
-            move_up: KeyBinding::parse("k").expect("default binding is valid"),
-            jump_top: KeyBinding::parse("g").expect("default binding is valid"),
-            jump_bottom: KeyBinding::parse("shift+g").expect("default binding is valid"),
-            half_page_down: KeyBinding::parse("ctrl+d").expect("default binding is valid"),
-            half_page_up: KeyBinding::parse("ctrl+u").expect("default binding is valid"),
-            scroll_viewport_down: KeyBinding::parse("shift+j").expect("default binding is valid"),
-            scroll_viewport_up: KeyBinding::parse("shift+k").expect("default binding is valid"),
-            scroll_pane_left: KeyBinding::parse("shift+h").expect("default binding is valid"),
-            scroll_pane_right: KeyBinding::parse("shift+l").expect("default binding is valid"),
+    #[allow(dead_code)]
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "quit" => Some(Self::Quit),
+            "return" => Some(Self::Return),
+            "toggle_debug_log" => Some(Self::ToggleDebugLog),
+            "focus_guilds" => Some(Self::FocusGuilds),
+            "focus_channels" => Some(Self::FocusChannels),
+            "focus_messages" => Some(Self::FocusMessages),
+            "focus_members" => Some(Self::FocusMembers),
+            "cycle_focus_forward" => Some(Self::CycleFocusForward),
+            "cycle_focus_backward" => Some(Self::CycleFocusBackward),
+            "open_composer" => Some(Self::OpenComposer),
+            "open_in_editor" => Some(Self::OpenInEditor),
+            "open_keymap" => Some(Self::OpenKeymap),
+            "open_leader" => Some(Self::OpenLeader),
+            "pane_search" => Some(Self::PaneSearch),
+            "move_down" => Some(Self::MoveDown),
+            "move_up" => Some(Self::MoveUp),
+            "half_page_down" => Some(Self::HalfPageDown),
+            "half_page_up" => Some(Self::HalfPageUp),
+            "jump_top" => Some(Self::JumpTop),
+            "jump_bottom" => Some(Self::JumpBottom),
+            "scroll_viewport_down" => Some(Self::ScrollViewportDown),
+            "scroll_viewport_up" => Some(Self::ScrollViewportUp),
+            "scroll_pane_left" => Some(Self::ScrollPaneLeft),
+            "scroll_pane_right" => Some(Self::ScrollPaneRight),
+            "narrow_pane" => Some(Self::NarrowPane),
+            "widen_pane" => Some(Self::WidenPane),
+            "confirm" => Some(Self::Confirm),
+            "expand_right" => Some(Self::ExpandRight),
+            "collapse_left" => Some(Self::CollapseLeft),
+            "scroll_top" => Some(Self::ScrollTop),
+            "scroll_bottom" => Some(Self::ScrollBottom),
+            _ => None,
+        }
+    }
+
+    /// Default key spec for user-configurable actions; `None` for fixed-only actions.
+    pub fn default_binding(self) -> Option<&'static str> {
+        match self {
+            Self::Quit => Some("q"),
+            Self::Return => Some("esc"),
+            Self::ToggleDebugLog => Some("`"),
+            Self::FocusGuilds => Some("1"),
+            Self::FocusChannels => Some("2"),
+            Self::FocusMessages => Some("3"),
+            Self::FocusMembers => Some("4"),
+            Self::CycleFocusForward => Some("tab"),
+            Self::CycleFocusBackward => Some("backtab"),
+            Self::OpenComposer => Some("i"),
+            Self::OpenInEditor => Some("ctrl+e"),
+            Self::OpenKeymap => Some("?"),
+            Self::OpenLeader => Some("space"),
+            Self::PaneSearch => Some("/"),
+            Self::MoveDown => Some("j"),
+            Self::MoveUp => Some("k"),
+            Self::HalfPageDown => Some("ctrl+d"),
+            Self::HalfPageUp => Some("ctrl+u"),
+            Self::JumpTop => Some("g"),
+            Self::JumpBottom => Some("shift+g"),
+            Self::ScrollViewportDown => Some("shift+j"),
+            Self::ScrollViewportUp => Some("shift+k"),
+            Self::ScrollPaneLeft => Some("shift+h"),
+            Self::ScrollPaneRight => Some("shift+l"),
+            Self::NarrowPane => Some("alt+h"),
+            Self::WidenPane => Some("alt+l"),
+            Self::Confirm => Some("enter"),
+            Self::ExpandRight => Some("l"),
+            Self::CollapseLeft => Some("h"),
+            Self::ScrollTop | Self::ScrollBottom => None,
         }
     }
 }
 
+/// All configurable actions in the order they appear in the config schema.
+const CONFIGURABLE_ACTIONS: &[Action] = &[
+    Action::Quit,
+    Action::Return,
+    Action::ToggleDebugLog,
+    Action::FocusGuilds,
+    Action::FocusChannels,
+    Action::FocusMessages,
+    Action::FocusMembers,
+    Action::CycleFocusForward,
+    Action::CycleFocusBackward,
+    Action::OpenComposer,
+    Action::OpenInEditor,
+    Action::OpenKeymap,
+    Action::OpenLeader,
+    Action::PaneSearch,
+    Action::MoveDown,
+    Action::MoveUp,
+    Action::HalfPageDown,
+    Action::HalfPageUp,
+    Action::JumpTop,
+    Action::JumpBottom,
+    Action::ScrollViewportDown,
+    Action::ScrollViewportUp,
+    Action::ScrollPaneLeft,
+    Action::ScrollPaneRight,
+    Action::NarrowPane,
+    Action::WidenPane,
+    Action::Confirm,
+    Action::ExpandRight,
+    Action::CollapseLeft,
+];
+
+/// Fixed aliases that are always present and cannot be overridden by config.
+/// These cover hardware-conventional keys (arrow keys, Enter, Esc, Tab, …).
+fn fixed_table() -> HashMap<KeyBinding, Action> {
+    let mut m = HashMap::new();
+    let entries: &[(&str, Action)] = &[
+        ("ctrl+c", Action::Quit),
+        ("down", Action::MoveDown),
+        ("up", Action::MoveUp),
+        ("pagedown", Action::HalfPageDown),
+        ("pageup", Action::HalfPageUp),
+        ("home", Action::ScrollTop),
+        ("end", Action::ScrollBottom),
+        ("right", Action::ExpandRight),
+        ("left", Action::CollapseLeft),
+        ("alt+left", Action::NarrowPane),
+        ("alt+right", Action::WidenPane),
+        ("tab", Action::CycleFocusForward),
+        ("backtab", Action::CycleFocusBackward),
+        ("enter", Action::Confirm),
+        ("esc", Action::Return),
+    ];
+    for (spec, action) in entries {
+        if let Some(binding) = KeyBinding::parse(spec) {
+            m.insert(binding, *action);
+        }
+    }
+    m
+}
+
+/// Resolved keybindings used at runtime.
+#[derive(Clone, Debug)]
+pub struct ActiveKeyBindings {
+    /// User-configurable bindings: config spec → action (with fallback to default).
+    named: HashMap<KeyBinding, Action>,
+    /// Reverse of `named`: action → its current key label (for display).
+    reverse: HashMap<Action, KeyBinding>,
+    /// Immutable hardware-conventional aliases (arrow keys, Enter, Esc, Tab, …).
+    fixed: HashMap<KeyBinding, Action>,
+}
+
 impl ActiveKeyBindings {
     pub fn from_config(config: &KeyBindingsConfig) -> Self {
-        Self {
-            open_in_editor: parse_binding(&config.open_in_editor, "ctrl+e"),
-            quit: parse_binding(&config.quit, "q"),
-            open_composer: parse_binding(&config.open_composer, "i"),
-            open_leader: parse_binding(&config.open_leader, "space"),
-            open_keymap: parse_binding(&config.open_keymap, "?"),
-            pane_search: parse_binding(&config.pane_search, "/"),
-            move_down: parse_binding(&config.move_down, "j"),
-            move_up: parse_binding(&config.move_up, "k"),
-            jump_top: parse_binding(&config.jump_top, "g"),
-            jump_bottom: parse_binding(&config.jump_bottom, "shift+g"),
-            half_page_down: parse_binding(&config.half_page_down, "ctrl+d"),
-            half_page_up: parse_binding(&config.half_page_up, "ctrl+u"),
-            scroll_viewport_down: parse_binding(&config.scroll_viewport_down, "shift+j"),
-            scroll_viewport_up: parse_binding(&config.scroll_viewport_up, "shift+k"),
-            scroll_pane_left: parse_binding(&config.scroll_pane_left, "shift+h"),
-            scroll_pane_right: parse_binding(&config.scroll_pane_right, "shift+l"),
+        let fixed = fixed_table();
+        let mut named: HashMap<KeyBinding, Action> = HashMap::new();
+        let mut reverse: HashMap<Action, KeyBinding> = HashMap::new();
+
+        for &action in CONFIGURABLE_ACTIONS {
+            let default_spec = match action.default_binding() {
+                Some(s) => s,
+                None => continue,
+            };
+            // Use the user's spec if present and parseable; fall back to default.
+            let spec = config
+                .0
+                .get(action.name())
+                .map(String::as_str)
+                .unwrap_or(default_spec);
+            let binding = KeyBinding::parse(spec)
+                .unwrap_or_else(|| KeyBinding::parse(default_spec).expect("default is always valid"));
+            named.insert(binding.clone(), action);
+            reverse.insert(action, binding);
         }
+
+        Self { named, reverse, fixed }
+    }
+
+    /// Look up which action the given key event triggers, if any.
+    /// Named (user-configurable) bindings take priority over fixed aliases.
+    pub fn lookup(&self, key: KeyEvent) -> Option<Action> {
+        let binding = KeyBinding::from_event(key);
+        self.named
+            .get(&binding)
+            .or_else(|| self.fixed.get(&binding))
+            .copied()
+    }
+
+    /// Human-readable key label for `action`, e.g. `"Ctrl+E"`.
+    /// Returns the current user binding if one exists, otherwise the fixed alias,
+    /// otherwise `"?"`.
+    pub fn label(&self, action: Action) -> String {
+        if let Some(binding) = self.reverse.get(&action) {
+            return binding.label();
+        }
+        for (binding, a) in &self.fixed {
+            if *a == action {
+                return binding.label();
+            }
+        }
+        "?".to_owned()
+    }
+}
+
+impl Default for ActiveKeyBindings {
+    fn default() -> Self {
+        Self::from_config(&KeyBindingsConfig::default())
     }
 }
 
@@ -215,33 +441,39 @@ mod tests {
     #[test]
     fn parse_ctrl_e() {
         let b = KeyBinding::parse("ctrl+e").expect("should parse");
-        assert!(b.matches(press(KeyCode::Char('e'), KeyModifiers::CONTROL)));
-        assert!(!b.matches(press(KeyCode::Char('e'), KeyModifiers::empty())));
-        assert!(!b.matches(press(KeyCode::Char('o'), KeyModifiers::CONTROL)));
+        assert!(b == KeyBinding::from_event(press(KeyCode::Char('e'), KeyModifiers::CONTROL)));
+        assert!(b != KeyBinding::from_event(press(KeyCode::Char('e'), KeyModifiers::empty())));
+        assert!(b != KeyBinding::from_event(press(KeyCode::Char('o'), KeyModifiers::CONTROL)));
     }
 
     #[test]
     fn parse_is_case_insensitive() {
         let b = KeyBinding::parse("Ctrl+E").expect("should parse");
-        assert!(b.matches(press(KeyCode::Char('e'), KeyModifiers::CONTROL)));
+        assert_eq!(b, KeyBinding::parse("ctrl+e").unwrap());
     }
 
     #[test]
     fn parse_alt_modifier() {
         let b = KeyBinding::parse("alt+e").expect("should parse");
-        assert!(b.matches(press(KeyCode::Char('e'), KeyModifiers::ALT)));
+        assert_eq!(
+            b,
+            KeyBinding::from_event(press(KeyCode::Char('e'), KeyModifiers::ALT))
+        );
     }
 
     #[test]
     fn parse_option_alias_for_alt() {
         let b = KeyBinding::parse("option+e").expect("should parse");
-        assert!(b.matches(press(KeyCode::Char('e'), KeyModifiers::ALT)));
+        assert_eq!(b, KeyBinding::parse("alt+e").unwrap());
     }
 
     #[test]
     fn parse_function_key() {
         let b = KeyBinding::parse("f12").expect("should parse");
-        assert!(b.matches(press(KeyCode::F(12), KeyModifiers::empty())));
+        assert_eq!(
+            b,
+            KeyBinding::from_event(press(KeyCode::F(12), KeyModifiers::empty()))
+        );
     }
 
     #[test]
@@ -249,6 +481,20 @@ mod tests {
         assert!(KeyBinding::parse("enter").is_some());
         assert!(KeyBinding::parse("esc").is_some());
         assert!(KeyBinding::parse("ctrl+backspace").is_some());
+    }
+
+    #[test]
+    fn parse_backtab_and_shift_tab_are_equivalent() {
+        let backtab = KeyBinding::parse("backtab").expect("should parse");
+        let shift_tab = KeyBinding::parse("shift+tab").expect("should parse");
+        assert_eq!(backtab, shift_tab);
+    }
+
+    #[test]
+    fn backtab_event_normalises_to_shift_tab() {
+        let backtab_event = KeyBinding::from_event(press(KeyCode::BackTab, KeyModifiers::empty()));
+        let shift_tab = KeyBinding::parse("shift+tab").expect("should parse");
+        assert_eq!(backtab_event, shift_tab);
     }
 
     #[test]
@@ -279,40 +525,84 @@ mod tests {
     }
 
     #[test]
+    fn label_backtab_is_shift_tab() {
+        let b = KeyBinding::parse("backtab").expect("should parse");
+        assert_eq!(b.label(), "Shift+Tab");
+    }
+
+    #[test]
     fn shift_binding_matches_all_three_terminal_styles() {
         let b = KeyBinding::parse("shift+j").expect("should parse");
         // (a) crossterm canonical: lowercase + SHIFT modifier
-        assert!(b.matches(press(KeyCode::Char('j'), KeyModifiers::SHIFT)));
+        assert_eq!(b, KeyBinding::from_event(press(KeyCode::Char('j'), KeyModifiers::SHIFT)));
         // (b) legacy: uppercase + no modifier
-        assert!(b.matches(press(KeyCode::Char('J'), KeyModifiers::empty())));
+        assert_eq!(b, KeyBinding::from_event(press(KeyCode::Char('J'), KeyModifiers::empty())));
         // (c) uppercase WITH SHIFT still set (some terminals)
-        assert!(b.matches(press(KeyCode::Char('J'), KeyModifiers::SHIFT)));
+        assert_eq!(b, KeyBinding::from_event(press(KeyCode::Char('J'), KeyModifiers::SHIFT)));
         // must NOT match plain lowercase
-        assert!(!b.matches(press(KeyCode::Char('j'), KeyModifiers::empty())));
+        assert_ne!(b, KeyBinding::from_event(press(KeyCode::Char('j'), KeyModifiers::empty())));
     }
 
     #[test]
     fn jump_bottom_matches_capital_g() {
         let b = KeyBinding::parse("shift+g").expect("should parse");
-        assert!(b.matches(press(KeyCode::Char('g'), KeyModifiers::SHIFT)));
-        assert!(b.matches(press(KeyCode::Char('G'), KeyModifiers::empty())));
-        assert!(b.matches(press(KeyCode::Char('G'), KeyModifiers::SHIFT)));
-        assert!(!b.matches(press(KeyCode::Char('g'), KeyModifiers::empty())));
+        assert_eq!(b, KeyBinding::from_event(press(KeyCode::Char('g'), KeyModifiers::SHIFT)));
+        assert_eq!(b, KeyBinding::from_event(press(KeyCode::Char('G'), KeyModifiers::empty())));
+        assert_eq!(b, KeyBinding::from_event(press(KeyCode::Char('G'), KeyModifiers::SHIFT)));
+        assert_ne!(b, KeyBinding::from_event(press(KeyCode::Char('g'), KeyModifiers::empty())));
+    }
+
+    #[test]
+    fn default_bindings_look_up_correctly() {
+        let kb = ActiveKeyBindings::default();
+        assert_eq!(kb.lookup(press(KeyCode::Char('q'), KeyModifiers::empty())), Some(Action::Quit));
+        assert_eq!(kb.lookup(press(KeyCode::Char('j'), KeyModifiers::empty())), Some(Action::MoveDown));
+        assert_eq!(kb.lookup(press(KeyCode::Down, KeyModifiers::empty())), Some(Action::MoveDown));
+        assert_eq!(kb.lookup(press(KeyCode::Tab, KeyModifiers::empty())), Some(Action::CycleFocusForward));
+        assert_eq!(kb.lookup(press(KeyCode::BackTab, KeyModifiers::empty())), Some(Action::CycleFocusBackward));
+        assert_eq!(kb.lookup(press(KeyCode::Enter, KeyModifiers::empty())), Some(Action::Confirm));
+        assert_eq!(kb.lookup(press(KeyCode::Esc, KeyModifiers::empty())), Some(Action::Return));
     }
 
     #[test]
     fn from_config_falls_back_on_bad_spec() {
+        use std::collections::HashMap;
         use crate::config::KeyBindingsConfig;
-        let cfg = KeyBindingsConfig {
-            open_in_editor: "notakey".to_owned(),
-            ..KeyBindingsConfig::default()
-        };
+        let mut map = HashMap::new();
+        map.insert("open_in_editor".to_owned(), "notakey".to_owned());
+        let cfg = KeyBindingsConfig(map);
         let bindings = ActiveKeyBindings::from_config(&cfg);
         // Should have fallen back to ctrl+e
-        assert!(
-            bindings
-                .open_in_editor
-                .matches(press(KeyCode::Char('e'), KeyModifiers::CONTROL))
+        assert_eq!(
+            bindings.lookup(press(KeyCode::Char('e'), KeyModifiers::CONTROL)),
+            Some(Action::OpenInEditor)
         );
+    }
+
+    #[test]
+    fn custom_binding_overrides_default() {
+        use std::collections::HashMap;
+        use crate::config::KeyBindingsConfig;
+        let mut map = HashMap::new();
+        map.insert("open_composer".to_owned(), "e".to_owned());
+        let cfg = KeyBindingsConfig(map);
+        let bindings = ActiveKeyBindings::from_config(&cfg);
+        assert_eq!(
+            bindings.lookup(press(KeyCode::Char('e'), KeyModifiers::empty())),
+            Some(Action::OpenComposer)
+        );
+        // Old default 'i' should no longer be mapped
+        assert_ne!(
+            bindings.lookup(press(KeyCode::Char('i'), KeyModifiers::empty())),
+            Some(Action::OpenComposer)
+        );
+    }
+
+    #[test]
+    fn label_returns_current_binding() {
+        let kb = ActiveKeyBindings::default();
+        assert_eq!(kb.label(Action::MoveDown), "j");
+        assert_eq!(kb.label(Action::Quit), "q");
+        assert_eq!(kb.label(Action::OpenInEditor), "Ctrl+E");
     }
 }

--- a/src/tui/media/targets.rs
+++ b/src/tui/media/targets.rs
@@ -323,7 +323,9 @@ fn discord_media_proxy_preview_url(
         ImagePreviewQualityPreset::High => {
             params.push(format!("quality={DISCORD_MEDIA_PROXY_PREVIEW_QUALITY}"));
         }
-        ImagePreviewQualityPreset::Balanced | ImagePreviewQualityPreset::Original => {}
+        ImagePreviewQualityPreset::Balanced
+        | ImagePreviewQualityPreset::Auto
+        | ImagePreviewQualityPreset::Original => {}
     }
     params.push(format!("width={width}"));
     params.push(format!("height={height}"));
@@ -361,7 +363,7 @@ fn discord_media_proxy_preview_dimensions(
 fn preview_source_scale(quality: ImagePreviewQualityPreset) -> (u64, u64) {
     match quality {
         ImagePreviewQualityPreset::Efficient => (3, 10),
-        ImagePreviewQualityPreset::Balanced => (1, 2),
+        ImagePreviewQualityPreset::Balanced | ImagePreviewQualityPreset::Auto => (1, 2),
         ImagePreviewQualityPreset::High | ImagePreviewQualityPreset::Original => (1, 1),
     }
 }
@@ -412,6 +414,7 @@ fn preview_source_pixels_per_cell(quality: ImagePreviewQualityPreset) -> (u64, u
     let pixels_per_column = match quality {
         ImagePreviewQualityPreset::Efficient => EFFICIENT_IMAGE_PREVIEW_SOURCE_PIXELS_PER_COLUMN,
         ImagePreviewQualityPreset::Balanced
+        | ImagePreviewQualityPreset::Auto
         | ImagePreviewQualityPreset::High
         | ImagePreviewQualityPreset::Original => IMAGE_PREVIEW_SOURCE_PIXELS_PER_COLUMN,
     };

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -4,6 +4,7 @@ mod events;
 mod format;
 mod fuzzy;
 mod input;
+mod keybinding;
 mod login;
 mod media;
 mod message_format;
@@ -23,7 +24,6 @@ use crate::{
     Result,
     discord::{AppCommand, DiscordClient, SequencedAppEvent, SnapshotRevision},
 };
-
 pub async fn prompt_login(notice: Option<String>) -> Result<String> {
     login::prompt_login(notice).await
 }

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 use super::{
-    commands as command_helpers, effects as effect_helpers, events, input,
+    commands as command_helpers, effects as effect_helpers, events, input, keybinding,
     media::{
         AvatarImageCache, EmojiImageCache, ImagePreviewCache, visible_avatar_targets,
         visible_emoji_image_targets, visible_image_preview_targets,
@@ -48,6 +48,14 @@ pub(super) async fn run_dashboard(
         }
     };
     let mut state = DashboardState::new_with_display_options(display_options);
+    let key_bindings = match config::load_key_bindings_config() {
+        Ok(cfg) => keybinding::ActiveKeyBindings::from_config(&cfg),
+        Err(error) => {
+            logging::error("config", format!("failed to load keybindings: {error}"));
+            keybinding::ActiveKeyBindings::default()
+        }
+    };
+    state.set_key_bindings(key_bindings);
     drop(snapshots.borrow_and_update());
     let initial_snapshot = client.current_discord_snapshot();
     let mut current_snapshot_revision = initial_snapshot.revision;
@@ -249,6 +257,11 @@ pub(super) async fn run_dashboard(
                             &mut mouse_clicks,
                             &mut redraw_diagnostics,
                         )?;
+                        if state.take_open_composer_in_editor_request() {
+                            if let Err(error) = open_composer_in_editor(terminal, &mut state) {
+                                logging::error("tui", format!("editor failed: {error}"));
+                            }
+                        }
                         if let Some(command) = outcome.command
                             && commands.send(command).await.is_err()
                         {
@@ -574,5 +587,59 @@ pub(super) async fn run_dashboard(
         }
     }
 
+    Ok(())
+}
+
+fn open_composer_in_editor(
+    terminal: &mut ratatui::DefaultTerminal,
+    state: &mut DashboardState,
+) -> crate::Result<()> {
+    use std::{env, io::stdout};
+    use crossterm::execute;
+    use crossterm::event::{
+        DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
+        KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+    };
+
+    let editor = env::var("EDITOR").unwrap_or_else(|_| "vi".to_owned());
+
+    let mut temp = tempfile::Builder::new()
+        .prefix("concord-message-")
+        .suffix(".txt")
+        .tempfile()?;
+    std::io::Write::write_all(&mut temp, state.composer_input().as_bytes())?;
+    let path = temp.path().to_path_buf();
+
+    let _ = execute!(
+        stdout(),
+        PopKeyboardEnhancementFlags,
+        DisableMouseCapture,
+        DisableBracketedPaste,
+    );
+    ratatui::restore();
+
+    let status = tokio::task::block_in_place(|| {
+        std::process::Command::new("sh")
+            .arg("-c")
+            .arg(format!("{editor} \"$1\""))
+            .arg("--")
+            .arg(&path)
+            .status()
+    });
+
+    *terminal = ratatui::init();
+    let _ = execute!(
+        stdout(),
+        PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES),
+        EnableMouseCapture,
+        EnableBracketedPaste,
+    );
+
+    if let Ok(status) = status
+        && status.success()
+        && let Ok(content) = std::fs::read_to_string(&path)
+    {
+        state.replace_composer_input_from_editor(content);
+    }
     Ok(())
 }

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -594,12 +594,12 @@ fn open_composer_in_editor(
     terminal: &mut ratatui::DefaultTerminal,
     state: &mut DashboardState,
 ) -> crate::Result<()> {
-    use std::{env, io::stdout};
-    use crossterm::execute;
     use crossterm::event::{
         DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
         KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
     };
+    use crossterm::execute;
+    use std::{env, io::stdout};
 
     let editor = env::var("EDITOR").unwrap_or_else(|_| "vi".to_owned());
 

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -36,6 +36,7 @@ mod message_render;
 mod message_viewport;
 mod model;
 mod options;
+mod pane_filter;
 mod polls;
 mod popups;
 mod presentation;
@@ -45,6 +46,7 @@ mod subscriptions;
 mod user;
 
 use channel_switcher::ChannelSwitcherState;
+use pane_filter::PaneFilterState;
 use composer::{EmojiCompletion, MentionCompletion};
 use message_render::{add_literal_mention_highlights, normalize_text_highlights};
 use popups::{
@@ -239,6 +241,8 @@ pub struct DashboardState {
     key_bindings: ActiveKeyBindings,
     leader_mode: Option<LeaderMode>,
     channel_switcher: Option<ChannelSwitcherState>,
+    guild_pane_filter: Option<PaneFilterState>,
+    channel_pane_filter: Option<PaneFilterState>,
     guild_pane_visible: bool,
     channel_pane_visible: bool,
     member_pane_visible: bool,
@@ -370,6 +374,8 @@ impl DashboardState {
             key_bindings: ActiveKeyBindings::default(),
             leader_mode: None,
             channel_switcher: None,
+            guild_pane_filter: None,
+            channel_pane_filter: None,
             guild_pane_visible: true,
             channel_pane_visible: true,
             member_pane_visible: true,
@@ -1467,13 +1473,13 @@ impl DashboardState {
     pub fn move_down(&mut self) {
         match self.focus {
             FocusPane::Guilds => {
-                let len = self.guild_pane_entries().len();
+                let len = self.guild_pane_filtered_entries().len();
                 move_index_down(&mut self.selected_guild, len);
                 self.guild_keep_selection_visible = true;
                 self.clamp_guild_viewport();
             }
             FocusPane::Channels => {
-                let len = self.channel_pane_entries().len();
+                let len = self.channel_pane_filtered_entries().len();
                 move_index_down(&mut self.selected_channel, len);
                 self.channel_keep_selection_visible = true;
                 self.clamp_channel_viewport();
@@ -1549,12 +1555,12 @@ impl DashboardState {
     pub fn jump_bottom(&mut self) {
         match self.focus {
             FocusPane::Guilds => {
-                self.selected_guild = last_index(self.guild_pane_entries().len());
+                self.selected_guild = last_index(self.guild_pane_filtered_entries().len());
                 self.guild_keep_selection_visible = true;
                 self.clamp_guild_viewport();
             }
             FocusPane::Channels => {
-                self.selected_channel = last_index(self.channel_pane_entries().len());
+                self.selected_channel = last_index(self.channel_pane_filtered_entries().len());
                 self.channel_keep_selection_visible = true;
                 self.clamp_channel_viewport();
             }
@@ -1576,14 +1582,14 @@ impl DashboardState {
         match self.focus {
             FocusPane::Guilds => {
                 let distance = pane_content_height(self.guild_view_height) / 2;
-                let len = self.guild_pane_entries().len();
+                let len = self.guild_pane_filtered_entries().len();
                 move_index_down_by(&mut self.selected_guild, len, distance.max(1));
                 self.guild_keep_selection_visible = true;
                 self.clamp_guild_viewport();
             }
             FocusPane::Channels => {
                 let distance = pane_content_height(self.channel_view_height) / 2;
-                let len = self.channel_pane_entries().len();
+                let len = self.channel_pane_filtered_entries().len();
                 move_index_down_by(&mut self.selected_channel, len, distance.max(1));
                 self.channel_keep_selection_visible = true;
                 self.clamp_channel_viewport();
@@ -1643,13 +1649,13 @@ impl DashboardState {
         match self.focus {
             FocusPane::Guilds => {
                 let height = pane_content_height(self.guild_view_height);
-                let len = self.guild_pane_entries().len();
+                let len = self.guild_pane_filtered_entries().len();
                 self.guild_keep_selection_visible = false;
                 scroll_list_down(&mut self.guild_scroll, height, len);
             }
             FocusPane::Channels => {
                 let height = pane_content_height(self.channel_view_height);
-                let len = self.channel_pane_entries().len();
+                let len = self.channel_pane_filtered_entries().len();
                 self.channel_keep_selection_visible = false;
                 scroll_list_down(&mut self.channel_scroll, height, len);
             }
@@ -1706,7 +1712,7 @@ impl DashboardState {
     }
 
     fn max_guild_horizontal_scroll(&self) -> usize {
-        self.guild_pane_entries()
+        self.guild_pane_filtered_entries()
             .into_iter()
             .map(|entry| entry.label().width().saturating_sub(1))
             .max()
@@ -1714,7 +1720,7 @@ impl DashboardState {
     }
 
     fn max_channel_horizontal_scroll(&self) -> usize {
-        self.channel_pane_entries()
+        self.channel_pane_filtered_entries()
             .into_iter()
             .map(|entry| match entry {
                 ChannelPaneEntry::CategoryHeader { state, .. }
@@ -1806,7 +1812,7 @@ impl DashboardState {
 
     fn select_visible_guild_row(&mut self, row: usize) -> bool {
         let index = self.guild_scroll.saturating_add(row);
-        if index >= self.guild_pane_entries().len() {
+        if index >= self.guild_pane_filtered_entries().len() {
             return false;
         }
         self.selected_guild = index;
@@ -1816,7 +1822,7 @@ impl DashboardState {
 
     fn select_visible_channel_row(&mut self, row: usize) -> bool {
         let index = self.channel_scroll.saturating_add(row);
-        if index >= self.channel_pane_entries().len() {
+        if index >= self.channel_pane_filtered_entries().len() {
             return false;
         }
         self.selected_channel = index;
@@ -1901,7 +1907,7 @@ impl DashboardState {
     }
 
     fn clamp_guild_viewport(&mut self) {
-        let entries_len = self.guild_pane_entries().len();
+        let entries_len = self.guild_pane_filtered_entries().len();
         self.selected_guild = clamp_selected_index(self.selected_guild, entries_len);
         clamp_list_viewport(
             self.selected_guild,
@@ -1913,7 +1919,7 @@ impl DashboardState {
     }
 
     fn clamp_channel_viewport(&mut self) {
-        let entries_len = self.channel_pane_entries().len();
+        let entries_len = self.channel_pane_filtered_entries().len();
         self.selected_channel = clamp_selected_index(self.selected_channel, entries_len);
         clamp_list_viewport(
             self.selected_channel,

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -20,6 +20,7 @@ use super::format::{
     MentionTarget, RenderedText, TextHighlightKind, render_user_mentions,
     render_user_mentions_with_highlights, replace_custom_emoji_markup,
 };
+use super::keybinding::ActiveKeyBindings;
 mod channel_switcher;
 mod channels;
 mod composer;
@@ -233,6 +234,9 @@ pub struct DashboardState {
     poll_vote_picker: Option<PollVotePickerState>,
     reaction_users_popup: Option<ReactionUsersPopupState>,
     debug_log_popup_open: bool,
+    keymap_popup_open: bool,
+    open_composer_in_editor_requested: bool,
+    key_bindings: ActiveKeyBindings,
     leader_mode: Option<LeaderMode>,
     channel_switcher: Option<ChannelSwitcherState>,
     guild_pane_visible: bool,
@@ -361,6 +365,9 @@ impl DashboardState {
             poll_vote_picker: None,
             reaction_users_popup: None,
             debug_log_popup_open: false,
+            keymap_popup_open: false,
+            open_composer_in_editor_requested: false,
+            key_bindings: ActiveKeyBindings::default(),
             leader_mode: None,
             channel_switcher: None,
             guild_pane_visible: true,

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -46,9 +46,9 @@ mod subscriptions;
 mod user;
 
 use channel_switcher::ChannelSwitcherState;
-use pane_filter::PaneFilterState;
 use composer::{EmojiCompletion, MentionCompletion};
 use message_render::{add_literal_mention_highlights, normalize_text_highlights};
+use pane_filter::PaneFilterState;
 use popups::{
     ChannelLeaderActionState, GuildLeaderActionState, ImageViewerState, MemberLeaderActionState,
     UserProfilePopupState,

--- a/src/tui/state/channels.rs
+++ b/src/tui/state/channels.rs
@@ -7,7 +7,8 @@ use crate::discord::ids::{
 use crate::discord::{AppCommand, AppEvent, ChannelState};
 
 use super::{
-    ActiveGuildScope, DashboardState, PendingReadAck, READ_ACK_DEBOUNCE, ThreadReturnTarget,
+    ActiveGuildScope, DashboardState, PaneFilterState, PendingReadAck, READ_ACK_DEBOUNCE,
+    ThreadReturnTarget,
 };
 use super::{
     model::{
@@ -22,6 +23,7 @@ use super::{
         pane_content_height, toggle_collapsed_key,
     },
 };
+use crate::tui::fuzzy::fuzzy_text_score;
 
 impl DashboardState {
     pub fn open_selected_channel_actions(&mut self) {
@@ -675,8 +677,110 @@ impl DashboardState {
         entries
     }
 
+    /// Returns channel pane entries filtered by the active pane filter query,
+    /// or all entries if no filter is active. Category headers are omitted when
+    /// a query is present so results appear as a flat list of matching channels.
+    pub fn channel_pane_filtered_entries(&self) -> Vec<ChannelPaneEntry<'_>> {
+        let query = self
+            .channel_pane_filter
+            .as_ref()
+            .map(|f| f.query.trim().to_owned())
+            .filter(|q| !q.is_empty());
+        let Some(query) = query else {
+            return self.channel_pane_entries();
+        };
+        self.channel_pane_entries()
+            .into_iter()
+            .filter(|entry| match entry {
+                ChannelPaneEntry::CategoryHeader { .. } => false,
+                ChannelPaneEntry::Channel { state, .. } => {
+                    fuzzy_text_score(&state.name, &query).is_some()
+                }
+            })
+            .collect()
+    }
+
+    pub fn is_channel_pane_filter_active(&self) -> bool {
+        self.channel_pane_filter.is_some()
+    }
+
+    pub fn channel_pane_filter_query(&self) -> Option<&str> {
+        self.channel_pane_filter.as_ref().map(|f| f.query())
+    }
+
+    pub fn channel_pane_filter_cursor(&self) -> Option<usize> {
+        self.channel_pane_filter
+            .as_ref()
+            .map(|f| f.cursor_byte_index())
+    }
+
+    pub fn open_channel_pane_filter(&mut self) {
+        self.selected_channel = 0;
+        self.channel_scroll = 0;
+        self.channel_keep_selection_visible = true;
+        self.channel_pane_filter = Some(PaneFilterState::new());
+    }
+
+    pub fn close_channel_pane_filter(&mut self) {
+        self.channel_pane_filter = None;
+        self.selected_channel = 0;
+        self.channel_scroll = 0;
+        self.channel_keep_selection_visible = true;
+    }
+
+    pub fn confirm_channel_pane_filter(&mut self) -> Option<AppCommand> {
+        let selected = self.selected_channel();
+        let channel_id = {
+            let entries = self.channel_pane_filtered_entries();
+            match entries.get(selected) {
+                Some(ChannelPaneEntry::Channel { state, .. }) => Some(state.id),
+                _ => None,
+            }
+        };
+        self.channel_pane_filter = None;
+        if let Some(channel_id) = channel_id {
+            // Restore selection to the unfiltered position
+            if let Some(idx) = self.channel_pane_entries().iter().position(|e| {
+                matches!(e, ChannelPaneEntry::Channel { state, .. } if state.id == channel_id)
+            }) {
+                self.selected_channel = idx;
+            }
+            self.channel_keep_selection_visible = true;
+            return self.confirm_selected_channel_command();
+        }
+        None
+    }
+
+    pub fn push_channel_pane_filter_char(&mut self, value: char) {
+        if let Some(f) = self.channel_pane_filter.as_mut() {
+            f.push_char(value);
+            self.selected_channel = 0;
+            self.channel_scroll = 0;
+        }
+    }
+
+    pub fn pop_channel_pane_filter_char(&mut self) {
+        if let Some(f) = self.channel_pane_filter.as_mut() {
+            f.pop_char();
+            self.selected_channel = 0;
+            self.channel_scroll = 0;
+        }
+    }
+
+    pub fn move_channel_pane_filter_cursor_left(&mut self) {
+        if let Some(f) = self.channel_pane_filter.as_mut() {
+            f.cursor_left();
+        }
+    }
+
+    pub fn move_channel_pane_filter_cursor_right(&mut self) {
+        if let Some(f) = self.channel_pane_filter.as_mut() {
+            f.cursor_right();
+        }
+    }
+
     pub fn selected_channel(&self) -> usize {
-        clamp_selected_index(self.selected_channel, self.channel_pane_entries().len())
+        clamp_selected_index(self.selected_channel, self.channel_pane_filtered_entries().len())
     }
 
     pub(super) fn selected_channel_cursor_id(&self) -> Option<Id<ChannelMarker>> {
@@ -691,7 +795,7 @@ impl DashboardState {
     }
 
     pub fn visible_channel_pane_entries(&self) -> Vec<ChannelPaneEntry<'_>> {
-        self.channel_pane_entries()
+        self.channel_pane_filtered_entries()
             .into_iter()
             .skip(self.channel_scroll)
             .take(pane_content_height(self.channel_view_height))
@@ -699,7 +803,7 @@ impl DashboardState {
     }
 
     pub fn focused_channel_selection(&self) -> Option<usize> {
-        if self.focus == FocusPane::Channels && !self.channel_pane_entries().is_empty() {
+        if self.focus == FocusPane::Channels && !self.channel_pane_filtered_entries().is_empty() {
             let selected = self.selected_channel();
             let visible_len = self.visible_channel_pane_entries().len();
             if selected >= self.channel_scroll && selected < self.channel_scroll + visible_len {
@@ -715,7 +819,7 @@ impl DashboardState {
     pub fn set_channel_view_height(&mut self, height: usize) {
         self.channel_view_height = height;
         let height = pane_content_height(self.channel_view_height);
-        let len = self.channel_pane_entries().len();
+        let len = self.channel_pane_filtered_entries().len();
         clamp_list_viewport(
             self.selected_channel,
             &mut self.channel_scroll,

--- a/src/tui/state/channels.rs
+++ b/src/tui/state/channels.rs
@@ -689,13 +689,17 @@ impl DashboardState {
         let Some(query) = query else {
             return self.channel_pane_entries();
         };
-        self.channel_pane_entries()
+        // Search directly over channels() so children inside collapsed
+        // categories are included in results even when not normally visible.
+        let mut channels = self.channels();
+        channels.retain(|c| {
+            !c.is_thread() && !c.is_category() && fuzzy_text_score(&c.name, &query).is_some()
+        });
+        channels
             .into_iter()
-            .filter(|entry| match entry {
-                ChannelPaneEntry::CategoryHeader { .. } => false,
-                ChannelPaneEntry::Channel { state, .. } => {
-                    fuzzy_text_score(&state.name, &query).is_some()
-                }
+            .map(|state| ChannelPaneEntry::Channel {
+                state,
+                branch: ChannelBranch::None,
             })
             .collect()
     }

--- a/src/tui/state/channels.rs
+++ b/src/tui/state/channels.rs
@@ -740,9 +740,9 @@ impl DashboardState {
         self.channel_pane_filter = None;
         if let Some(channel_id) = channel_id {
             // Restore selection to the unfiltered position
-            if let Some(idx) = self.channel_pane_entries().iter().position(|e| {
-                matches!(e, ChannelPaneEntry::Channel { state, .. } if state.id == channel_id)
-            }) {
+            if let Some(idx) = self.channel_pane_entries().iter().position(
+                |e| matches!(e, ChannelPaneEntry::Channel { state, .. } if state.id == channel_id),
+            ) {
                 self.selected_channel = idx;
             }
             self.channel_keep_selection_visible = true;
@@ -780,7 +780,10 @@ impl DashboardState {
     }
 
     pub fn selected_channel(&self) -> usize {
-        clamp_selected_index(self.selected_channel, self.channel_pane_filtered_entries().len())
+        clamp_selected_index(
+            self.selected_channel,
+            self.channel_pane_filtered_entries().len(),
+        )
     }
 
     pub(super) fn selected_channel_cursor_id(&self) -> Option<Id<ChannelMarker>> {

--- a/src/tui/state/composer_state.rs
+++ b/src/tui/state/composer_state.rs
@@ -128,6 +128,13 @@ impl DashboardState {
         self.focus = FocusPane::Messages;
     }
 
+    pub fn replace_composer_input_from_editor(&mut self, value: String) {
+        self.composer_input = value;
+        self.composer_cursor_byte_index = self.composer_input.len();
+        self.reset_mention_picker_state();
+        self.refresh_active_mention_query();
+    }
+
     pub fn cancel_composer(&mut self) {
         self.composer_active = false;
         self.composer_input.clear();

--- a/src/tui/state/diagnostics.rs
+++ b/src/tui/state/diagnostics.rs
@@ -32,6 +32,14 @@ impl DashboardState {
         self.keymap_popup_open = false;
     }
 
+    pub fn request_open_composer_in_editor(&mut self) {
+        self.open_composer_in_editor_requested = true;
+    }
+
+    pub fn take_open_composer_in_editor_request(&mut self) -> bool {
+        std::mem::take(&mut self.open_composer_in_editor_requested)
+    }
+
     pub fn debug_log_lines(&self) -> Vec<String> {
         logging::error_entries()
             .into_iter()

--- a/src/tui/state/diagnostics.rs
+++ b/src/tui/state/diagnostics.rs
@@ -20,6 +20,18 @@ impl DashboardState {
         self.debug_log_popup_open = false;
     }
 
+    pub fn is_keymap_popup_open(&self) -> bool {
+        self.keymap_popup_open
+    }
+
+    pub fn open_keymap_popup(&mut self) {
+        self.keymap_popup_open = true;
+    }
+
+    pub fn close_keymap_popup(&mut self) {
+        self.keymap_popup_open = false;
+    }
+
     pub fn debug_log_lines(&self) -> Vec<String> {
         logging::error_entries()
             .into_iter()

--- a/src/tui/state/guilds.rs
+++ b/src/tui/state/guilds.rs
@@ -132,19 +132,23 @@ impl DashboardState {
         let Some(query) = query else {
             return self.guild_pane_entries();
         };
-        self.guild_pane_entries()
-            .into_iter()
-            .filter(|entry| match entry {
-                GuildPaneEntry::DirectMessages => {
-                    fuzzy_text_score("direct messages", &query).is_some()
-                        || fuzzy_text_score("dm", &query).is_some()
-                }
-                GuildPaneEntry::FolderHeader { .. } => false,
-                GuildPaneEntry::Guild { state, .. } => {
-                    fuzzy_text_score(&state.name, &query).is_some()
-                }
-            })
-            .collect()
+        // Search directly over discord.guilds() so servers inside collapsed
+        // folders appear in results even when they're not normally visible.
+        let mut results: Vec<GuildPaneEntry<'_>> = Vec::new();
+        if fuzzy_text_score("direct messages", &query).is_some()
+            || fuzzy_text_score("dm", &query).is_some()
+        {
+            results.push(GuildPaneEntry::DirectMessages);
+        }
+        for guild in self.discord.guilds() {
+            if fuzzy_text_score(&guild.name, &query).is_some() {
+                results.push(GuildPaneEntry::Guild {
+                    state: guild,
+                    branch: GuildBranch::None,
+                });
+            }
+        }
+        results
     }
 
     pub fn is_guild_pane_filter_active(&self) -> bool {

--- a/src/tui/state/guilds.rs
+++ b/src/tui/state/guilds.rs
@@ -243,7 +243,10 @@ impl DashboardState {
     }
 
     pub fn selected_guild(&self) -> usize {
-        clamp_selected_index(self.selected_guild, self.guild_pane_filtered_entries().len())
+        clamp_selected_index(
+            self.selected_guild,
+            self.guild_pane_filtered_entries().len(),
+        )
     }
 
     pub fn guild_scroll(&self) -> usize {

--- a/src/tui/state/guilds.rs
+++ b/src/tui/state/guilds.rs
@@ -6,7 +6,7 @@ use crate::discord::ids::{
 };
 use crate::discord::{AppCommand, AppEvent, GuildFolder, GuildState};
 
-use super::{ActiveGuildScope, DashboardState, FolderKey};
+use super::{ActiveGuildScope, DashboardState, FolderKey, PaneFilterState};
 use super::{
     model::{
         FocusPane, GuildActionItem, GuildActionKind, GuildBranch, GuildPaneEntry,
@@ -18,6 +18,7 @@ use super::{
         pane_content_height, toggle_collapsed_key,
     },
 };
+use crate::tui::fuzzy::fuzzy_text_score;
 
 impl DashboardState {
     pub fn guild_name(&self, guild_id: Id<GuildMarker>) -> Option<&str> {
@@ -119,8 +120,130 @@ impl DashboardState {
         entries
     }
 
+    /// Returns guild pane entries filtered by the active pane filter query, or
+    /// all entries if no filter is active. Folder headers are omitted when a
+    /// query is present so results appear as a flat, scored list.
+    pub fn guild_pane_filtered_entries(&self) -> Vec<GuildPaneEntry<'_>> {
+        let query = self
+            .guild_pane_filter
+            .as_ref()
+            .map(|f| f.query.trim().to_owned())
+            .filter(|q| !q.is_empty());
+        let Some(query) = query else {
+            return self.guild_pane_entries();
+        };
+        self.guild_pane_entries()
+            .into_iter()
+            .filter(|entry| match entry {
+                GuildPaneEntry::DirectMessages => {
+                    fuzzy_text_score("direct messages", &query).is_some()
+                        || fuzzy_text_score("dm", &query).is_some()
+                }
+                GuildPaneEntry::FolderHeader { .. } => false,
+                GuildPaneEntry::Guild { state, .. } => {
+                    fuzzy_text_score(&state.name, &query).is_some()
+                }
+            })
+            .collect()
+    }
+
+    pub fn is_guild_pane_filter_active(&self) -> bool {
+        self.guild_pane_filter.is_some()
+    }
+
+    pub fn guild_pane_filter_query(&self) -> Option<&str> {
+        self.guild_pane_filter.as_ref().map(|f| f.query())
+    }
+
+    pub fn guild_pane_filter_cursor(&self) -> Option<usize> {
+        self.guild_pane_filter
+            .as_ref()
+            .map(|f| f.cursor_byte_index())
+    }
+
+    pub fn open_guild_pane_filter(&mut self) {
+        self.selected_guild = 0;
+        self.guild_scroll = 0;
+        self.guild_keep_selection_visible = true;
+        self.guild_pane_filter = Some(PaneFilterState::new());
+    }
+
+    pub fn close_guild_pane_filter(&mut self) {
+        self.guild_pane_filter = None;
+        self.selected_guild = 0;
+        self.guild_scroll = 0;
+        self.guild_keep_selection_visible = true;
+    }
+
+    pub fn confirm_guild_pane_filter(&mut self) {
+        let selected = self.selected_guild();
+        let action = {
+            let entries = self.guild_pane_filtered_entries();
+            match entries.get(selected) {
+                Some(GuildPaneEntry::DirectMessages) => Some(ActiveGuildScope::DirectMessages),
+                Some(GuildPaneEntry::Guild { state, .. }) => {
+                    Some(ActiveGuildScope::Guild(state.id))
+                }
+                _ => None,
+            }
+        };
+        self.guild_pane_filter = None;
+        self.selected_guild = 0;
+        self.guild_scroll = 0;
+        if let Some(scope) = action {
+            match scope {
+                ActiveGuildScope::DirectMessages => {
+                    if let Some(idx) = self
+                        .guild_pane_entries()
+                        .iter()
+                        .position(|e| matches!(e, GuildPaneEntry::DirectMessages))
+                    {
+                        self.selected_guild = idx;
+                    }
+                }
+                ActiveGuildScope::Guild(guild_id) => {
+                    if let Some(idx) = self.guild_pane_entries().iter().position(|e| {
+                        matches!(e, GuildPaneEntry::Guild { state, .. } if state.id == guild_id)
+                    }) {
+                        self.selected_guild = idx;
+                    }
+                }
+                ActiveGuildScope::Unset => {}
+            }
+            self.activate_guild(scope);
+        }
+    }
+
+    pub fn push_guild_pane_filter_char(&mut self, value: char) {
+        if let Some(f) = self.guild_pane_filter.as_mut() {
+            f.push_char(value);
+            self.selected_guild = 0;
+            self.guild_scroll = 0;
+        }
+    }
+
+    pub fn pop_guild_pane_filter_char(&mut self) {
+        if let Some(f) = self.guild_pane_filter.as_mut() {
+            f.pop_char();
+            self.selected_guild = 0;
+            self.guild_scroll = 0;
+        }
+    }
+
+    pub fn move_guild_pane_filter_cursor_left(&mut self) {
+        if let Some(f) = self.guild_pane_filter.as_mut() {
+            f.cursor_left();
+        }
+    }
+
+    pub fn move_guild_pane_filter_cursor_right(&mut self) {
+        if let Some(f) = self.guild_pane_filter.as_mut() {
+            f.cursor_right();
+        }
+    }
+
     pub fn selected_guild(&self) -> usize {
-        clamp_selected_index(self.selected_guild, self.guild_pane_entries().len())
+        clamp_selected_index(self.selected_guild, self.guild_pane_filtered_entries().len())
     }
 
     pub fn guild_scroll(&self) -> usize {
@@ -128,7 +251,7 @@ impl DashboardState {
     }
 
     pub fn visible_guild_pane_entries(&self) -> Vec<GuildPaneEntry<'_>> {
-        self.guild_pane_entries()
+        self.guild_pane_filtered_entries()
             .into_iter()
             .skip(self.guild_scroll)
             .take(pane_content_height(self.guild_view_height))
@@ -136,7 +259,7 @@ impl DashboardState {
     }
 
     pub fn focused_guild_selection(&self) -> Option<usize> {
-        if self.focus == FocusPane::Guilds && !self.guild_pane_entries().is_empty() {
+        if self.focus == FocusPane::Guilds && !self.guild_pane_filtered_entries().is_empty() {
             let selected = self.selected_guild();
             let visible_len = self.visible_guild_pane_entries().len();
             if selected >= self.guild_scroll && selected < self.guild_scroll + visible_len {
@@ -152,7 +275,7 @@ impl DashboardState {
     pub fn set_guild_view_height(&mut self, height: usize) {
         self.guild_view_height = height;
         let height = pane_content_height(self.guild_view_height);
-        let len = self.guild_pane_entries().len();
+        let len = self.guild_pane_filtered_entries().len();
         clamp_list_viewport(
             self.selected_guild,
             &mut self.guild_scroll,

--- a/src/tui/state/options.rs
+++ b/src/tui/state/options.rs
@@ -1,4 +1,5 @@
 use crate::config::{DisplayOptions, ImagePreviewQualityPreset};
+use crate::tui::keybinding::ActiveKeyBindings;
 
 use super::{DashboardState, FocusPane, popups::OptionsPopupState};
 
@@ -21,6 +22,14 @@ impl DashboardState {
             display_options,
             ..Self::new()
         }
+    }
+
+    pub fn set_key_bindings(&mut self, key_bindings: ActiveKeyBindings) {
+        self.key_bindings = key_bindings;
+    }
+
+    pub fn key_bindings(&self) -> &ActiveKeyBindings {
+        &self.key_bindings
     }
 
     pub fn display_options(&self) -> DisplayOptions {

--- a/src/tui/state/pane_filter.rs
+++ b/src/tui/state/pane_filter.rs
@@ -1,0 +1,76 @@
+use unicode_segmentation::UnicodeSegmentation;
+
+#[derive(Debug)]
+pub(super) struct PaneFilterState {
+    pub(super) query: String,
+    pub(super) query_cursor_byte_index: usize,
+}
+
+impl PaneFilterState {
+    pub(super) fn new() -> Self {
+        Self {
+            query: String::new(),
+            query_cursor_byte_index: 0,
+        }
+    }
+
+    pub(super) fn query(&self) -> &str {
+        &self.query
+    }
+
+    pub(super) fn cursor_byte_index(&self) -> usize {
+        clamp_cursor_index(&self.query, self.query_cursor_byte_index)
+    }
+
+    pub(super) fn push_char(&mut self, value: char) {
+        let cursor = self.cursor_byte_index();
+        self.query.insert(cursor, value);
+        self.query_cursor_byte_index = cursor + value.len_utf8();
+    }
+
+    pub(super) fn pop_char(&mut self) {
+        let cursor = self.cursor_byte_index();
+        if cursor == 0 {
+            return;
+        }
+        let start = previous_char_boundary(&self.query, cursor);
+        self.query.replace_range(start..cursor, "");
+        self.query_cursor_byte_index = start;
+    }
+
+    pub(super) fn cursor_left(&mut self) {
+        let cursor = self.cursor_byte_index();
+        self.query_cursor_byte_index = previous_char_boundary(&self.query, cursor);
+    }
+
+    pub(super) fn cursor_right(&mut self) {
+        let cursor = self.cursor_byte_index();
+        self.query_cursor_byte_index = next_char_boundary(&self.query, cursor);
+    }
+}
+
+fn clamp_cursor_index(value: &str, index: usize) -> usize {
+    let mut index = index.min(value.len());
+    while index > 0 && !value.is_char_boundary(index) {
+        index -= 1;
+    }
+    index
+}
+
+fn previous_char_boundary(value: &str, index: usize) -> usize {
+    let index = clamp_cursor_index(value, index);
+    value[..index]
+        .grapheme_indices(true)
+        .next_back()
+        .map(|(start, _)| start)
+        .unwrap_or(0)
+}
+
+fn next_char_boundary(value: &str, index: usize) -> usize {
+    let index = clamp_cursor_index(value, index);
+    value[index..]
+        .grapheme_indices(true)
+        .nth(1)
+        .map(|(offset, _)| index + offset)
+        .unwrap_or(value.len())
+}

--- a/src/tui/state/reactions.rs
+++ b/src/tui/state/reactions.rs
@@ -227,7 +227,7 @@ impl DashboardState {
         }
     }
 
-    pub(super) fn open_emoji_reaction_picker(&mut self) {
+    pub fn open_emoji_reaction_picker(&mut self) {
         if let Some(message) = self.selected_message_state() {
             if !self.can_open_reaction_picker(message) {
                 return;

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -113,8 +113,12 @@ pub fn sync_view_heights(area: Rect, state: &mut DashboardState) {
         state.is_guild_pane_filter_active() && state.is_pane_visible(FocusPane::Guilds),
     );
     state.set_guild_view_height(
-        visible_panel_content_height(areas.guilds, "Servers", state.is_pane_visible(FocusPane::Guilds))
-            .saturating_sub(guild_filter_row),
+        visible_panel_content_height(
+            areas.guilds,
+            "Servers",
+            state.is_pane_visible(FocusPane::Guilds),
+        )
+        .saturating_sub(guild_filter_row),
     );
     let channel_filter_row = usize::from(
         state.is_channel_pane_filter_active() && state.is_pane_visible(FocusPane::Channels),

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -74,9 +74,9 @@ use self::panes::{
 use self::panes::{render_channels, render_guilds, render_header, render_members};
 use self::popups::{
     render_channel_switcher_popup, render_debug_log_popup, render_emoji_reaction_picker,
-    render_image_viewer, render_leader_popup, render_message_action_menu, render_options_popup,
-    render_poll_vote_picker, render_reaction_users_popup, render_user_profile_popup,
-    user_profile_popup_has_avatar, user_profile_popup_text_geometry,
+    render_image_viewer, render_keymap_popup, render_leader_popup, render_message_action_menu,
+    render_options_popup, render_poll_vote_picker, render_reaction_users_popup,
+    render_user_profile_popup, user_profile_popup_has_avatar, user_profile_popup_text_geometry,
     user_profile_popup_total_lines,
 };
 use self::types::{
@@ -109,16 +109,24 @@ use self::{
 };
 pub fn sync_view_heights(area: Rect, state: &mut DashboardState) {
     let areas = dashboard_areas(area, state);
-    state.set_guild_view_height(visible_panel_content_height(
-        areas.guilds,
-        "Servers",
-        state.is_pane_visible(FocusPane::Guilds),
-    ));
-    state.set_channel_view_height(visible_panel_content_height(
-        areas.channels,
-        "Channels",
-        state.is_pane_visible(FocusPane::Channels),
-    ));
+    let guild_filter_row = usize::from(
+        state.is_guild_pane_filter_active() && state.is_pane_visible(FocusPane::Guilds),
+    );
+    state.set_guild_view_height(
+        visible_panel_content_height(areas.guilds, "Servers", state.is_pane_visible(FocusPane::Guilds))
+            .saturating_sub(guild_filter_row),
+    );
+    let channel_filter_row = usize::from(
+        state.is_channel_pane_filter_active() && state.is_pane_visible(FocusPane::Channels),
+    );
+    state.set_channel_view_height(
+        visible_panel_content_height(
+            areas.channels,
+            "Channels",
+            state.is_pane_visible(FocusPane::Channels),
+        )
+        .saturating_sub(channel_filter_row),
+    );
     state.set_message_view_height(message_list_area(areas.messages, state).height as usize);
     state.set_member_view_height(visible_panel_content_height(
         areas.members,
@@ -205,6 +213,7 @@ pub fn render(
     render_reaction_users_popup(frame, areas.messages, state);
     render_image_viewer(frame, areas.messages, state, viewer_image_preview);
     render_debug_log_popup(frame, areas.messages, state);
+    render_keymap_popup(frame, areas.messages, state);
 }
 
 fn message_content_width(list: Rect) -> usize {

--- a/src/tui/ui/interaction.rs
+++ b/src/tui/ui/interaction.rs
@@ -42,13 +42,24 @@ pub(crate) fn mouse_target_at(
         return Some(target);
     }
     if state.is_pane_visible(FocusPane::Guilds)
-        && let Some(target) = pane_row_mouse_target(areas.guilds, FocusPane::Guilds, column, row)
+        && let Some(target) = pane_row_mouse_target(
+            areas.guilds,
+            FocusPane::Guilds,
+            column,
+            row,
+            state.guild_pane_filter_query().is_some(),
+        )
     {
         return Some(target);
     }
     if state.is_pane_visible(FocusPane::Channels)
-        && let Some(target) =
-            pane_row_mouse_target(areas.channels, FocusPane::Channels, column, row)
+        && let Some(target) = pane_row_mouse_target(
+            areas.channels,
+            FocusPane::Channels,
+            column,
+            row,
+            state.channel_pane_filter_query().is_some(),
+        )
     {
         return Some(target);
     }
@@ -56,7 +67,8 @@ pub(crate) fn mouse_target_at(
         return Some(target);
     }
     if state.is_pane_visible(FocusPane::Members)
-        && let Some(target) = pane_row_mouse_target(areas.members, FocusPane::Members, column, row)
+        && let Some(target) =
+            pane_row_mouse_target(areas.members, FocusPane::Members, column, row, false)
     {
         return Some(target);
     }
@@ -142,12 +154,24 @@ fn pane_row_mouse_target(
     pane: FocusPane,
     column: u16,
     row: u16,
+    filter_active: bool,
 ) -> Option<MouseTarget> {
     if !rect_contains(area, column, row) {
         return None;
     }
     let inner = panel_block("", false).inner(area);
-    if rect_contains(inner, column, row) {
+    // When the filter bar occupies the last row of the inner area, shrink the
+    // list hit region so clicks on that row don't resolve to a list entry.
+    let list_height = if filter_active && inner.height >= 2 {
+        inner.height - 1
+    } else {
+        inner.height
+    };
+    let list_area = Rect {
+        height: list_height,
+        ..inner
+    };
+    if rect_contains(list_area, column, row) {
         return Some(MouseTarget::PaneRow {
             pane,
             row: row.saturating_sub(inner.y) as usize,

--- a/src/tui/ui/panes.rs
+++ b/src/tui/ui/panes.rs
@@ -178,8 +178,7 @@ pub(super) fn render_guilds(frame: &mut Frame, area: Rect, state: &DashboardStat
     if let Some(filter_rect) = filter_area {
         let query = filter_query.unwrap_or_default();
         let cursor = state.guild_pane_filter_cursor().unwrap_or(0);
-        let cursor_x =
-            render_pane_filter_bar(frame, filter_rect, query, cursor, focused);
+        let cursor_x = render_pane_filter_bar(frame, filter_rect, query, cursor, focused);
         if focused {
             frame.set_cursor_position(Position {
                 x: filter_rect.x.saturating_add(cursor_x as u16),
@@ -1388,9 +1387,9 @@ pub(super) fn render_header(frame: &mut Frame, area: Rect, state: &DashboardStat
     let keymap_key = state.key_bindings().label(Action::OpenKeymap);
     let hint = format!("Press {keymap_key} to see keybinds");
     frame.render_widget(
-        Paragraph::new(hint).alignment(Alignment::Right).style(Style::default()),
+        Paragraph::new(hint)
+            .alignment(Alignment::Right)
+            .style(Style::default()),
         area,
     );
 }
-
-

--- a/src/tui/ui/panes.rs
+++ b/src/tui/ui/panes.rs
@@ -142,11 +142,27 @@ pub(super) fn render_guilds(frame: &mut Frame, area: Rect, state: &DashboardStat
         })
         .collect();
 
-    let list = List::new(items)
-        .block(panel_block("Servers", state.focus() == FocusPane::Guilds))
-        .highlight_style(highlight_style());
+    let list = List::new(items).highlight_style(highlight_style());
+    let list = if filter_area.is_none() {
+        list.block(panel_block("Servers", focused))
+    } else {
+        list
+    };
+    frame.render_widget(list, list_area);
 
-    frame.render_widget(list, area);
+    if let Some(filter_rect) = filter_area {
+        let query = filter_query.unwrap_or_default();
+        let cursor = state.guild_pane_filter_cursor().unwrap_or(0);
+        let cursor_x =
+            render_pane_filter_bar(frame, filter_rect, query, cursor, focused);
+        if focused {
+            frame.set_cursor_position(Position {
+                x: filter_rect.x.saturating_add(cursor_x as u16),
+                y: filter_rect.y,
+            });
+        }
+    }
+
     render_vertical_scrollbar(
         frame,
         panel_scrollbar_area(area),
@@ -258,14 +274,26 @@ pub(super) fn render_channels(frame: &mut Frame, area: Rect, state: &DashboardSt
         })
         .collect();
 
-    let list = List::new(items)
-        .block(panel_block(
-            "Channels",
-            state.focus() == FocusPane::Channels,
-        ))
-        .highlight_style(highlight_style());
+    let list = List::new(items).highlight_style(highlight_style());
+    let list = if filter_area.is_none() {
+        list.block(panel_block("Channels", focused))
+    } else {
+        list
+    };
+    frame.render_widget(list, list_area);
 
-    frame.render_widget(list, area);
+    if let Some(filter_rect) = filter_area {
+        let query = filter_query.unwrap_or_default();
+        let cursor = state.channel_pane_filter_cursor().unwrap_or(0);
+        let cursor_x = render_pane_filter_bar(frame, filter_rect, query, cursor, focused);
+        if focused {
+            frame.set_cursor_position(Position {
+                x: filter_rect.x.saturating_add(cursor_x as u16),
+                y: filter_rect.y,
+            });
+        }
+    }
+
     render_vertical_scrollbar(
         frame,
         panel_scrollbar_area(area),
@@ -1251,6 +1279,14 @@ pub(super) fn render_header(frame: &mut Frame, area: Rect, state: &DashboardStat
     }
     frame.render_widget(
         Paragraph::new(Line::from(spans)).alignment(Alignment::Left),
+        area,
+    );
+
+    // Right-aligned hint so users discover the keybind help popup.
+    let keymap_key = state.key_bindings().open_keymap.label();
+    let hint = format!("Press {keymap_key} to see keybinds");
+    frame.render_widget(
+        Paragraph::new(hint).alignment(Alignment::Right).style(Style::default()),
         area,
     );
 }

--- a/src/tui/ui/panes.rs
+++ b/src/tui/ui/panes.rs
@@ -11,6 +11,7 @@ use unicode_width::UnicodeWidthStr;
 use crate::discord::{
     ActivityInfo, ActivityKind, ChannelUnreadState, MessageState, PresenceStatus,
 };
+use crate::tui::keybinding::Action;
 
 use super::super::{
     format::{truncate_display_width, truncate_display_width_from},
@@ -177,7 +178,8 @@ pub(super) fn render_guilds(frame: &mut Frame, area: Rect, state: &DashboardStat
     if let Some(filter_rect) = filter_area {
         let query = filter_query.unwrap_or_default();
         let cursor = state.guild_pane_filter_cursor().unwrap_or(0);
-        let cursor_x = render_pane_filter_bar(frame, filter_rect, query, cursor, focused);
+        let cursor_x =
+            render_pane_filter_bar(frame, filter_rect, query, cursor, focused);
         if focused {
             frame.set_cursor_position(Position {
                 x: filter_rect.x.saturating_add(cursor_x as u16),
@@ -1071,9 +1073,11 @@ pub(super) fn composer_text(state: &DashboardState, width: u16) -> String {
         // SEND is allowed but ATTACH is not. Tell the user uploads will be
         // refused before they try.
         if !state.can_attach_in_selected_channel() {
-            return format!("press i to write in {label} (attachments disabled)");
+            let key = state.key_bindings().label(Action::OpenComposer);
+            return format!("press {key} to write in {label} (attachments disabled)");
         }
-        return format!("press i to write in {label}");
+        let key = state.key_bindings().label(Action::OpenComposer);
+        return format!("press {key} to write in {label}");
     }
 
     "select a channel to write a message".to_owned()
@@ -1381,12 +1385,12 @@ pub(super) fn render_header(frame: &mut Frame, area: Rect, state: &DashboardStat
     );
 
     // Right-aligned hint so users discover the keybind help popup.
-    let keymap_key = state.key_bindings().open_keymap.label();
+    let keymap_key = state.key_bindings().label(Action::OpenKeymap);
     let hint = format!("Press {keymap_key} to see keybinds");
     frame.render_widget(
-        Paragraph::new(hint)
-            .alignment(Alignment::Right)
-            .style(Style::default()),
+        Paragraph::new(hint).alignment(Alignment::Right).style(Style::default()),
         area,
     );
 }
+
+

--- a/src/tui/ui/panes.rs
+++ b/src/tui/ui/panes.rs
@@ -177,8 +177,7 @@ pub(super) fn render_guilds(frame: &mut Frame, area: Rect, state: &DashboardStat
     if let Some(filter_rect) = filter_area {
         let query = filter_query.unwrap_or_default();
         let cursor = state.guild_pane_filter_cursor().unwrap_or(0);
-        let cursor_x =
-            render_pane_filter_bar(frame, filter_rect, query, cursor, focused);
+        let cursor_x = render_pane_filter_bar(frame, filter_rect, query, cursor, focused);
         if focused {
             frame.set_cursor_position(Position {
                 x: filter_rect.x.saturating_add(cursor_x as u16),
@@ -1385,7 +1384,9 @@ pub(super) fn render_header(frame: &mut Frame, area: Rect, state: &DashboardStat
     let keymap_key = state.key_bindings().open_keymap.label();
     let hint = format!("Press {keymap_key} to see keybinds");
     frame.render_widget(
-        Paragraph::new(hint).alignment(Alignment::Right).style(Style::default()),
+        Paragraph::new(hint)
+            .alignment(Alignment::Right)
+            .style(Style::default()),
         area,
     );
 }

--- a/src/tui/ui/panes.rs
+++ b/src/tui/ui/panes.rs
@@ -33,8 +33,32 @@ use super::{
 
 pub(super) fn render_guilds(frame: &mut Frame, area: Rect, state: &DashboardState) {
     let dashboard = state;
+    let focused = state.focus() == FocusPane::Guilds;
+    let filter_query = state.guild_pane_filter_query();
+
+    // When the filter is active split off one row at the bottom for the search
+    // bar, rendering the border block separately so we can carve up the inner.
+    let (list_area, filter_area) = if filter_query.is_some() && area.height >= 4 {
+        let block = panel_block("Servers", focused);
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+        let list_h = inner.height.saturating_sub(1);
+        let list_rect = Rect {
+            height: list_h,
+            ..inner
+        };
+        let filter_rect = Rect {
+            y: inner.y + list_h,
+            height: 1,
+            ..inner
+        };
+        (list_rect, Some(filter_rect))
+    } else {
+        (area, None)
+    };
+
     let entries = state.visible_guild_pane_entries();
-    let max_width = area.width.saturating_sub(6) as usize;
+    let max_width = list_area.width.saturating_sub(6) as usize;
     let horizontal_scroll = state.guild_horizontal_scroll();
     let selected = state.focused_guild_selection();
     let items: Vec<ListItem> = entries
@@ -177,10 +201,85 @@ fn notification_count_badge(unread: ChannelUnreadState) -> Span<'static> {
     badge.expect("numeric unread state always renders a badge")
 }
 
+/// Renders a one-line search bar at `area` and returns the visual column offset
+/// of the cursor within that area (column 0 = leftmost cell of `area`).
+fn render_pane_filter_bar(
+    frame: &mut Frame,
+    area: Rect,
+    query: &str,
+    cursor_byte: usize,
+    focused: bool,
+) -> usize {
+    let prompt = "/ ";
+    let prompt_width = prompt.width();
+    let available = (area.width as usize).saturating_sub(prompt_width).max(1);
+
+    // Scroll the visible window so the cursor is always in view.
+    let cursor_byte = cursor_byte.min(query.len());
+    let mut start = 0usize;
+    while query[start..cursor_byte].width() > available {
+        // Advance start by one char boundary
+        start = query[start..]
+            .char_indices()
+            .nth(1)
+            .map(|(off, _)| start + off)
+            .unwrap_or(query.len());
+    }
+    let mut end = cursor_byte;
+    while end < query.len() {
+        let next = query[end..]
+            .char_indices()
+            .nth(1)
+            .map(|(off, _)| end + off)
+            .unwrap_or(query.len());
+        if query[start..next].width() > available {
+            break;
+        }
+        end = next;
+    }
+    let visible = &query[start..end];
+    let cursor_col = prompt_width + query[start..cursor_byte].width();
+
+    let accent = if focused { ACCENT } else { Color::DarkGray };
+    let shown_query = if query.is_empty() {
+        Span::styled("search...", Style::default().fg(DIM))
+    } else {
+        Span::raw(visible.to_owned())
+    };
+    let line = Line::from(vec![
+        Span::styled(prompt, Style::default().fg(accent)),
+        shown_query,
+    ]);
+    frame.render_widget(Paragraph::new(line), area);
+    cursor_col
+}
+
 pub(super) fn render_channels(frame: &mut Frame, area: Rect, state: &DashboardState) {
     let dashboard = state;
+    let focused = state.focus() == FocusPane::Channels;
+    let filter_query = state.channel_pane_filter_query();
+
+    let (list_area, filter_area) = if filter_query.is_some() && area.height >= 4 {
+        let block = panel_block("Channels", focused);
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+        let list_h = inner.height.saturating_sub(1);
+        let list_rect = Rect {
+            height: list_h,
+            ..inner
+        };
+        let filter_rect = Rect {
+            y: inner.y + list_h,
+            height: 1,
+            ..inner
+        };
+        (list_rect, Some(filter_rect))
+    } else {
+        (area, None)
+    };
+
     let entries = state.visible_channel_pane_entries();
-    let max_width = area.width.saturating_sub(8) as usize;
+    let max_width = list_area.width.saturating_sub(8) as usize;
     let horizontal_scroll = state.channel_horizontal_scroll();
     let selected = state.focused_channel_selection();
     let items: Vec<ListItem> = entries

--- a/src/tui/ui/popups.rs
+++ b/src/tui/ui/popups.rs
@@ -8,6 +8,7 @@ mod action_menu;
 mod channel_switcher;
 mod debug_log;
 mod image_viewer;
+mod keymap;
 mod options;
 mod polls;
 mod profile;
@@ -42,6 +43,9 @@ pub(super) use reactions::{
     emoji_reaction_picker_lines, emoji_reaction_picker_lines_for_width,
     filtered_emoji_reaction_picker_lines, reaction_users_popup_lines,
 };
+pub(super) use keymap::render_keymap_popup;
+#[cfg(test)]
+pub(super) use keymap::keymap_popup_lines;
 pub(super) use reactions::{render_emoji_reaction_picker, render_reaction_users_popup};
 
 fn truncate_line_to_display_width(line: Line<'static>, max_width: usize) -> Line<'static> {

--- a/src/tui/ui/popups.rs
+++ b/src/tui/ui/popups.rs
@@ -26,6 +26,7 @@ pub(super) use channel_switcher::{
 pub(super) use debug_log::debug_log_popup_lines;
 pub(super) use debug_log::render_debug_log_popup;
 pub(super) use image_viewer::render_image_viewer;
+pub(super) use keymap::render_keymap_popup;
 #[cfg(test)]
 pub(super) use options::options_popup_lines;
 pub(super) use options::render_options_popup;
@@ -43,7 +44,6 @@ pub(super) use reactions::{
     emoji_reaction_picker_lines, emoji_reaction_picker_lines_for_width,
     filtered_emoji_reaction_picker_lines, reaction_users_popup_lines,
 };
-pub(super) use keymap::render_keymap_popup;
 pub(super) use reactions::{render_emoji_reaction_picker, render_reaction_users_popup};
 
 fn truncate_line_to_display_width(line: Line<'static>, max_width: usize) -> Line<'static> {

--- a/src/tui/ui/popups.rs
+++ b/src/tui/ui/popups.rs
@@ -2,6 +2,7 @@ use super::activity::{ActivityLeading, build_activity_render};
 use super::message_list::render_image_preview;
 use super::*;
 use crate::discord::ActivityKind;
+use crate::tui::keybinding::Action;
 use ratatui::layout::Position;
 
 mod action_menu;

--- a/src/tui/ui/popups.rs
+++ b/src/tui/ui/popups.rs
@@ -2,7 +2,6 @@ use super::activity::{ActivityLeading, build_activity_render};
 use super::message_list::render_image_preview;
 use super::*;
 use crate::discord::ActivityKind;
-use crate::tui::keybinding::Action;
 use ratatui::layout::Position;
 
 mod action_menu;
@@ -45,8 +44,6 @@ pub(super) use reactions::{
     filtered_emoji_reaction_picker_lines, reaction_users_popup_lines,
 };
 pub(super) use keymap::render_keymap_popup;
-#[cfg(test)]
-pub(super) use keymap::keymap_popup_lines;
 pub(super) use reactions::{render_emoji_reaction_picker, render_reaction_users_popup};
 
 fn truncate_line_to_display_width(line: Line<'static>, max_width: usize) -> Line<'static> {

--- a/src/tui/ui/popups/keymap.rs
+++ b/src/tui/ui/popups/keymap.rs
@@ -1,0 +1,104 @@
+use super::*;
+
+pub(in crate::tui::ui) fn render_keymap_popup(
+    frame: &mut Frame,
+    area: Rect,
+    state: &DashboardState,
+) {
+    if !state.is_keymap_popup_open() {
+        return;
+    }
+
+    let lines = keymap_popup_lines(state);
+    let width: u16 = 52;
+    let height = (lines.len() as u16).saturating_add(2);
+    let popup = centered_rect(area, width, height);
+    frame.render_widget(Clear, popup);
+    let kb = state.key_bindings();
+    let title = format!(
+        "Default Keymaps  [{}/{}/Esc to close]",
+        kb.open_keymap.label(),
+        kb.quit.label(),
+    );
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(panel_block_owned(title, true))
+            .wrap(Wrap { trim: false }),
+        popup,
+    );
+}
+
+pub fn keymap_popup_lines(state: &DashboardState) -> Vec<Line<'static>> {
+    let kb = state.key_bindings();
+    let move_down = kb.move_down.label();
+    let move_up = kb.move_up.label();
+    let jump_top = kb.jump_top.label();
+    let jump_bottom = kb.jump_bottom.label();
+    let half_page_down = kb.half_page_down.label();
+    let half_page_up = kb.half_page_up.label();
+    let scroll_pane_left = kb.scroll_pane_left.label();
+    let scroll_pane_right = kb.scroll_pane_right.label();
+    let quit = kb.quit.label();
+    let open_leader = kb.open_leader.label();
+    let open_composer = kb.open_composer.label();
+    let open_in_editor = kb.open_in_editor.label();
+    let scroll_viewport_down = kb.scroll_viewport_down.label();
+    let scroll_viewport_up = kb.scroll_viewport_up.label();
+    let open_keymap = kb.open_keymap.label();
+
+    fn row(key: String, desc: &'static str) -> Line<'static> {
+        Line::from(vec![
+            Span::styled(format!("{key:<18}"), Style::default().fg(ACCENT)),
+            Span::raw(desc),
+        ])
+    }
+    fn section(label: String) -> Line<'static> {
+        Line::from(Span::styled(
+            label,
+            Style::default().fg(DIM).add_modifier(Modifier::BOLD),
+        ))
+    }
+
+    vec![
+        section("Navigation".into()),
+        row("1 / 2 / 3 / 4".into(), "focus pane"),
+        row("Tab / Shift+Tab".into(), "cycle focus"),
+        row(format!("{move_down} / {move_up} / ↑↓"), "move selection"),
+        row(format!("{jump_top} / {jump_bottom}"), "jump top / bottom"),
+        row(
+            format!("{half_page_down} / {half_page_up}"),
+            "half page down / up",
+        ),
+        row(
+            format!("{scroll_pane_left} / {scroll_pane_right}"),
+            "scroll pane left / right",
+        ),
+        row("Alt+←→".into(), "resize pane"),
+        row("Enter".into(), "open channel / message"),
+        row("Esc".into(), "go back"),
+        row(format!("{quit} / Ctrl+C"), "quit"),
+        Line::from(""),
+        section(format!("Leader  [{open_leader}]")),
+        row(format!("{open_leader} → 1/2/4"), "toggle pane visibility"),
+        row(format!("{open_leader} → a"), "actions"),
+        row(format!("{open_leader} → o"), "options"),
+        row(format!("{open_leader} → {open_leader}"), "channel switcher"),
+        Line::from(""),
+        section("Composer".into()),
+        row(open_composer, "open composer"),
+        row("Enter".into(), "send message"),
+        row("Shift+Enter".into(), "newline"),
+        row(open_in_editor, "edit in $EDITOR"),
+        row("Ctrl+←→".into(), "jump by word"),
+        row("Esc".into(), "cancel"),
+        Line::from(""),
+        section("Messages".into()),
+        row("Space → a".into(), "message actions"),
+        row("r".into(), "react with emoji"),
+        row(
+            format!("{scroll_viewport_down} / {scroll_viewport_up}"),
+            "scroll viewport",
+        ),
+        row(open_keymap, "show this help"),
+    ]
+}

--- a/src/tui/ui/popups/keymap.rs
+++ b/src/tui/ui/popups/keymap.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::tui::keybinding::Action;
 
 pub(in crate::tui::ui) fn render_keymap_popup(
     frame: &mut Frame,
@@ -17,8 +18,8 @@ pub(in crate::tui::ui) fn render_keymap_popup(
     let kb = state.key_bindings();
     let title = format!(
         "Default Keymaps  [{}/{}/Esc to close]",
-        kb.open_keymap.label(),
-        kb.quit.label(),
+        kb.label(Action::OpenKeymap),
+        kb.label(Action::Quit),
     );
     frame.render_widget(
         Paragraph::new(lines)
@@ -30,21 +31,21 @@ pub(in crate::tui::ui) fn render_keymap_popup(
 
 pub fn keymap_popup_lines(state: &DashboardState) -> Vec<Line<'static>> {
     let kb = state.key_bindings();
-    let move_down = kb.move_down.label();
-    let move_up = kb.move_up.label();
-    let jump_top = kb.jump_top.label();
-    let jump_bottom = kb.jump_bottom.label();
-    let half_page_down = kb.half_page_down.label();
-    let half_page_up = kb.half_page_up.label();
-    let scroll_pane_left = kb.scroll_pane_left.label();
-    let scroll_pane_right = kb.scroll_pane_right.label();
-    let quit = kb.quit.label();
-    let open_leader = kb.open_leader.label();
-    let open_composer = kb.open_composer.label();
-    let open_in_editor = kb.open_in_editor.label();
-    let scroll_viewport_down = kb.scroll_viewport_down.label();
-    let scroll_viewport_up = kb.scroll_viewport_up.label();
-    let open_keymap = kb.open_keymap.label();
+    let move_down = kb.label(Action::MoveDown);
+    let move_up = kb.label(Action::MoveUp);
+    let jump_top = kb.label(Action::JumpTop);
+    let jump_bottom = kb.label(Action::JumpBottom);
+    let half_page_down = kb.label(Action::HalfPageDown);
+    let half_page_up = kb.label(Action::HalfPageUp);
+    let scroll_pane_left = kb.label(Action::ScrollPaneLeft);
+    let scroll_pane_right = kb.label(Action::ScrollPaneRight);
+    let quit = kb.label(Action::Quit);
+    let open_leader = kb.label(Action::OpenLeader);
+    let open_composer = kb.label(Action::OpenComposer);
+    let open_in_editor = kb.label(Action::OpenInEditor);
+    let scroll_viewport_down = kb.label(Action::ScrollViewportDown);
+    let scroll_viewport_up = kb.label(Action::ScrollViewportUp);
+    let open_keymap = kb.label(Action::OpenKeymap);
 
     fn row(key: String, desc: &'static str) -> Line<'static> {
         Line::from(vec![


### PR DESCRIPTION
## Summary (SORRY FOR THE BIG PR)

This PR adds several keyboard-focused improvements to the TUI:

- Adds configurable keybindings through the existing config file
- Adds a keybinding help popup, opened by the configured keymap key
- Adds support for opening the composer buffer in `$EDITOR`
- Adds `/` search/filter mode for the guild and channel panes
- Preserves existing config sections when saving display options

## Details

### Configurable keybindings

Adds a new `[keybindings]` config section with defaults for common navigation and TUI actions, including composer, leader menu, movement, scrolling, pane search, keymap help, and external editor support.

Invalid or missing keybinding config values fall back to the built-in defaults.

Ex:
```toml
# ~/.config/concord/config.toml

[display]
disable_image_preview = false
image_preview_quality = "auto"

[keybindings]
# Composer
open_composer = "i"
open_in_editor = "ctrl+e"

# Menus / popups
open_leader = "space"
open_keymap = "?"
quit = "q"

# Pane search
pane_search = "/"

# Navigation
move_down = "j"
move_up = "k"
jump_top = "g"
jump_bottom = "shift+g"

# Scrolling
half_page_down = "ctrl+d"
half_page_up = "ctrl+u"
scroll_viewport_down = "shift+j"
scroll_viewport_up = "shift+k"
scroll_pane_left = "shift+h"
scroll_pane_right = "shift+l"
```

### Keybinding help popup

Adds a keymap/help popup so users can discover the current bindings from inside the app. The header also includes a small hint pointing users toward the popup. Press "?"

### External editor support

Adds a composer action for editing the current message in `$EDITOR`, defaulting to `ctrl+e`. The current composer buffer is written to a temporary file, the terminal is restored while the editor runs, and the edited contents are loaded back into the composer when the editor exits successfully. 

Basically, let's say you wanted to write a big message. The current design basically makes it kinda hard. Since we use the terminal we can call our favorite editor to write the message (with all our favorite movements/tools) and then just load the message back to input. 

### Guild/channel pane search

Adds a lightweight `/` filter mode for the guild and channel panes. When active, users can type a fuzzy query, move through the filtered results, and confirm a selected guild or channel. The filter UI appears inline at the bottom of the active pane. When in this mode we can do <Ctrl-{n,p}> for next/prev.

NOTE: This works for now, but in the future I want to be in-line with the discord behavior of "/". That is when using discord and you use "/" it has smart-navigation instead of searching through guilds/channels/members.

## Additional Notes

This PR tries to keep existing keyboard behavior intact where possible. Arrow keys, page keys, tab navigation, pane focus shortcuts, and existing leader-mode actions continue to work alongside the new configurable bindings.

Also I added tests, though I think there could be better tests written...