### PR TITLE
feat: expanding support for embedded content

### DIFF
--- a/src/discord/events.rs
+++ b/src/discord/events.rs
@@ -274,6 +274,7 @@ pub struct EmbedInfo {
     pub author_name: Option<String>,
     pub title: Option<String>,
     pub description: Option<String>,
+    pub timestamp: Option<String>,
     pub fields: Vec<EmbedFieldInfo>,
     pub footer_text: Option<String>,
     pub url: Option<String>,

--- a/src/discord/gateway/parser.rs
+++ b/src/discord/gateway/parser.rs
@@ -1702,6 +1702,7 @@ mod tests {
                 "provider": { "name": "YouTube" },
                 "title": "Example Video",
                 "description": "A video description",
+                "timestamp": "2026-05-13T15:22:03+00:00",
                 "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
                 "thumbnail": {
                     "url": "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg",
@@ -1727,6 +1728,10 @@ mod tests {
         assert_eq!(embeds[0].color, Some(16711680));
         assert_eq!(embeds[0].provider_name.as_deref(), Some("YouTube"));
         assert_eq!(embeds[0].title.as_deref(), Some("Example Video"));
+        assert_eq!(
+            embeds[0].timestamp.as_deref(),
+            Some("2026-05-13T15:22:03+00:00")
+        );
         assert_eq!(
             embeds[0].thumbnail_url.as_deref(),
             Some("https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg")

--- a/src/discord/gateway/parser/messages.rs
+++ b/src/discord/gateway/parser/messages.rs
@@ -158,6 +158,10 @@ fn parse_embed(value: &Value) -> Option<EmbedInfo> {
             .get("description")
             .and_then(Value::as_str)
             .map(str::to_owned),
+        timestamp: value
+            .get("timestamp")
+            .and_then(Value::as_str)
+            .map(str::to_owned),
         fields,
         footer_text: value
             .get("footer")

--- a/src/tui/media.rs
+++ b/src/tui/media.rs
@@ -2146,6 +2146,7 @@ mod tests {
             author_name: None,
             title: Some("Example Video".to_owned()),
             description: Some("A video description".to_owned()),
+            timestamp: None,
             fields: Vec::new(),
             footer_text: None,
             url: Some("https://www.youtube.com/watch?v=dQw4w9WgXcQ".to_owned()),

--- a/src/tui/message_format.rs
+++ b/src/tui/message_format.rs
@@ -4,6 +4,7 @@ use crate::discord::ids::{
     Id,
     marker::{GuildMarker, MessageMarker},
 };
+use chrono::{DateTime, Local};
 use ratatui::{
     style::{Color, Modifier, Style},
     text::Span,
@@ -432,6 +433,15 @@ fn format_embed(
         embed_title_style(),
         loaded_custom_emoji_urls,
     );
+    let description = embed.description.as_deref().map(plain_embed_text);
+    push_embed_text(
+        &mut lines,
+        description.as_deref(),
+        show_custom_emoji,
+        inner_width,
+        Style::default(),
+        loaded_custom_emoji_urls,
+    );
     for field in &embed.fields {
         push_embed_text(
             &mut lines,
@@ -450,9 +460,10 @@ fn format_embed(
             loaded_custom_emoji_urls,
         );
     }
+    let footer = format_embed_footer(embed);
     push_embed_text(
         &mut lines,
-        embed.footer_text.as_deref(),
+        footer.as_deref(),
         show_custom_emoji,
         inner_width,
         embed_footer_style(),
@@ -477,6 +488,83 @@ fn format_embed(
         .into_iter()
         .map(|line| prefix_message_content_line_with_style(PREFIX, embed_line_style(embed), line))
         .collect()
+}
+
+fn plain_embed_text(value: &str) -> String {
+    let value = value.replace('\u{fe00}', "");
+    let mut output = String::with_capacity(value.len());
+    let mut cursor = 0usize;
+    while let Some(relative_start) = value[cursor..].find('[') {
+        let start = cursor.saturating_add(relative_start);
+        output.push_str(&unescape_embed_markdown(&value[cursor..start]));
+
+        let Some(label_end) = value[start + 1..].find(']').map(|end| start + 1 + end) else {
+            output.push_str(&unescape_embed_markdown(&value[start..]));
+            return strip_embed_markdown_emphasis(&output);
+        };
+        let url_start = label_end.saturating_add(1);
+        if !value[url_start..].starts_with('(') {
+            output.push('[');
+            cursor = start.saturating_add(1);
+            continue;
+        }
+        let Some(url_end) = value[url_start + 1..]
+            .find(')')
+            .map(|end| url_start + 1 + end)
+        else {
+            output.push_str(&unescape_embed_markdown(&value[start..]));
+            return strip_embed_markdown_emphasis(&output);
+        };
+
+        output.push_str(&unescape_embed_markdown(&value[start + 1..label_end]));
+        cursor = url_end.saturating_add(1);
+    }
+    output.push_str(&unescape_embed_markdown(&value[cursor..]));
+    strip_embed_markdown_emphasis(&output)
+}
+
+fn unescape_embed_markdown(value: &str) -> String {
+    let mut output = String::with_capacity(value.len());
+    let mut chars = value.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '\\'
+            && chars.peek().is_some_and(|next| {
+                matches!(
+                    next,
+                    '\\' | '*' | '_' | '`' | '~' | '|' | '[' | ']' | '(' | ')' | '.' | '!' | '#'
+                )
+            })
+        {
+            if let Some(next) = chars.next() {
+                output.push(next);
+            }
+        } else {
+            output.push(ch);
+        }
+    }
+    output
+}
+
+fn strip_embed_markdown_emphasis(value: &str) -> String {
+    value.replace("**", "")
+}
+
+fn format_embed_footer(embed: &EmbedInfo) -> Option<String> {
+    match (
+        embed.footer_text.as_deref(),
+        embed.timestamp.as_deref().and_then(format_embed_timestamp),
+    ) {
+        (Some(text), Some(timestamp)) => Some(format!("{text} · {timestamp}")),
+        (Some(text), None) => Some(text.to_owned()),
+        (None, Some(timestamp)) => Some(timestamp),
+        (None, None) => None,
+    }
+}
+
+fn format_embed_timestamp(timestamp: &str) -> Option<String> {
+    DateTime::parse_from_rfc3339(timestamp)
+        .ok()
+        .map(|datetime| datetime.with_timezone(&Local).format("%H:%M").to_string())
 }
 
 fn push_embed_text(

--- a/src/tui/state/tests/fixtures.rs
+++ b/src/tui/state/tests/fixtures.rs
@@ -1048,6 +1048,7 @@ pub(super) fn youtube_embed() -> EmbedInfo {
         author_name: None,
         title: Some("Example Video".to_owned()),
         description: Some("A video description".to_owned()),
+        timestamp: None,
         fields: Vec::new(),
         footer_text: None,
         url: Some("https://www.youtube.com/watch?v=dQw4w9WgXcQ".to_owned()),

--- a/src/tui/state/tests/mod.rs
+++ b/src/tui/state/tests/mod.rs
@@ -1681,7 +1681,7 @@ fn discord_embed_rows_increase_message_rendered_height() {
         ..MessageState::default()
     };
 
-    assert_eq!(message_rendered_height(&message, 80, 16, 3), 8);
+    assert_eq!(message_rendered_height(&message, 80, 16, 3), 9);
 }
 
 #[test]
@@ -1885,7 +1885,7 @@ fn forwarded_snapshot_embed_rows_increase_rendered_height() {
         ..MessageState::default()
     };
 
-    assert_eq!(message_rendered_height(&message, 200, 16, 3), 10);
+    assert_eq!(message_rendered_height(&message, 200, 16, 3), 11);
 }
 
 #[test]

--- a/src/tui/ui/tests.rs
+++ b/src/tui/ui/tests.rs
@@ -1956,6 +1956,7 @@ fn message_content_lines_render_discord_embed_preview() {
             "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
             "  ▎ YouTube",
             "  ▎ Example Video",
+            "  ▎ A video description",
         ]
     );
     assert_eq!(lines[1].style.fg, Some(DIM));
@@ -1987,6 +1988,7 @@ fn message_embed_hides_media_and_player_urls() {
             "watch this",
             "  ▎ YouTube",
             "  ▎ Example Video",
+            "  ▎ A video description",
             "  ▎ https://www.youtube.com/watch?v=dQw4w9WgXcQ",
         ]
     );
@@ -2030,6 +2032,36 @@ fn message_embed_url_underline_skips_marker() {
             .add_modifier
             .contains(Modifier::UNDERLINED)
     );
+}
+
+#[test]
+fn message_embed_renders_tweet_description_as_readable_text() {
+    let mut message = message_with_content(Some(
+        "Fx'ed that for you! https://www.fxtwitter.com/MikeReiss/status/2054582956438524124"
+            .to_owned(),
+    ));
+    let mut embed = youtube_embed();
+    embed.color = Some(0x6364ff);
+    embed.provider_name = None;
+    embed.author_name = Some("Mike Reiss (@MikeReiss)".to_owned());
+    embed.title = None;
+    embed.description = Some(
+        "Patriots rookie Quintayvious Hutchins \\(seventh round, Boston College\\) was arraigned\\.\n\u{fe00}\n**[💬](https://x.com/intent/tweet?in_reply_to=1) 2 [🔁](https://x.com/intent/retweet?tweet_id=1) 11 [❤️](https://x.com/intent/like?tweet_id=1) 44 👁️ 12\\.4K **"
+            .to_owned(),
+    );
+    embed.footer_text = Some("FxTwitter".to_owned());
+    embed.url = Some("https://www.fxtwitter.com/MikeReiss/status/2054582956438524124".to_owned());
+    message.embeds = vec![embed];
+
+    let lines = format_message_content_lines(&message, &DashboardState::new(), 120);
+    let texts = line_texts(&lines);
+
+    assert!(texts.contains(&"  ▎ Mike Reiss (@MikeReiss)"));
+    assert!(texts.contains(
+        &"  ▎ Patriots rookie Quintayvious Hutchins (seventh round, Boston College) was arraigned."
+    ));
+    assert!(texts.contains(&"  ▎ 💬 2 🔁 11 ❤️ 44 👁️ 12.4K "));
+    assert!(texts.contains(&"  ▎ FxTwitter"));
 }
 
 #[test]
@@ -3656,6 +3688,7 @@ fn forwarded_snapshot_renders_discord_embed_preview() {
             "│ https://www.youtube.com/watch?v=dQw4w9WgXcQ",
             "│   ▎ YouTube",
             "│   ▎ Example Video",
+            "│   ▎ A video description",
         ]
     );
     let url_spans = lines[2].spans();
@@ -4626,6 +4659,7 @@ fn youtube_embed() -> EmbedInfo {
         author_name: None,
         title: Some("Example Video".to_owned()),
         description: Some("A video description".to_owned()),
+        timestamp: None,
         fields: Vec::new(),
         footer_text: None,
         url: Some("https://www.youtube.com/watch?v=dQw4w9WgXcQ".to_owned()),


### PR DESCRIPTION
## Problem

When someone posts a tweet that a Tweet bot formats, the contents are mostly lost and only the title of the embedded content is shown.

## Proposed solution

Here I pull more of the content out of the content (e.g. the `description` where a lot of the "meat" of the content is) and display it alongside the rest of the message.

## Screenshots

### Official Discord client

<img width="760" height="313" alt="original" src="https://github.com/user-attachments/assets/b449a8ef-46e0-40ea-9022-62867b5e5f0a" />

### Concord before

<img width="649" height="166" alt="Screenshot 2026-05-13 at 7 07 33 PM" src="https://github.com/user-attachments/assets/71e98cc4-288d-482a-aa24-b3c235cc2d1f" />

### Concord after

<img width="1423" height="321" alt="Screenshot 2026-05-13 at 7 07 49 PM" src="https://github.com/user-attachments/assets/d0ad440f-4a8f-4603-9c95-fe1d5f6dd3f5" />