### PR TITLE
feat: add already reacted emojis to top of picker list (attempt #2)

### DIFF
--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -65,7 +65,8 @@ pub use model::{
     FORUM_POST_CARD_HEIGHT, FocusPane, GuildActionItem, GuildPaneEntry, ImageViewerItem,
     MemberActionItem, MessageActionItem, MessageActionKind, MuteActionDurationItem,
     PollVotePickerItem, ThreadMessagePreview, ThreadSummary, channel_action_shortcut,
-    guild_action_shortcut, indexed_shortcut, member_action_shortcut, message_action_shortcut,
+    emoji_reaction_shortcut, guild_action_shortcut, indexed_shortcut, member_action_shortcut,
+    message_action_shortcut,
 };
 #[allow(unused_imports)]
 pub use model::{ChannelActionKind, ChannelBranch, GuildActionKind, GuildBranch, MemberActionKind};

--- a/src/tui/state/model.rs
+++ b/src/tui/state/model.rs
@@ -234,6 +234,31 @@ pub fn indexed_shortcut(index: usize) -> Option<char> {
     }
 }
 
+pub fn emoji_reaction_shortcut(
+    reactions: &[EmojiReactionItem],
+    existing_reactions: &[ReactionEmoji],
+    index: usize,
+) -> Option<char> {
+    let reaction = reactions.get(index)?;
+    if let Some(existing_index) = existing_reactions
+        .iter()
+        .position(|existing| existing == &reaction.emoji)
+    {
+        return qwerty_shortcut(existing_index);
+    }
+
+    let regular_index = reactions[..index]
+        .iter()
+        .filter(|item| !existing_reactions.contains(&item.emoji))
+        .count();
+    indexed_shortcut(regular_index)
+}
+
+fn qwerty_shortcut(index: usize) -> Option<char> {
+    const SHORTCUTS: &[u8] = b"qwertyuiop";
+    SHORTCUTS.get(index).map(|shortcut| char::from(*shortcut))
+}
+
 fn unique_preferred_shortcut(
     preferred: Option<char>,
     shortcuts: impl IntoIterator<Item = Option<char>>,

--- a/src/tui/state/popups.rs
+++ b/src/tui/state/popups.rs
@@ -1,3 +1,4 @@
+use crate::discord::ReactionEmoji;
 use crate::discord::ids::{
     Id,
     marker::{ChannelMarker, GuildMarker, MessageMarker, UserMarker},
@@ -75,6 +76,7 @@ pub struct EmojiReactionPickerState {
     pub(super) filter: Option<String>,
     pub(super) items: Vec<EmojiReactionItem>,
     pub(super) filtered_items: Vec<EmojiReactionItem>,
+    pub(super) existing_reactions: Vec<ReactionEmoji>,
     pub(super) guild_id: Option<Id<GuildMarker>>,
     pub(super) channel_id: Id<ChannelMarker>,
     pub(super) message_id: Id<MessageMarker>,

--- a/src/tui/state/reactions.rs
+++ b/src/tui/state/reactions.rs
@@ -9,7 +9,7 @@ use super::emoji::{
 use super::scroll::{clamp_selected_index, move_index_down, move_index_up};
 use super::{
     DashboardState, EmojiReactionItem, EmojiReactionPickerState, ReactionUsersPopupState,
-    indexed_shortcut,
+    emoji_reaction_shortcut,
 };
 
 impl DashboardState {
@@ -77,6 +77,13 @@ impl DashboardState {
         self.emoji_reaction_picker
             .as_ref()
             .and_then(|picker| picker.filter.as_deref())
+    }
+
+    pub fn existing_emoji_reactions(&self) -> &[crate::discord::ReactionEmoji] {
+        self.emoji_reaction_picker
+            .as_ref()
+            .map(|picker| picker.existing_reactions.as_slice())
+            .unwrap_or(&[])
     }
 
     pub fn is_filtering_emoji_reactions(&self) -> bool {
@@ -188,11 +195,15 @@ impl DashboardState {
 
     pub fn activate_emoji_reaction_shortcut(&mut self, shortcut: char) -> Option<AppCommand> {
         let shortcut = shortcut.to_ascii_lowercase();
-        let index = self
-            .filtered_emoji_reaction_items()
+        let picker = self.emoji_reaction_picker.as_ref()?;
+        let index = picker
+            .filtered_items
             .iter()
             .enumerate()
-            .position(|(index, _)| indexed_shortcut(index) == Some(shortcut))?;
+            .position(|(index, _)| {
+                emoji_reaction_shortcut(&picker.filtered_items, &picker.existing_reactions, index)
+                    == Some(shortcut)
+            })?;
         if let Some(picker) = &mut self.emoji_reaction_picker {
             picker.selected = index;
         }
@@ -235,8 +246,16 @@ impl DashboardState {
             let guild_id = message
                 .guild_id
                 .or_else(|| self.selected_channel_guild_id());
+            let existing_reactions = message
+                .reactions
+                .iter()
+                .map(|reaction| reaction.emoji.clone())
+                .collect::<Vec<_>>();
             let items = if self.can_add_new_reaction_for_message(message) {
-                self.emoji_reaction_items_for_guild(guild_id)
+                prioritize_existing_reactions(
+                    self.emoji_reaction_items_for_guild(guild_id),
+                    &existing_reactions,
+                )
             } else {
                 message
                     .reactions
@@ -252,6 +271,7 @@ impl DashboardState {
                 filter: None,
                 filtered_items: items.clone(),
                 items,
+                existing_reactions,
                 guild_id,
                 channel_id: message.channel_id,
                 message_id: message.id,
@@ -276,6 +296,33 @@ fn filter_emoji_reaction_items(
     filter: &str,
 ) -> Vec<EmojiReactionItem> {
     filter_emoji_reaction_items_from_slice(&items, filter)
+}
+
+fn prioritize_existing_reactions(
+    items: Vec<EmojiReactionItem>,
+    existing_reactions: &[crate::discord::ReactionEmoji],
+) -> Vec<EmojiReactionItem> {
+    if existing_reactions.is_empty() {
+        return items;
+    }
+
+    let mut prioritized = Vec::with_capacity(items.len());
+    for existing in existing_reactions {
+        if let Some(item) = items.iter().find(|item| &item.emoji == existing) {
+            prioritized.push(item.clone());
+        } else {
+            prioritized.push(EmojiReactionItem {
+                emoji: existing.clone(),
+                label: existing.status_label(),
+            });
+        }
+    }
+    prioritized.extend(
+        items
+            .into_iter()
+            .filter(|item| !existing_reactions.contains(&item.emoji)),
+    );
+    prioritized
 }
 
 fn filter_emoji_reaction_items_from_slice(

--- a/src/tui/state/tests/mod.rs
+++ b/src/tui/state/tests/mod.rs
@@ -3096,6 +3096,34 @@ fn existing_reaction_can_be_added_without_add_reactions_permission() {
 }
 
 #[test]
+fn reaction_picker_prioritizes_existing_reactions_and_qwerty_shortcuts() {
+    let mut state = state_with_reaction_message();
+
+    state.open_emoji_reaction_picker();
+
+    let items = state.filtered_emoji_reaction_items();
+    assert_eq!(items[0].emoji, ReactionEmoji::Unicode("👍".to_owned()));
+    assert_eq!(
+        items[1].emoji,
+        ReactionEmoji::Custom {
+            id: Id::new(50),
+            name: Some("party".to_owned()),
+            animated: false,
+        }
+    );
+
+    let command = state.activate_emoji_reaction_shortcut('q');
+    assert_eq!(
+        command,
+        Some(AppCommand::RemoveReaction {
+            channel_id: Id::new(2),
+            message_id: Id::new(1),
+            emoji: ReactionEmoji::Unicode("👍".to_owned()),
+        })
+    );
+}
+
+#[test]
 fn show_reacted_users_requires_read_message_history() {
     let reactions = vec![ReactionInfo {
         emoji: ReactionEmoji::Unicode("👍".to_owned()),

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -25,9 +25,9 @@ use super::{
     state::{
         ChannelSwitcherItem, ChannelThreadItem, DashboardState, DisplayOptionItem,
         EmojiReactionItem, FORUM_POST_CARD_HEIGHT, FocusPane, ImageViewerItem, MessageActionItem,
-        PollVotePickerItem, channel_action_shortcut, discord_color, guild_action_shortcut,
-        indexed_shortcut, member_action_shortcut, message_action_shortcut, presence_color,
-        presence_marker,
+        PollVotePickerItem, channel_action_shortcut, discord_color, emoji_reaction_shortcut,
+        guild_action_shortcut, indexed_shortcut, member_action_shortcut, message_action_shortcut,
+        presence_color, presence_marker,
     },
 };
 use crate::discord::{
@@ -102,8 +102,9 @@ use self::{
     popups::{
         channel_switcher_cursor_position, channel_switcher_lines, debug_log_popup_lines,
         emoji_reaction_picker_lines, emoji_reaction_picker_lines_for_width,
-        filtered_emoji_reaction_picker_lines, message_action_menu_lines, options_popup_lines,
-        poll_vote_picker_lines, reaction_users_popup_lines, user_profile_popup_lines,
+        emoji_reaction_picker_lines_with_existing, filtered_emoji_reaction_picker_lines,
+        message_action_menu_lines, options_popup_lines, poll_vote_picker_lines,
+        reaction_users_popup_lines, user_profile_popup_lines,
         user_profile_popup_lines_with_activities,
     },
 };

--- a/src/tui/ui/popups.rs
+++ b/src/tui/ui/popups.rs
@@ -40,7 +40,8 @@ pub(super) use profile::{user_profile_popup_lines, user_profile_popup_lines_with
 #[cfg(test)]
 pub(super) use reactions::{
     emoji_reaction_picker_lines, emoji_reaction_picker_lines_for_width,
-    filtered_emoji_reaction_picker_lines, reaction_users_popup_lines,
+    emoji_reaction_picker_lines_with_existing, filtered_emoji_reaction_picker_lines,
+    reaction_users_popup_lines,
 };
 pub(super) use reactions::{render_emoji_reaction_picker, render_reaction_users_popup};
 

--- a/src/tui/ui/popups/reactions.rs
+++ b/src/tui/ui/popups/reactions.rs
@@ -16,6 +16,7 @@ pub(in crate::tui::ui) fn render_emoji_reaction_picker(
         return;
     }
     let filter = state.emoji_reaction_filter();
+    let existing_reactions = state.existing_emoji_reactions();
 
     let selected = state
         .selected_emoji_reaction_index_for_len(reactions.len())
@@ -46,11 +47,14 @@ pub(in crate::tui::ui) fn render_emoji_reaction_picker(
         Paragraph::new(emoji_reaction_picker_lines_with_custom_emoji_images(
             reactions,
             selected,
-            visible_items,
-            &ready_urls,
-            state.show_custom_emoji(),
-            filter,
-            usize::from(content.width),
+            EmojiReactionPickerRenderOptions {
+                max_visible_items: visible_items,
+                thumbnail_urls: &ready_urls,
+                existing_reactions,
+                show_custom_emoji: state.show_custom_emoji(),
+                filter,
+                max_width: usize::from(content.width),
+            },
         ))
         .block(block)
         .wrap(Wrap { trim: false }),
@@ -217,11 +221,14 @@ pub(in crate::tui::ui) fn emoji_reaction_picker_lines(
     emoji_reaction_picker_lines_with_custom_emoji_images(
         reactions,
         selected,
-        max_visible_items,
-        thumbnail_urls,
-        true,
-        None,
-        usize::MAX,
+        EmojiReactionPickerRenderOptions {
+            max_visible_items,
+            thumbnail_urls,
+            existing_reactions: &[],
+            show_custom_emoji: true,
+            filter: None,
+            max_width: usize::MAX,
+        },
     )
 }
 
@@ -236,11 +243,36 @@ pub(in crate::tui::ui) fn emoji_reaction_picker_lines_for_width(
     emoji_reaction_picker_lines_with_custom_emoji_images(
         reactions,
         selected,
-        max_visible_items,
-        thumbnail_urls,
-        true,
-        None,
-        width,
+        EmojiReactionPickerRenderOptions {
+            max_visible_items,
+            thumbnail_urls,
+            existing_reactions: &[],
+            show_custom_emoji: true,
+            filter: None,
+            max_width: width,
+        },
+    )
+}
+
+#[cfg(test)]
+pub(in crate::tui::ui) fn emoji_reaction_picker_lines_with_existing(
+    reactions: &[EmojiReactionItem],
+    existing_reactions: &[crate::discord::ReactionEmoji],
+    selected: usize,
+    max_visible_items: usize,
+    thumbnail_urls: &[String],
+) -> Vec<Line<'static>> {
+    emoji_reaction_picker_lines_with_custom_emoji_images(
+        reactions,
+        selected,
+        EmojiReactionPickerRenderOptions {
+            max_visible_items,
+            thumbnail_urls,
+            existing_reactions,
+            show_custom_emoji: true,
+            filter: None,
+            max_width: usize::MAX,
+        },
     )
 }
 
@@ -255,25 +287,33 @@ pub(in crate::tui::ui) fn filtered_emoji_reaction_picker_lines(
     emoji_reaction_picker_lines_with_custom_emoji_images(
         reactions,
         selected,
-        max_visible_items,
-        thumbnail_urls,
-        true,
-        Some(filter),
-        usize::MAX,
+        EmojiReactionPickerRenderOptions {
+            max_visible_items,
+            thumbnail_urls,
+            existing_reactions: &[],
+            show_custom_emoji: true,
+            filter: Some(filter),
+            max_width: usize::MAX,
+        },
     )
+}
+
+struct EmojiReactionPickerRenderOptions<'a> {
+    max_visible_items: usize,
+    thumbnail_urls: &'a [String],
+    existing_reactions: &'a [crate::discord::ReactionEmoji],
+    show_custom_emoji: bool,
+    filter: Option<&'a str>,
+    max_width: usize,
 }
 
 fn emoji_reaction_picker_lines_with_custom_emoji_images(
     reactions: &[EmojiReactionItem],
     selected: usize,
-    max_visible_items: usize,
-    thumbnail_urls: &[String],
-    show_custom_emoji: bool,
-    filter: Option<&str>,
-    max_width: usize,
+    options: EmojiReactionPickerRenderOptions<'_>,
 ) -> Vec<Line<'static>> {
     let selected = selected.min(reactions.len().saturating_sub(1));
-    let visible_items = max_visible_items.max(1).min(reactions.len().max(1));
+    let visible_items = options.max_visible_items.max(1).min(reactions.len().max(1));
     let visible_range = selection::visible_item_range(reactions.len(), selected, visible_items);
 
     let mut lines: Vec<Line<'static>> = reactions[visible_range.clone()]
@@ -282,22 +322,30 @@ fn emoji_reaction_picker_lines_with_custom_emoji_images(
         .map(|(offset, reaction)| {
             let index = visible_range.start + offset;
             let marker = if index == selected { "› " } else { "  " };
-            let shortcut = shortcut_prefix(indexed_shortcut(index));
+            let shortcut = shortcut_prefix(emoji_reaction_shortcut(
+                reactions,
+                options.existing_reactions,
+                index,
+            ));
             let mut style = Style::default();
             if index == selected {
                 style = style
                     .bg(Color::Rgb(40, 45, 90))
                     .add_modifier(Modifier::BOLD);
             }
-            let thumbnail_ready = show_custom_emoji
+            let thumbnail_ready = options.show_custom_emoji
                 && reaction
                     .custom_image_url()
-                    .is_some_and(|url| thumbnail_urls.iter().any(|ready| ready == &url));
+                    .is_some_and(|url| options.thumbnail_urls.iter().any(|ready| ready == &url));
             Line::from(vec![
                 Span::styled(marker, Style::default().fg(ACCENT)),
                 Span::styled(shortcut, Style::default().fg(DIM)),
                 Span::styled(
-                    format_emoji_reaction_item(reaction, thumbnail_ready, show_custom_emoji),
+                    format_emoji_reaction_item(
+                        reaction,
+                        thumbnail_ready,
+                        options.show_custom_emoji,
+                    ),
                     style,
                 ),
             ])
@@ -311,7 +359,7 @@ fn emoji_reaction_picker_lines_with_custom_emoji_images(
         )));
     }
 
-    if let Some(filter) = filter {
+    if let Some(filter) = options.filter {
         lines.push(Line::from(vec![
             Span::styled("Filter ", Style::default().fg(DIM)),
             Span::styled(
@@ -320,12 +368,12 @@ fn emoji_reaction_picker_lines_with_custom_emoji_images(
             ),
         ]));
     }
-    if max_width == usize::MAX {
+    if options.max_width == usize::MAX {
         lines
     } else {
         lines
             .into_iter()
-            .map(|line| truncate_line_to_display_width(line, max_width))
+            .map(|line| truncate_line_to_display_width(line, options.max_width))
             .collect()
     }
 }
@@ -358,13 +406,18 @@ fn render_emoji_reaction_images(
             continue;
         }
         let image_area = Rect::new(
-            area.x.saturating_add(2),
+            area.x.saturating_add(emoji_reaction_image_x_offset()),
             y,
-            EMOJI_REACTION_IMAGE_WIDTH.min(area.width.saturating_sub(2)),
+            EMOJI_REACTION_IMAGE_WIDTH
+                .min(area.width.saturating_sub(emoji_reaction_image_x_offset())),
             1,
         );
         frame.render_widget(RatatuiImage::new(image.protocol), image_area);
     }
+}
+
+fn emoji_reaction_image_x_offset() -> u16 {
+    2 + shortcut_prefix(Some('q')).width() as u16
 }
 
 fn format_emoji_reaction_item(

--- a/src/tui/ui/tests.rs
+++ b/src/tui/ui/tests.rs
@@ -17,16 +17,17 @@ use super::{
     composer_lines_with_loaded_custom_emoji_urls, composer_prompt_line_count, composer_text,
     date_separator_line, debug_log_popup_lines, dm_presence_dot_span, emoji_picker_lines,
     emoji_reaction_picker_lines, emoji_reaction_picker_lines_for_width,
-    filtered_emoji_reaction_picker_lines, focus_pane_at, format_message_sent_time,
-    forum_post_reaction_summary, forum_post_scrollbar_visible_count, forum_post_viewport_lines,
-    inline_image_preview_area, inline_image_preview_row, member_display_label, member_name_style,
-    message_action_menu_lines, message_author_style, message_body_custom_emoji_rows,
-    message_item_lines, message_viewport_lines, new_messages_notice_line, options_popup_lines,
-    poll_vote_picker_lines, primary_activity_summary, reaction_users_popup_lines,
-    reaction_users_visible_line_count, render_channels, render_guilds, selected_avatar_x_offset,
-    selected_message_card_width, selected_message_content_x_offset, sync_view_heights,
-    user_profile_popup_has_avatar, user_profile_popup_lines,
-    user_profile_popup_lines_with_activities, user_profile_popup_text_geometry,
+    emoji_reaction_picker_lines_with_existing, filtered_emoji_reaction_picker_lines, focus_pane_at,
+    format_message_sent_time, forum_post_reaction_summary, forum_post_scrollbar_visible_count,
+    forum_post_viewport_lines, inline_image_preview_area, inline_image_preview_row,
+    member_display_label, member_name_style, message_action_menu_lines, message_author_style,
+    message_body_custom_emoji_rows, message_item_lines, message_viewport_lines,
+    new_messages_notice_line, options_popup_lines, poll_vote_picker_lines,
+    primary_activity_summary, reaction_users_popup_lines, reaction_users_visible_line_count,
+    render_channels, render_guilds, selected_avatar_x_offset, selected_message_card_width,
+    selected_message_content_x_offset, sync_view_heights, user_profile_popup_has_avatar,
+    user_profile_popup_lines, user_profile_popup_lines_with_activities,
+    user_profile_popup_text_geometry,
 };
 use crate::tui::message_time::{
     discord_epoch_unix_millis, format_unix_millis_with_offset, message_starts_new_day,
@@ -2990,6 +2991,36 @@ fn emoji_reaction_picker_marks_selected_reaction() {
     assert_eq!(
         line_texts_from_ratatui(&lines),
         vec!["  [1] 👍 Thumbs up", "› [2] :party: Party",]
+    );
+}
+
+#[test]
+fn emoji_reaction_picker_uses_qwerty_shortcuts_for_existing_reactions() {
+    let reactions = vec![
+        EmojiReactionItem {
+            emoji: ReactionEmoji::Unicode("👍".to_owned()),
+            label: "Thumbs up".to_owned(),
+        },
+        EmojiReactionItem {
+            emoji: ReactionEmoji::Unicode("❤️".to_owned()),
+            label: "Heart".to_owned(),
+        },
+        EmojiReactionItem {
+            emoji: ReactionEmoji::Unicode("😂".to_owned()),
+            label: "Joy".to_owned(),
+        },
+    ];
+    let existing_reactions = vec![
+        ReactionEmoji::Unicode("👍".to_owned()),
+        ReactionEmoji::Unicode("❤️".to_owned()),
+    ];
+
+    let lines =
+        emoji_reaction_picker_lines_with_existing(&reactions, &existing_reactions, 0, 10, &[]);
+
+    assert_eq!(
+        line_texts_from_ratatui(&lines),
+        vec!["› [q] 👍 Thumbs up", "  [w] ❤️ Heart", "  [1] 😂 Joy"]
     );
 }
 


### PR DESCRIPTION
Note: this second attempt was easier to accomplish than trying to deal with the merge conflicts in #58 after the refactoring of the reaction picker. The functionality is otherwise the same.

## Problem

When a message has had a reaction, statistically it is likely that another person may want to react similarly.  Currently, you need to know the name of the reaction (may be difficult for server-specific custom reactions/emojis).

## Proposed solution

When opening the picker, we find the reactions that have already been used and put them at the top of the list, using new keyboard shortcuts (I've chosen to use `qwertyuiop` as the list, but I'm open to alternative suggestions if this doesn't align with the direction of the project) to avoid overwriting the original `1..9` ones.

### Screenshot

<img width="911" height="339" alt="Screenshot 2026-05-12 at 11 38 33 PM" src="https://github.com/user-attachments/assets/5969687f-c0df-4d75-9ef7-4b7d93be1422" />