### PR TITLE
feat: Add configurable color scheme via [theme] config section

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -105,11 +105,71 @@ impl DisplayOptions {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct KeyBindingsConfig(pub HashMap<String, String>);
 
+/// Hex color overrides for the UI color scheme. All values default to the
+/// built-in colors when absent. Each value must be a 6-digit hex string with
+/// an optional leading `#`, e.g. `"#00FFFF"` or `"00FFFF"`. Invalid values
+/// fall back silently to the built-in default for that color.
+///
+/// Example `~/.config/concord/config.toml`:
+/// ```toml
+/// [theme]
+/// accent = "#FF6600"
+/// dim    = "#666666"
+/// ```
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(default)]
+pub struct Theme {
+    pub background: String,
+    pub accent: String,
+    pub dim: String,
+    pub scrollbar_thumb: String,
+    pub selection_border: String,
+    pub mention_badge: String,
+    pub channel_read: String,
+    pub channel_unread: String,
+    pub self_reaction: String,
+    pub self_mention_bg: String,
+    pub self_mention_fg: String,
+    pub other_mention_bg: String,
+    pub other_mention_fg: String,
+    pub presence_online: String,
+    pub presence_idle: String,
+    pub presence_dnd: String,
+    pub presence_offline: String,
+    pub folder_default: String,
+}
+
+impl Default for Theme {
+    fn default() -> Self {
+        Self {
+            background: String::new(),
+            accent: "#00FFFF".to_owned(),
+            dim: "#808080".to_owned(),
+            scrollbar_thumb: "#AAAAAA".to_owned(),
+            selection_border: "#00FF00".to_owned(),
+            mention_badge: "#FFA500".to_owned(),
+            channel_read: "#828282".to_owned(),
+            channel_unread: "#FFFFFF".to_owned(),
+            self_reaction: "#FFFF00".to_owned(),
+            self_mention_bg: "#4C4C23".to_owned(),
+            self_mention_fg: "#FFFF00".to_owned(),
+            other_mention_bg: "#28325C".to_owned(),
+            other_mention_fg: "#C1CEF7".to_owned(),
+            presence_online: "#00FF00".to_owned(),
+            presence_idle: "#B48C00".to_owned(),
+            presence_dnd: "#FF0000".to_owned(),
+            presence_offline: "#808080".to_owned(),
+            folder_default: "#00FFFF".to_owned(),
+        }
+    }
+}
+
 #[derive(Debug, Default, Deserialize, Serialize)]
 #[serde(default)]
 struct AppConfig {
     display: DisplayOptions,
     keybindings: KeyBindingsConfig,
+    theme: Theme,
 }
 
 pub fn load_display_options() -> Result<DisplayOptions> {
@@ -127,6 +187,15 @@ pub fn load_key_bindings_config() -> Result<KeyBindingsConfig> {
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
             Ok(KeyBindingsConfig::default())
         }
+        Err(error) => Err(error.into()),
+    }
+}
+
+pub fn load_theme() -> Result<Theme> {
+    let path = config_path()?;
+    match std::fs::read_to_string(&path) {
+        Ok(content) => Ok(section_from_toml::<Theme>(&content, "theme")?),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(Theme::default()),
         Err(error) => Err(error.into()),
     }
 }

--- a/src/discord/events.rs
+++ b/src/discord/events.rs
@@ -395,6 +395,7 @@ pub struct MessageSnapshotInfo {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ReplyInfo {
+    pub author_id: Option<Id<UserMarker>>,
     pub author: String,
     pub content: Option<String>,
     pub sticker_names: Vec<String>,
@@ -747,11 +748,10 @@ pub enum AppEvent {
         note: Option<String>,
     },
     RelationshipsLoaded {
-        relationships: Vec<(Id<UserMarker>, FriendStatus)>,
+        relationships: Vec<RelationshipInfo>,
     },
     RelationshipUpsert {
-        user_id: Id<UserMarker>,
-        status: FriendStatus,
+        relationship: RelationshipInfo,
     },
     RelationshipRemove {
         user_id: Id<UserMarker>,
@@ -836,6 +836,19 @@ pub enum FriendStatus {
     Blocked,
     IncomingRequest,
     OutgoingRequest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RelationshipInfo {
+    pub user_id: Id<UserMarker>,
+    pub status: FriendStatus,
+    /// Friend nickname set by the current user. This is distinct from guild
+    /// nicknames and only applies to 1:1 friendships / DMs.
+    pub nickname: Option<String>,
+    /// Best available non-nickname label from the relationship payload,
+    /// usually `global_name` and otherwise the username.
+    pub display_name: Option<String>,
+    pub username: Option<String>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/src/discord/gateway/parser.rs
+++ b/src/discord/gateway/parser.rs
@@ -31,7 +31,7 @@ use messages::{
 };
 use presence::{parse_presence_update, parse_typing_start};
 use ready::{parse_ready, parse_ready_supplemental};
-use relationships::{parse_relationship_add, parse_relationship_remove};
+use relationships::{parse_relationship_add, parse_relationship_remove, parse_relationship_update};
 
 /// Best-effort fallback that rebuilds the dashboard's domain events directly
 /// from the raw gateway payload. We only extract the fields the UI consumes,
@@ -85,6 +85,7 @@ pub(super) fn parse_user_account_event(raw: &str) -> Vec<AppEvent> {
         "GUILD_MEMBER_LIST_UPDATE" => parse_member_list_update(data),
         "GUILD_MEMBERS_CHUNK" => parse_member_chunk(data),
         "RELATIONSHIP_ADD" => parse_relationship_add(data).into_iter().collect(),
+        "RELATIONSHIP_UPDATE" => parse_relationship_update(data).into_iter().collect(),
         "RELATIONSHIP_REMOVE" => parse_relationship_remove(data).into_iter().collect(),
         "GUILD_MEMBER_REMOVE" => parse_member_remove(data).into_iter().collect(),
         "PRESENCE_UPDATE" => parse_presence_update(data),
@@ -273,7 +274,12 @@ mod tests {
                 "d": {
                     "id": "20",
                     "type": 1,
-                    "user": {"id": "20", "username": "alice"}
+                    "nickname": "Bestie",
+                    "user": {
+                        "id": "20",
+                        "global_name": "Alice Global",
+                        "username": "alice"
+                    }
                 }
             })
             .to_string(),
@@ -281,8 +287,37 @@ mod tests {
         assert_eq!(events.len(), 1);
         assert!(matches!(
             &events[0],
-            AppEvent::RelationshipUpsert { user_id, status }
-                if *user_id == Id::new(20) && *status == FriendStatus::Friend
+            AppEvent::RelationshipUpsert { relationship }
+                if relationship.user_id == Id::new(20)
+                    && relationship.status == FriendStatus::Friend
+                    && relationship.nickname.as_deref() == Some("Bestie")
+                    && relationship.display_name.as_deref() == Some("Alice Global")
+                    && relationship.username.as_deref() == Some("alice")
+        ));
+    }
+
+    #[test]
+    fn relationship_update_emits_friend_upsert() {
+        let events = parse_user_account_event(
+            &json!({
+                "t": "RELATIONSHIP_UPDATE",
+                "d": {
+                    "id": "20",
+                    "type": 1,
+                    "nickname": "Bestie"
+                }
+            })
+            .to_string(),
+        );
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            &events[0],
+            AppEvent::RelationshipUpsert { relationship }
+                if relationship.user_id == Id::new(20)
+                    && relationship.status == FriendStatus::Friend
+                    && relationship.nickname.as_deref() == Some("Bestie")
+                    && relationship.display_name.is_none()
+                    && relationship.username.is_none()
         ));
     }
 
@@ -1924,6 +1959,7 @@ mod tests {
         assert_eq!(
             reply,
             Some(ReplyInfo {
+                author_id: Some(Id::new(31)),
                 author: "Alex".to_owned(),
                 content: Some("잘되는군".to_owned()),
                 sticker_names: Vec::new(),

--- a/src/discord/gateway/parser/messages.rs
+++ b/src/discord/gateway/parser/messages.rs
@@ -252,6 +252,7 @@ fn parse_reply_info(value: &Value) -> Option<ReplyInfo> {
     }
 
     let author = value.get("author")?;
+    let author_id = author.get("id").and_then(parse_id::<UserMarker>);
     let author_name = message_author_display_name(value, author);
     let content = value
         .get("content")
@@ -262,6 +263,7 @@ fn parse_reply_info(value: &Value) -> Option<ReplyInfo> {
     let mentions = parse_mentions(value.get("mentions"));
 
     Some(ReplyInfo {
+        author_id,
         author: author_name,
         content,
         sticker_names,

--- a/src/discord/gateway/parser/ready.rs
+++ b/src/discord/gateway/parser/ready.rs
@@ -7,8 +7,8 @@ use serde_json::Value;
 
 use crate::{
     discord::{
-        ActivityInfo, ChannelInfo, ChannelRecipientInfo, FriendStatus, GuildFolder, PresenceStatus,
-        ReadStateInfo, RoleInfo,
+        ActivityInfo, ChannelInfo, ChannelRecipientInfo, GuildFolder, PresenceStatus,
+        ReadStateInfo, RelationshipInfo, RoleInfo,
         events::AppEvent,
         ids::{
             Id,
@@ -154,7 +154,7 @@ pub(super) fn parse_ready(data: &Value) -> Vec<AppEvent> {
     // it as a single event so the profile popup can show friend / pending /
     // blocked badges without an extra REST round trip.
     if let Some(relationships) = data.get("relationships").and_then(Value::as_array) {
-        let parsed: Vec<(Id<UserMarker>, FriendStatus)> = relationships
+        let parsed: Vec<RelationshipInfo> = relationships
             .iter()
             .filter_map(parse_relationship_entry)
             .collect();

--- a/src/discord/gateway/parser/relationships.rs
+++ b/src/discord/gateway/parser/relationships.rs
@@ -1,16 +1,17 @@
 use serde_json::Value;
 
-use crate::discord::{
-    FriendStatus,
-    events::AppEvent,
-    ids::{Id, marker::UserMarker},
-};
+use crate::discord::{FriendStatus, RelationshipInfo, events::AppEvent, ids::marker::UserMarker};
 
 use super::shared::parse_id;
 
 pub(super) fn parse_relationship_add(data: &Value) -> Option<AppEvent> {
-    let (user_id, status) = parse_relationship_entry(data)?;
-    Some(AppEvent::RelationshipUpsert { user_id, status })
+    let relationship = parse_relationship_entry(data)?;
+    Some(AppEvent::RelationshipUpsert { relationship })
+}
+
+pub(super) fn parse_relationship_update(data: &Value) -> Option<AppEvent> {
+    let relationship = parse_relationship_entry(data)?;
+    Some(AppEvent::RelationshipUpsert { relationship })
 }
 
 pub(super) fn parse_relationship_remove(data: &Value) -> Option<AppEvent> {
@@ -25,7 +26,7 @@ pub(super) fn parse_relationship_remove(data: &Value) -> Option<AppEvent> {
     Some(AppEvent::RelationshipRemove { user_id })
 }
 
-pub(super) fn parse_relationship_entry(value: &Value) -> Option<(Id<UserMarker>, FriendStatus)> {
+pub(super) fn parse_relationship_entry(value: &Value) -> Option<RelationshipInfo> {
     // READY's `relationships` array uses ids on the entry itself for the
     // target user. Older shards may nest it under `user.id`, so check both.
     let user_id = value
@@ -45,5 +46,29 @@ pub(super) fn parse_relationship_entry(value: &Value) -> Option<(Id<UserMarker>,
         4 => FriendStatus::OutgoingRequest,
         _ => return None,
     };
-    Some((user_id, status))
+    let nickname = value
+        .get("nickname")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned);
+    let username = value
+        .get("user")
+        .and_then(|user| user.get("username"))
+        .and_then(Value::as_str);
+    let display_name = value
+        .get("user")
+        .and_then(|user| {
+            user.get("global_name")
+                .and_then(Value::as_str)
+                .filter(|value| !value.is_empty())
+                .or(username)
+        })
+        .map(str::to_owned);
+    Some(RelationshipInfo {
+        user_id,
+        status,
+        nickname,
+        display_name,
+        username: username.map(str::to_owned),
+    })
 }

--- a/src/discord/mod.rs
+++ b/src/discord/mod.rs
@@ -24,8 +24,8 @@ pub use events::{
     InlinePreviewInfo, MemberInfo, MentionInfo, MessageInfo, MessageKind, MessageReferenceInfo,
     MessageSnapshotInfo, MutualGuildInfo, NotificationLevel, PermissionOverwriteInfo,
     PermissionOverwriteKind, PollAnswerInfo, PollInfo, PresenceStatus, ReactionInfo,
-    ReactionUserInfo, ReactionUsersInfo, ReadStateInfo, ReplyInfo, RoleInfo, SequencedAppEvent,
-    UserProfileInfo,
+    ReactionUserInfo, ReactionUsersInfo, ReadStateInfo, RelationshipInfo, ReplyInfo, RoleInfo,
+    SequencedAppEvent, UserProfileInfo,
 };
 pub use ids::{Id, marker};
 pub use rest::ForumPostPage;

--- a/src/discord/state.rs
+++ b/src/discord/state.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::time::{Duration, Instant};
 
 mod channels;
@@ -32,7 +32,7 @@ use reads::ChannelReadState;
 
 use super::{
     ActivityInfo, AppEvent, CustomEmojiInfo, FriendStatus, GuildFolder, PresenceStatus,
-    UserProfileInfo,
+    RelationshipInfo, UserProfileInfo,
 };
 
 const DEFAULT_MAX_MESSAGES_PER_CHANNEL: usize = 200;
@@ -59,7 +59,7 @@ pub struct DiscordState {
     /// Friend / blocked / pending request state delivered through READY's
     /// `relationships` array. Used to colour the profile popup's friend
     /// indicator and to enrich `UserProfileInfo` on insert.
-    relationships: BTreeMap<Id<UserMarker>, FriendStatus>,
+    relationships: BTreeMap<Id<UserMarker>, RelationshipInfo>,
     /// Last known presence by user id. This gives DM/profile views a fallback
     /// when the private-channel recipient payload omitted status.
     user_presences: BTreeMap<Id<UserMarker>, PresenceStatus>,
@@ -482,15 +482,53 @@ impl DiscordState {
                 profile.friend_status = self
                     .relationships
                     .get(&profile.user_id)
-                    .copied()
+                    .map(|relationship| relationship.status)
                     .unwrap_or(FriendStatus::None);
                 if let Some(note) = self.fetched_notes.get(&profile.user_id) {
                     profile.note = note.clone();
                 }
+                let profile_display_name = profile.display_name().to_owned();
+                let avatar_url = profile.avatar_url.clone();
+                let username = profile.username.clone();
+                let user_id = profile.user_id;
                 self.user_profiles.insert(
                     UserProfileCacheKey::new(profile.user_id, *guild_id),
                     profile,
                 );
+                let display_name = if guild_id.is_some() {
+                    profile_display_name.clone()
+                } else {
+                    self.private_user_display_name(
+                        user_id,
+                        Some(profile_display_name.as_str()),
+                        Some(username.as_str()),
+                    )
+                };
+                self.refresh_message_author_from_profile(
+                    *guild_id,
+                    user_id,
+                    &display_name,
+                    avatar_url.as_deref(),
+                );
+                if let Some(guild_id) = guild_id {
+                    if let Some(member) = self
+                        .members
+                        .get_mut(guild_id)
+                        .and_then(|members| members.get_mut(&user_id))
+                    {
+                        if member.username.is_none() {
+                            member.display_name = profile_display_name;
+                            member.username = Some(username);
+                        }
+                    }
+                } else {
+                    self.refresh_dm_channel_info_from_profile(
+                        user_id,
+                        &display_name,
+                        Some(username.as_str()),
+                        avatar_url.as_deref(),
+                    );
+                }
             }
             AppEvent::UserNoteLoaded { user_id, note } => {
                 self.fetched_notes.insert(*user_id, note.clone());
@@ -503,30 +541,65 @@ impl DiscordState {
                 }
             }
             AppEvent::RelationshipsLoaded { relationships } => {
-                self.relationships.clear();
-                for (user_id, status) in relationships {
-                    self.relationships.insert(*user_id, *status);
+                let previous = std::mem::take(&mut self.relationships);
+                for relationship in relationships {
+                    self.relationships
+                        .insert(relationship.user_id, relationship.clone());
+                }
+                let affected_users: BTreeSet<Id<UserMarker>> = previous
+                    .keys()
+                    .copied()
+                    .chain(self.relationships.keys().copied())
+                    .collect();
+                for user_id in affected_users {
+                    let status = self
+                        .relationships
+                        .get(&user_id)
+                        .map(|relationship| relationship.status)
+                        .unwrap_or(FriendStatus::None);
                     for profile in self
                         .user_profiles
                         .values_mut()
-                        .filter(|profile| profile.user_id == *user_id)
+                        .filter(|profile| profile.user_id == user_id)
                     {
-                        profile.friend_status = *status;
+                        profile.friend_status = status;
                     }
+                    let previous = previous.get(&user_id);
+                    self.refresh_private_user_display_name(
+                        user_id,
+                        previous.and_then(|relationship| relationship.display_name.as_deref()),
+                        previous.and_then(|relationship| relationship.username.as_deref()),
+                        previous.and_then(|relationship| relationship.nickname.as_deref()),
+                    );
                 }
             }
-            AppEvent::RelationshipUpsert { user_id, status } => {
-                self.relationships.insert(*user_id, *status);
+            AppEvent::RelationshipUpsert { relationship } => {
+                let previous = self.relationships.get(&relationship.user_id).cloned();
+                let relationship = merge_relationship_info(previous.as_ref(), relationship);
+                self.relationships
+                    .insert(relationship.user_id, relationship.clone());
                 for profile in self
                     .user_profiles
                     .values_mut()
-                    .filter(|profile| profile.user_id == *user_id)
+                    .filter(|profile| profile.user_id == relationship.user_id)
                 {
-                    profile.friend_status = *status;
+                    profile.friend_status = relationship.status;
                 }
+                self.refresh_private_user_display_name(
+                    relationship.user_id,
+                    previous
+                        .as_ref()
+                        .and_then(|relationship| relationship.display_name.as_deref()),
+                    previous
+                        .as_ref()
+                        .and_then(|relationship| relationship.username.as_deref()),
+                    previous
+                        .as_ref()
+                        .and_then(|relationship| relationship.nickname.as_deref()),
+                );
             }
             AppEvent::RelationshipRemove { user_id } => {
-                self.relationships.remove(user_id);
+                let previous = self.relationships.remove(user_id);
                 for profile in self
                     .user_profiles
                     .values_mut()
@@ -534,6 +607,18 @@ impl DiscordState {
                 {
                     profile.friend_status = FriendStatus::None;
                 }
+                self.refresh_private_user_display_name(
+                    *user_id,
+                    previous
+                        .as_ref()
+                        .and_then(|relationship| relationship.display_name.as_deref()),
+                    previous
+                        .as_ref()
+                        .and_then(|relationship| relationship.username.as_deref()),
+                    previous
+                        .as_ref()
+                        .and_then(|relationship| relationship.nickname.as_deref()),
+                );
             }
             AppEvent::Ready { user, user_id } => {
                 self.current_user = Some(user.clone());
@@ -614,6 +699,111 @@ impl DiscordState {
         self.notification_settings = snapshot.notification_settings.clone();
         self.private_notification_settings = snapshot.private_notification_settings.clone();
     }
+
+    fn private_user_display_name(
+        &self,
+        user_id: Id<UserMarker>,
+        fallback_display_name: Option<&str>,
+        fallback_username: Option<&str>,
+    ) -> String {
+        if let Some(nickname) = self
+            .relationships
+            .get(&user_id)
+            .and_then(|relationship| relationship.nickname.as_deref())
+        {
+            return nickname.to_owned();
+        }
+        if let Some(display_name) = self
+            .relationships
+            .get(&user_id)
+            .and_then(|relationship| relationship.display_name.as_deref())
+        {
+            return display_name.to_owned();
+        }
+        if let Some(profile) = self
+            .user_profiles
+            .get(&UserProfileCacheKey::new(user_id, None))
+        {
+            return profile.display_name().to_owned();
+        }
+        fallback_display_name
+            .filter(|value| !value.is_empty())
+            .or_else(|| fallback_username.filter(|value| !value.is_empty()))
+            .unwrap_or("unknown")
+            .to_owned()
+    }
+
+    fn refresh_private_user_display_name(
+        &mut self,
+        user_id: Id<UserMarker>,
+        fallback_display_name: Option<&str>,
+        fallback_username: Option<&str>,
+        previous_nickname: Option<&str>,
+    ) {
+        let (channel_display_name, channel_username) =
+            self.current_private_recipient_identity(user_id);
+        let channel_display_name = channel_display_name
+            .filter(|display_name| previous_nickname != Some(display_name.as_str()));
+        let display_name = self.private_user_display_name(
+            user_id,
+            fallback_display_name
+                .or(channel_display_name.as_deref())
+                .filter(|value| !value.is_empty()),
+            fallback_username
+                .or(channel_username.as_deref())
+                .filter(|value| !value.is_empty()),
+        );
+        let username = self
+            .relationships
+            .get(&user_id)
+            .and_then(|relationship| relationship.username.clone())
+            .or(channel_username)
+            .or_else(|| fallback_username.map(str::to_owned));
+        self.refresh_message_author_from_profile(None, user_id, &display_name, None);
+        self.refresh_dm_channel_info_from_profile(
+            user_id,
+            &display_name,
+            username.as_deref(),
+            None,
+        );
+    }
+
+    fn current_private_recipient_identity(
+        &self,
+        user_id: Id<UserMarker>,
+    ) -> (Option<String>, Option<String>) {
+        self.channels
+            .values()
+            .filter(|channel| channel.guild_id.is_none())
+            .flat_map(|channel| channel.recipients.iter())
+            .find(|recipient| recipient.user_id == user_id)
+            .map(|recipient| {
+                (
+                    Some(recipient.display_name.clone()),
+                    recipient.username.clone(),
+                )
+            })
+            .unwrap_or((None, None))
+    }
+}
+
+fn merge_relationship_info(
+    previous: Option<&RelationshipInfo>,
+    incoming: &RelationshipInfo,
+) -> RelationshipInfo {
+    RelationshipInfo {
+        user_id: incoming.user_id,
+        status: incoming.status,
+        nickname: incoming.nickname.clone(),
+        display_name: incoming
+            .display_name
+            .clone()
+            .or_else(|| previous.and_then(|relationship| relationship.display_name.clone())),
+        username: incoming
+            .username
+            .clone()
+            .or_else(|| previous.and_then(|relationship| relationship.username.clone())),
+    }
 }
 
 #[cfg(test)]
@@ -630,8 +820,8 @@ mod tests {
         GuildNotificationSettingsInfo, MemberInfo, MentionInfo, MessageInfo, MessageKind,
         MessageReferenceInfo, MessageSnapshotInfo, MessageState, MutualGuildInfo,
         NotificationLevel, PermissionOverwriteInfo, PermissionOverwriteKind, PollAnswerInfo,
-        PollInfo, PresenceStatus, ReactionEmoji, ReactionInfo, ReadStateInfo, ReplyInfo, RoleInfo,
-        UserProfileInfo,
+        PollInfo, PresenceStatus, ReactionEmoji, ReactionInfo, ReadStateInfo, RelationshipInfo,
+        ReplyInfo, RoleInfo, UserProfileInfo,
     };
 
     fn profile_info(user_id: u64, guild_nick: Option<&str>) -> UserProfileInfo {
@@ -648,6 +838,22 @@ mod tests {
             mutual_friends_count: 0,
             friend_status: FriendStatus::None,
             note: None,
+        }
+    }
+
+    fn relationship_info(
+        user_id: u64,
+        status: FriendStatus,
+        nickname: Option<&str>,
+        display_name: Option<&str>,
+        username: Option<&str>,
+    ) -> RelationshipInfo {
+        RelationshipInfo {
+            user_id: Id::new(user_id),
+            status,
+            nickname: nickname.map(str::to_owned),
+            display_name: display_name.map(str::to_owned),
+            username: username.map(str::to_owned),
         }
     }
 
@@ -1540,6 +1746,93 @@ mod tests {
     }
 
     #[test]
+    fn dm_message_author_prefers_friend_nickname() {
+        let channel_id = Id::new(2);
+        let author_id = Id::new(4);
+        let mut state = DiscordState::default();
+
+        state.apply_event(&AppEvent::RelationshipsLoaded {
+            relationships: vec![relationship_info(
+                author_id.get(),
+                FriendStatus::Friend,
+                Some("Bestie"),
+                Some("Alice Global"),
+                Some("alice"),
+            )],
+        });
+        state.apply_event(&AppEvent::MessageCreate {
+            guild_id: None,
+            channel_id,
+            message_id: Id::new(3),
+            author_id,
+            author: "Alice Global".to_owned(),
+            author_avatar_url: None,
+            author_role_ids: Vec::new(),
+            message_kind: crate::discord::MessageKind::regular(),
+            reference: None,
+            reply: None,
+            poll: None,
+            content: Some("hello".to_owned()),
+            sticker_names: Vec::new(),
+            mentions: Vec::new(),
+            attachments: Vec::new(),
+            embeds: Vec::new(),
+            forwarded_snapshots: Vec::new(),
+        });
+
+        let messages = state.messages_for_channel(channel_id);
+        assert_eq!(messages[0].author, "Bestie");
+    }
+
+    #[test]
+    fn relationship_nickname_update_refreshes_existing_dm_message_authors() {
+        let channel_id = Id::new(2);
+        let author_id = Id::new(4);
+        let mut state = DiscordState::default();
+
+        state.apply_event(&AppEvent::RelationshipsLoaded {
+            relationships: vec![relationship_info(
+                author_id.get(),
+                FriendStatus::Friend,
+                Some("Bestie"),
+                Some("Alice Global"),
+                Some("alice"),
+            )],
+        });
+        state.apply_event(&AppEvent::MessageCreate {
+            guild_id: None,
+            channel_id,
+            message_id: Id::new(3),
+            author_id,
+            author: "Alice Global".to_owned(),
+            author_avatar_url: None,
+            author_role_ids: Vec::new(),
+            message_kind: crate::discord::MessageKind::regular(),
+            reference: None,
+            reply: None,
+            poll: None,
+            content: Some("hello".to_owned()),
+            sticker_names: Vec::new(),
+            mentions: Vec::new(),
+            attachments: Vec::new(),
+            embeds: Vec::new(),
+            forwarded_snapshots: Vec::new(),
+        });
+        state.apply_event(&AppEvent::RelationshipUpsert {
+            relationship: relationship_info(
+                author_id.get(),
+                FriendStatus::Friend,
+                None,
+                None,
+                None,
+            ),
+        });
+
+        let messages = state.messages_for_channel(channel_id);
+        assert_eq!(messages[0].author, "Alice Global");
+    }
+
+    #[test]
     fn member_update_refreshes_existing_message_author() {
         let guild_id = Id::new(1);
         let channel_id = Id::new(2);
@@ -1667,6 +1960,159 @@ mod tests {
             Some("https://cdn.discordapp.com/avatar.png")
         );
         assert_eq!(channel.recipients[0].status, PresenceStatus::Online);
+    }
+
+    #[test]
+    fn dm_channel_upsert_prefers_friend_nickname() {
+        let channel_id: Id<ChannelMarker> = Id::new(10);
+        let mut state = DiscordState::default();
+
+        state.apply_event(&AppEvent::RelationshipsLoaded {
+            relationships: vec![relationship_info(
+                20,
+                FriendStatus::Friend,
+                Some("Bestie"),
+                Some("Alice Global"),
+                Some("alice"),
+            )],
+        });
+        state.apply_event(&AppEvent::ChannelUpsert(ChannelInfo {
+            guild_id: None,
+            channel_id,
+            parent_id: None,
+            position: None,
+            last_message_id: None,
+            name: "Alice Global".to_owned(),
+            kind: "dm".to_owned(),
+            message_count: None,
+            total_message_sent: None,
+            thread_archived: None,
+            thread_locked: None,
+            thread_pinned: None,
+            recipients: Some(vec![ChannelRecipientInfo {
+                user_id: Id::new(20),
+                display_name: "Alice Global".to_owned(),
+                username: Some("alice".to_owned()),
+                is_bot: false,
+                avatar_url: None,
+                status: None,
+            }]),
+            permission_overwrites: Vec::new(),
+        }));
+
+        let channel = state.channel(channel_id).expect("channel should be stored");
+        assert_eq!(channel.name, "Bestie");
+        assert_eq!(channel.recipients[0].display_name, "Bestie");
+    }
+
+    #[test]
+    fn relationships_without_user_fields_preserve_existing_dm_names() {
+        let channel_id: Id<ChannelMarker> = Id::new(10);
+        let user_id: Id<UserMarker> = Id::new(20);
+        let mut state = DiscordState::default();
+
+        state.apply_event(&AppEvent::ChannelUpsert(ChannelInfo {
+            guild_id: None,
+            channel_id,
+            parent_id: None,
+            position: None,
+            last_message_id: None,
+            name: "Alice Global".to_owned(),
+            kind: "dm".to_owned(),
+            message_count: None,
+            total_message_sent: None,
+            thread_archived: None,
+            thread_locked: None,
+            thread_pinned: None,
+            recipients: Some(vec![ChannelRecipientInfo {
+                user_id,
+                display_name: "Alice Global".to_owned(),
+                username: Some("alice".to_owned()),
+                is_bot: false,
+                avatar_url: None,
+                status: None,
+            }]),
+            permission_overwrites: Vec::new(),
+        }));
+        state.apply_event(&AppEvent::MessageCreate {
+            guild_id: None,
+            channel_id,
+            message_id: Id::new(3),
+            author_id: user_id,
+            author: "Alice Global".to_owned(),
+            author_avatar_url: None,
+            author_role_ids: Vec::new(),
+            message_kind: crate::discord::MessageKind::regular(),
+            reference: None,
+            reply: None,
+            poll: None,
+            content: Some("hello".to_owned()),
+            sticker_names: Vec::new(),
+            mentions: Vec::new(),
+            attachments: Vec::new(),
+            embeds: Vec::new(),
+            forwarded_snapshots: Vec::new(),
+        });
+        state.apply_event(&AppEvent::RelationshipsLoaded {
+            relationships: vec![relationship_info(
+                user_id.get(),
+                FriendStatus::Friend,
+                None,
+                None,
+                None,
+            )],
+        });
+
+        let channel = state.channel(channel_id).expect("channel should be stored");
+        assert_eq!(channel.name, "Alice Global");
+        assert_eq!(channel.recipients[0].display_name, "Alice Global");
+        assert_eq!(
+            state.messages_for_channel(channel_id)[0].author,
+            "Alice Global"
+        );
+    }
+
+    #[test]
+    fn relationship_nickname_refresh_preserves_explicit_group_dm_name() {
+        let channel_id: Id<ChannelMarker> = Id::new(10);
+        let mut state = DiscordState::default();
+
+        state.apply_event(&AppEvent::ChannelUpsert(ChannelInfo {
+            guild_id: None,
+            channel_id,
+            parent_id: None,
+            position: None,
+            last_message_id: None,
+            name: "project chat".to_owned(),
+            kind: "group-dm".to_owned(),
+            message_count: None,
+            total_message_sent: None,
+            thread_archived: None,
+            thread_locked: None,
+            thread_pinned: None,
+            recipients: Some(vec![ChannelRecipientInfo {
+                user_id: Id::new(20),
+                display_name: "Alice Global".to_owned(),
+                username: Some("alice".to_owned()),
+                is_bot: false,
+                avatar_url: None,
+                status: None,
+            }]),
+            permission_overwrites: Vec::new(),
+        }));
+        state.apply_event(&AppEvent::RelationshipsLoaded {
+            relationships: vec![relationship_info(
+                20,
+                FriendStatus::Friend,
+                Some("Bestie"),
+                Some("Alice Global"),
+                Some("alice"),
+            )],
+        });
+
+        let channel = state.channel(channel_id).expect("channel should be stored");
+        assert_eq!(channel.name, "project chat");
+        assert_eq!(channel.recipients[0].display_name, "Bestie");
     }
 
     #[test]
@@ -2095,6 +2541,7 @@ mod tests {
             message_kind: MessageKind::new(19),
             reference: None,
             reply: Some(ReplyInfo {
+                author_id: None,
                 author: "Alex".to_owned(),
                 content: Some("잘되는군".to_owned()),
                 sticker_names: Vec::new(),
@@ -2144,6 +2591,7 @@ mod tests {
             message_kind: MessageKind::new(19),
             reference: None,
             reply: Some(ReplyInfo {
+                author_id: None,
                 author: "Alex".to_owned(),
                 content: Some("잘되는군".to_owned()),
                 sticker_names: Vec::new(),
@@ -2531,6 +2979,7 @@ mod tests {
     fn message_capabilities_track_reply_and_forwarded_traits() {
         let mut message = message_state("reply body");
         message.reply = Some(ReplyInfo {
+            author_id: None,
             author: "neo".to_owned(),
             content: Some("original".to_owned()),
             sticker_names: Vec::new(),

--- a/src/discord/state/channels.rs
+++ b/src/discord/state/channels.rs
@@ -61,14 +61,15 @@ pub struct ChannelRecipientState {
 }
 
 impl ChannelRecipientState {
-    fn from_info(
+    pub(super) fn from_info(
         recipient: &ChannelRecipientInfo,
         previous_status: Option<PresenceStatus>,
         known_status: Option<PresenceStatus>,
+        display_name: String,
     ) -> Self {
         Self {
             user_id: recipient.user_id,
-            display_name: recipient.display_name.clone(),
+            display_name,
             username: recipient.username.clone(),
             is_bot: recipient.is_bot,
             avatar_url: recipient.avatar_url.clone(),
@@ -170,12 +171,58 @@ impl DiscordState {
                             })
                             .map(|recipient| recipient.status);
                         let known_status = self.user_presences.get(&recipient.user_id).copied();
-                        ChannelRecipientState::from_info(recipient, previous_status, known_status)
+                        let display_name = self.private_user_display_name(
+                            recipient.user_id,
+                            Some(recipient.display_name.as_str()),
+                            recipient.username.as_deref(),
+                        );
+                        ChannelRecipientState::from_info(
+                            recipient,
+                            previous_status,
+                            known_status,
+                            display_name,
+                        )
                     })
                     .collect()
             })
             .or_else(|| existing.map(|existing| existing.recipients.clone()))
             .unwrap_or_default();
+
+        let incoming_recipient_names: Vec<String> = channel
+            .recipients
+            .as_ref()
+            .map(|recipients| {
+                recipients
+                    .iter()
+                    .map(|recipient| recipient.display_name.clone())
+                    .collect()
+            })
+            .unwrap_or_default();
+        let existing_name_follows_recipients = existing.is_some_and(|existing| {
+            private_channel_name_follows_recipients(
+                &existing.kind,
+                &existing.name,
+                existing.id,
+                &existing
+                    .recipients
+                    .iter()
+                    .map(|recipient| recipient.display_name.clone())
+                    .collect::<Vec<_>>(),
+            )
+        });
+        let name = if channel.guild_id.is_none()
+            && !recipients.is_empty()
+            && (private_channel_name_follows_recipients(
+                &channel.kind,
+                &channel.name,
+                channel.channel_id,
+                &incoming_recipient_names,
+            ) || existing_name_follows_recipients)
+        {
+            joined_recipient_display_names(&recipients)
+        } else {
+            channel.name.clone()
+        };
 
         // Threads do not own channel-level overwrites. `permitted` is decided
         // by the parent. For everything else, take the newest payload as
@@ -196,7 +243,7 @@ impl DiscordState {
                 parent_id: channel.parent_id,
                 position: channel.position,
                 last_message_id,
-                name: channel.name.clone(),
+                name,
                 kind: channel.kind.clone(),
                 message_count: channel.message_count,
                 total_message_sent: channel.total_message_sent,
@@ -207,6 +254,41 @@ impl DiscordState {
                 permission_overwrites,
             },
         );
+    }
+
+    pub(super) fn refresh_dm_channel_info_from_profile(
+        &mut self,
+        user_id: Id<UserMarker>,
+        display_name: &str,
+        username: Option<&str>,
+        avatar_url: Option<&str>,
+    ) {
+        for channel in self.channels.values_mut() {
+            if channel.guild_id.is_some() {
+                continue;
+            }
+            let previous_names: Vec<String> = channel
+                .recipients
+                .iter()
+                .map(|recipient| recipient.display_name.clone())
+                .collect();
+            let mut updated = false;
+            for recipient in &mut channel.recipients {
+                if recipient.user_id == user_id {
+                    recipient.display_name = display_name.to_owned();
+                    if let Some(username) = username {
+                        recipient.username = Some(username.to_owned());
+                    }
+                    if avatar_url.is_some() || recipient.avatar_url.is_none() {
+                        recipient.avatar_url = avatar_url.map(str::to_owned);
+                    }
+                    updated = true;
+                }
+            }
+            if updated {
+                refresh_private_channel_name_from_recipients(channel, &previous_names);
+            }
+        }
     }
 
     pub(super) fn update_channel_recipient_presence(
@@ -248,5 +330,45 @@ impl DiscordState {
         if let Some(count) = channel.total_message_sent.as_mut() {
             *count = count.saturating_add(1);
         }
+    }
+}
+
+pub(super) fn joined_recipient_display_names(recipients: &[ChannelRecipientState]) -> String {
+    recipients
+        .iter()
+        .map(|recipient| recipient.display_name.as_str())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+pub(super) fn private_channel_name_follows_recipients(
+    kind: &str,
+    current_name: &str,
+    channel_id: Id<ChannelMarker>,
+    recipient_names: &[String],
+) -> bool {
+    matches!(kind, "dm" | "Private")
+        || current_name == format!("dm-{}", channel_id.get())
+        || current_name == recipient_names.join(", ")
+}
+
+pub(super) fn refresh_private_channel_name_from_recipients(
+    channel: &mut ChannelState,
+    previous_names: &[String],
+) {
+    if channel.guild_id.is_some() {
+        return;
+    }
+    if !private_channel_name_follows_recipients(
+        &channel.kind,
+        &channel.name,
+        channel.id,
+        previous_names,
+    ) {
+        return;
+    }
+    let new_name = joined_recipient_display_names(&channel.recipients);
+    if !new_name.is_empty() {
+        channel.name = new_name;
     }
 }

--- a/src/discord/state/members.rs
+++ b/src/discord/state/members.rs
@@ -97,6 +97,22 @@ impl DiscordState {
             .map(|member| member.display_name.as_str())
     }
 
+    /// Returns true only when the cached member entry has a real Discord
+    /// username — meaning the member data was complete when it was stored.
+    /// A member with `username: None` has a synthesised fallback display name
+    /// and should still be looked up via the profile API.
+    pub fn member_has_known_name(
+        &self,
+        guild_id: Id<GuildMarker>,
+        user_id: Id<UserMarker>,
+    ) -> bool {
+        self.members
+            .get(&guild_id)
+            .and_then(|members| members.get(&user_id))
+            .map(|member| member.username.is_some())
+            .unwrap_or(false)
+    }
+
     pub(super) fn update_user_activities(
         &mut self,
         user_id: Id<UserMarker>,
@@ -116,14 +132,36 @@ pub(super) fn upsert_member(
     previous_status: Option<PresenceStatus>,
 ) {
     let status = previous_status.unwrap_or(PresenceStatus::Unknown);
+
+    // When the incoming payload is a bare-minimum fallback (no username resolved,
+    // display_name fell through to "unknown"), don't clobber a previously cached
+    // complete entry — the complete data came from a profile fetch and is better.
+    let is_fallback = member.username.is_none() && member.display_name == "unknown";
+    let existing_complete = is_fallback
+        .then(|| map.get(&member.user_id))
+        .flatten()
+        .filter(|e| e.username.is_some());
+    let (display_name, username, avatar_url) = match existing_complete {
+        Some(existing) => (
+            existing.display_name.clone(),
+            existing.username.clone(),
+            existing.avatar_url.clone(),
+        ),
+        None => (
+            member.display_name.clone(),
+            member.username.clone(),
+            member.avatar_url.clone(),
+        ),
+    };
+
     map.insert(
         member.user_id,
         GuildMemberState {
             user_id: member.user_id,
-            display_name: member.display_name.clone(),
-            username: member.username.clone(),
+            display_name,
+            username,
             is_bot: member.is_bot,
-            avatar_url: member.avatar_url.clone(),
+            avatar_url,
             role_ids: member.role_ids.clone(),
             status,
         },

--- a/src/discord/state/messages.rs
+++ b/src/discord/state/messages.rs
@@ -13,6 +13,7 @@ use crate::discord::{
 use super::{
     DiscordState, OLDER_HISTORY_EXTRA_WINDOW_MULTIPLIER,
     members::{selected_member_role_color, selected_role_ids_color},
+    profiles::UserProfileCacheKey,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -209,10 +210,23 @@ impl DiscordState {
         author_id: Id<UserMarker>,
         fallback: &str,
     ) -> String {
-        guild_id
+        if guild_id.is_none() {
+            return self.private_user_display_name(author_id, Some(fallback), None);
+        }
+        if let Some(member) = guild_id
             .and_then(|guild_id| self.members.get(&guild_id))
             .and_then(|members| members.get(&author_id))
-            .map(|member| member.display_name.clone())
+        {
+            // Only trust the member entry if it has real name data. When
+            // username is None and display_name is "unknown" the entry is a
+            // bare fallback — fall through to the profile cache instead.
+            if member.username.is_some() || member.display_name != "unknown" {
+                return member.display_name.clone();
+            }
+        }
+        self.user_profiles
+            .get(&UserProfileCacheKey::new(author_id, guild_id))
+            .map(|profile| profile.display_name().to_owned())
             .unwrap_or_else(|| fallback.to_owned())
     }
 
@@ -259,11 +273,64 @@ impl DiscordState {
         guild_id: Id<GuildMarker>,
         member: &MemberInfo,
     ) {
+        // If this member payload is a fallback ("unknown", no username), avoid
+        // clobbering messages that already have a real name. Try the profile
+        // cache for a better name; if nothing is available, skip the refresh.
+        let display_name = if member.username.is_none() && member.display_name == "unknown" {
+            match self
+                .user_profiles
+                .get(&UserProfileCacheKey::new(member.user_id, Some(guild_id)))
+            {
+                Some(profile) => profile.display_name().to_owned(),
+                None => return,
+            }
+        } else {
+            member.display_name.clone()
+        };
+        let avatar_url = member.avatar_url.clone();
+
+        for messages in self
+            .messages
+            .values_mut()
+            .chain(self.pinned_messages.values_mut())
+        {
+            for message in messages.iter_mut().filter(|m| m.guild_id == Some(guild_id)) {
+                if message.author_id == member.user_id {
+                    message.author = display_name.clone();
+                    if avatar_url.is_some() || message.author_avatar_url.is_none() {
+                        message.author_avatar_url = avatar_url.clone();
+                    }
+                }
+                if let Some(reply) = message
+                    .reply
+                    .as_mut()
+                    .filter(|r| r.author_id == Some(member.user_id))
+                {
+                    reply.author = display_name.clone();
+                }
+            }
+        }
+    }
+
+    pub(super) fn refresh_message_author_from_profile(
+        &mut self,
+        guild_id: Option<Id<GuildMarker>>,
+        user_id: Id<UserMarker>,
+        display_name: &str,
+        avatar_url: Option<&str>,
+    ) {
         self.for_each_cached_message_mut(|message| {
-            if message.guild_id == Some(guild_id) && message.author_id == member.user_id {
-                message.author = member.display_name.clone();
-                if member.avatar_url.is_some() || message.author_avatar_url.is_none() {
-                    message.author_avatar_url = member.avatar_url.clone();
+            if message.guild_id == guild_id {
+                if message.author_id == user_id {
+                    message.author = display_name.to_owned();
+                    if avatar_url.is_some() || message.author_avatar_url.is_none() {
+                        message.author_avatar_url = avatar_url.map(str::to_owned);
+                    }
+                }
+                if let Some(reply) = &mut message.reply {
+                    if reply.author_id == Some(user_id) {
+                        reply.author = display_name.to_owned();
+                    }
                 }
             }
         });

--- a/src/tui/input/keyboard.rs
+++ b/src/tui/input/keyboard.rs
@@ -84,6 +84,9 @@ pub fn handle_key(state: &mut DashboardState, key: KeyEvent) -> Option<AppComman
 
     if let Some(action) = action {
         dispatch_action(state, action, focus)
+    } else if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+        state.quit();
+        None
     } else {
         None
     }

--- a/src/tui/input/tests.rs
+++ b/src/tui/input/tests.rs
@@ -1218,12 +1218,12 @@ fn ctrl_c_clears_composer_without_quitting() {
 }
 
 #[test]
-fn ctrl_c_does_not_quit_dashboard() {
+fn ctrl_c_quits_dashboard() {
     let mut state = state_with_channel_tree();
 
     handle_key(&mut state, ctrl_key('c'));
 
-    assert!(!state.should_quit());
+    assert!(state.should_quit());
 }
 
 #[test]

--- a/src/tui/message_format.rs
+++ b/src/tui/message_format.rs
@@ -18,12 +18,14 @@ use super::{
     },
     message_time,
     state::{DashboardState, ThreadSummary, discord_color},
+    theme::ColorScheme,
 };
 use crate::discord::{
     AttachmentInfo, EmbedInfo, MessageKind, MessageSnapshotInfo, MessageState, PollInfo,
     ReactionEmoji, ReactionInfo, ReplyInfo,
 };
 
+#[cfg(test)]
 const ACCENT: Color = Color::Cyan;
 const DIM: Color = Color::DarkGray;
 const SELF_REACTION: Color = Color::Yellow;
@@ -38,6 +40,8 @@ pub(super) struct MessageContentLine {
     mention_highlights: Vec<TextHighlight>,
     styled_prefixes: Vec<StyledPrefix>,
     pub(super) image_slots: Vec<MessageContentImageSlot>,
+    self_mention_style: Style,
+    other_mention_style: Style,
 }
 
 #[derive(Clone, Copy)]
@@ -67,6 +71,8 @@ impl MessageContentLine {
             mention_highlights: Vec::new(),
             styled_prefixes: Vec::new(),
             image_slots: Vec::new(),
+            self_mention_style: mention_highlight_style(TextHighlightKind::SelfMention),
+            other_mention_style: mention_highlight_style(TextHighlightKind::OtherMention),
         }
     }
 
@@ -77,27 +83,39 @@ impl MessageContentLine {
             mention_highlights,
             styled_prefixes: Vec::new(),
             image_slots: Vec::new(),
+            self_mention_style: mention_highlight_style(TextHighlightKind::SelfMention),
+            other_mention_style: mention_highlight_style(TextHighlightKind::OtherMention),
         }
     }
 
-    fn dim(text: String) -> Self {
+    fn dim(text: String, color: Color) -> Self {
         Self {
             text,
-            style: Style::default().fg(DIM),
+            style: Style::default().fg(color),
             mention_highlights: Vec::new(),
             styled_prefixes: Vec::new(),
             image_slots: Vec::new(),
+            self_mention_style: mention_highlight_style(TextHighlightKind::SelfMention),
+            other_mention_style: mention_highlight_style(TextHighlightKind::OtherMention),
         }
     }
 
-    fn accent(text: String) -> Self {
+    fn accent(text: String, color: Color) -> Self {
         Self {
             text,
-            style: Style::default().fg(ACCENT),
+            style: Style::default().fg(color),
             mention_highlights: Vec::new(),
             styled_prefixes: Vec::new(),
             image_slots: Vec::new(),
+            self_mention_style: mention_highlight_style(TextHighlightKind::SelfMention),
+            other_mention_style: mention_highlight_style(TextHighlightKind::OtherMention),
         }
+    }
+
+    fn with_mention_styles(mut self, self_style: Style, other_style: Style) -> Self {
+        self.self_mention_style = self_style;
+        self.other_mention_style = other_style;
+        self
     }
 
     fn with_image_slots(mut self, slots: Vec<MessageContentImageSlot>) -> Self {
@@ -172,7 +190,11 @@ impl MessageContentLine {
             .iter()
             .find(|highlight| highlight.start <= start && end <= highlight.end)
         {
-            style = style.patch(mention_highlight_style(highlight.kind));
+            let mention_style = match highlight.kind {
+                TextHighlightKind::SelfMention => self.self_mention_style,
+                TextHighlightKind::OtherMention => self.other_mention_style,
+            };
+            style = style.patch(mention_style);
         }
 
         style
@@ -304,8 +326,9 @@ pub(super) fn format_message_content_sections_with_loaded_custom_emoji_urls(
             content,
             width,
             loaded_custom_emoji_urls,
+            state.theme(),
         ));
-    } else if let Some(line) = format_message_kind_line(message.message_kind) {
+    } else if let Some(line) = format_message_kind_line(message.message_kind, state.theme().dim) {
         lines.push(line);
     }
 
@@ -320,6 +343,8 @@ pub(super) fn format_message_content_sections_with_loaded_custom_emoji_urls(
             width,
             Style::default(),
             loaded_custom_emoji_urls,
+            state.theme().self_mention_style(),
+            state.theme().other_mention_style(),
         ));
     }
     lines.extend(format_embed_lines(
@@ -328,12 +353,13 @@ pub(super) fn format_message_content_sections_with_loaded_custom_emoji_urls(
         state.show_custom_emoji(),
         width,
         loaded_custom_emoji_urls,
+        state.theme().dim,
     ));
     for attachment in attachment_summary_lines {
-        lines.push(MessageContentLine::accent(truncate_text(
-            &attachment,
-            width,
-        )));
+        lines.push(MessageContentLine::accent(
+            truncate_text(&attachment, width),
+            state.theme().accent,
+        ));
     }
     if let Some(snapshot) = message.forwarded_snapshots.first() {
         lines.extend(format_forwarded_snapshot(
@@ -352,16 +378,21 @@ pub(super) fn format_message_content_sections_with_loaded_custom_emoji_urls(
     }
 
     if message.edited_timestamp.is_some() {
-        append_edited_marker(&mut lines, width);
+        append_edited_marker(&mut lines, width, state.theme().dim);
     }
 
-    let reaction_lines =
-        format_message_reaction_lines(&message.reactions, width, state.show_custom_emoji());
+    let reaction_lines = format_message_reaction_lines(
+        &message.reactions,
+        width,
+        state.show_custom_emoji(),
+        state.theme().accent,
+        state.theme().self_reaction,
+    );
     (lines, reaction_lines)
 }
 
-fn append_edited_marker(lines: &mut Vec<MessageContentLine>, width: usize) {
-    let marker_style = Style::default().fg(DIM).add_modifier(Modifier::ITALIC);
+fn append_edited_marker(lines: &mut Vec<MessageContentLine>, width: usize, dim: Color) {
+    let marker_style = Style::default().fg(dim).add_modifier(Modifier::ITALIC);
     let marker_width = EDITED_MARKER.width();
     if let Some(line) = lines.last_mut()
         && line.text.width().saturating_add(marker_width) <= width
@@ -382,6 +413,7 @@ fn format_embed_lines(
     show_custom_emoji: bool,
     width: usize,
     loaded_custom_emoji_urls: &[String],
+    dim: Color,
 ) -> Vec<MessageContentLine> {
     embeds
         .iter()
@@ -392,6 +424,7 @@ fn format_embed_lines(
                 show_custom_emoji,
                 width,
                 loaded_custom_emoji_urls,
+                dim,
             )
         })
         .collect()
@@ -403,6 +436,7 @@ fn format_embed(
     show_custom_emoji: bool,
     width: usize,
     loaded_custom_emoji_urls: &[String],
+    dim: Color,
 ) -> Vec<MessageContentLine> {
     const PREFIX: &str = "  ▎ ";
     let inner_width = width.saturating_sub(PREFIX.width()).max(1);
@@ -413,7 +447,7 @@ fn format_embed(
         embed.provider_name.as_deref(),
         show_custom_emoji,
         inner_width,
-        embed_provider_style(),
+        embed_provider_style(dim),
         loaded_custom_emoji_urls,
     );
     push_embed_text(
@@ -455,7 +489,7 @@ fn format_embed(
         embed.footer_text.as_deref(),
         show_custom_emoji,
         inner_width,
-        embed_footer_style(),
+        embed_footer_style(dim),
         loaded_custom_emoji_urls,
     );
     for url in [&embed.url]
@@ -505,11 +539,13 @@ fn push_embed_text(
         width,
         style,
         loaded_custom_emoji_urls,
+        mention_highlight_style(TextHighlightKind::SelfMention),
+        mention_highlight_style(TextHighlightKind::OtherMention),
     ));
 }
 
-fn embed_provider_style() -> Style {
-    Style::default().fg(DIM).add_modifier(Modifier::ITALIC)
+fn embed_provider_style(dim: Color) -> Style {
+    Style::default().fg(dim).add_modifier(Modifier::ITALIC)
 }
 
 fn embed_author_style() -> Style {
@@ -528,8 +564,8 @@ fn embed_field_name_style() -> Style {
         .add_modifier(Modifier::UNDERLINED)
 }
 
-fn embed_footer_style() -> Style {
-    Style::default().fg(DIM).add_modifier(Modifier::ITALIC)
+fn embed_footer_style(dim: Color) -> Style {
+    Style::default().fg(dim).add_modifier(Modifier::ITALIC)
 }
 
 fn embed_url_style() -> Style {
@@ -558,6 +594,8 @@ pub(super) fn format_message_reaction_lines(
     reactions: &[ReactionInfo],
     width: usize,
     show_custom_emoji: bool,
+    accent: Color,
+    self_reaction: Color,
 ) -> Vec<MessageContentLine> {
     let layout =
         lay_out_reaction_chips_with_custom_emoji_images(reactions, width, show_custom_emoji);
@@ -568,12 +606,12 @@ pub(super) fn format_message_reaction_lines(
         .into_iter()
         .enumerate()
         .map(|(line_index, text)| {
-            let mut line = MessageContentLine::accent(text);
+            let mut line = MessageContentLine::accent(text, accent);
             for range in self_ranges
                 .iter()
                 .filter(|range| range.line as usize == line_index)
             {
-                line.styled_range(range.start, range.len, Style::default().fg(SELF_REACTION));
+                line.styled_range(range.start, range.len, Style::default().fg(self_reaction));
             }
             line
         })
@@ -739,6 +777,8 @@ fn wrap_rendered_text_lines_with_loaded_custom_emoji_urls(
     width: usize,
     style: Style,
     loaded_custom_emoji_urls: &[String],
+    self_mention_style: Style,
+    other_mention_style: Style,
 ) -> Vec<MessageContentLine> {
     let rendered =
         rendered_text_with_loaded_custom_emoji_placeholders(rendered, loaded_custom_emoji_urls);
@@ -752,6 +792,7 @@ fn wrap_rendered_text_lines_with_loaded_custom_emoji_urls(
     .map(|(text, mention_highlights, image_slots)| {
         MessageContentLine::styled_text(text, style, mention_highlights)
             .with_image_slots(image_slots)
+            .with_mention_styles(self_mention_style, other_mention_style)
     })
     .collect()
 }
@@ -1107,6 +1148,7 @@ fn format_poll_lines(
     content: Option<RenderedText>,
     width: usize,
     loaded_custom_emoji_urls: &[String],
+    theme: &ColorScheme,
 ) -> Vec<MessageContentLine> {
     let inner_width = poll_card_inner_width(width);
     let helper = if poll.allow_multiselect {
@@ -1114,7 +1156,10 @@ fn format_poll_lines(
     } else {
         "Select one answer"
     };
-    let mut lines = vec![MessageContentLine::accent(poll_box_border('╭', '╮', width))];
+    let mut lines = vec![MessageContentLine::accent(
+        poll_box_border('╭', '╮', width),
+        theme.accent,
+    )];
     lines.push(poll_box_line(
         MessageContentLine::plain(truncate_display_width(&poll.question, inner_width)),
         inner_width,
@@ -1126,13 +1171,15 @@ fn format_poll_lines(
                 inner_width,
                 Style::default(),
                 loaded_custom_emoji_urls,
+                theme.self_mention_style(),
+                theme.other_mention_style(),
             )
             .into_iter()
             .map(|line| poll_box_line(line, inner_width)),
         );
     }
     lines.push(poll_box_line(
-        MessageContentLine::dim(truncate_display_width(helper, inner_width)),
+        MessageContentLine::dim(truncate_display_width(helper, inner_width), theme.dim),
         inner_width,
     ));
     let counted_votes = poll
@@ -1151,13 +1198,16 @@ fn format_poll_lines(
         )
     }));
     lines.push(poll_box_line(
-        MessageContentLine::dim(truncate_display_width(
-            &format_poll_footer(poll, total_votes),
-            inner_width,
-        )),
+        MessageContentLine::dim(
+            truncate_display_width(&format_poll_footer(poll, total_votes), inner_width),
+            theme.dim,
+        ),
         inner_width,
     ));
-    lines.push(MessageContentLine::accent(poll_box_border('╰', '╯', width)));
+    lines.push(MessageContentLine::accent(
+        poll_box_border('╰', '╯', width),
+        theme.accent,
+    ));
     lines
 }
 
@@ -1187,15 +1237,20 @@ fn poll_box_line(mut line: MessageContentLine, inner_width: usize) -> MessageCon
     line
 }
 
-fn format_poll_result_lines(poll: Option<&PollInfo>, width: usize) -> Vec<MessageContentLine> {
+fn format_poll_result_lines(
+    poll: Option<&PollInfo>,
+    width: usize,
+    accent: Color,
+    dim: Color,
+) -> Vec<MessageContentLine> {
     let Some(poll) = poll else {
         return vec![
-            MessageContentLine::accent(truncate_text("Poll results", width)),
-            MessageContentLine::dim(truncate_text("Result details unavailable", width)),
+            MessageContentLine::accent(truncate_text("Poll results", width), accent),
+            MessageContentLine::dim(truncate_text("Result details unavailable", width), dim),
         ];
     };
     let mut lines = vec![
-        MessageContentLine::accent(truncate_text("Poll results", width)),
+        MessageContentLine::accent(truncate_text("Poll results", width), accent),
         MessageContentLine::plain(truncate_text(&poll.question, width)),
     ];
     if let Some(winner) = poll.answers.first() {
@@ -1208,10 +1263,10 @@ fn format_poll_result_lines(poll: Option<&PollInfo>, width: usize) -> Vec<Messag
             width,
         )));
     } else {
-        lines.push(MessageContentLine::dim(truncate_text(
-            "No winning answer recorded",
-            width,
-        )));
+        lines.push(MessageContentLine::dim(
+            truncate_text("No winning answer recorded", width),
+            dim,
+        ));
     }
     let counted_votes = poll
         .answers
@@ -1223,10 +1278,13 @@ fn format_poll_result_lines(poll: Option<&PollInfo>, width: usize) -> Vec<Messag
         .or_else(|| (counted_votes > 0).then_some(counted_votes));
     if let Some(total_votes) = total_votes {
         let vote_label = if total_votes == 1 { "vote" } else { "votes" };
-        lines.push(MessageContentLine::dim(truncate_text(
-            &format!("{total_votes} total {vote_label} · Final results"),
-            width,
-        )));
+        lines.push(MessageContentLine::dim(
+            truncate_text(
+                &format!("{total_votes} total {vote_label} · Final results"),
+                width,
+            ),
+            dim,
+        ));
     }
     lines
 }
@@ -1296,7 +1354,7 @@ fn sticker_display_text(sticker_names: &[String]) -> Option<String> {
     })
 }
 
-fn format_message_kind_line(message_kind: MessageKind) -> Option<MessageContentLine> {
+fn format_message_kind_line(message_kind: MessageKind, dim: Color) -> Option<MessageContentLine> {
     if message_kind.is_regular() {
         return None;
     }
@@ -1309,7 +1367,7 @@ fn format_message_kind_line(message_kind: MessageKind) -> Option<MessageContentL
             .unwrap_or("<unsupported message type>"),
     };
 
-    Some(MessageContentLine::dim(label.to_owned()))
+    Some(MessageContentLine::dim(label.to_owned(), dim))
 }
 
 fn format_system_message_lines(
@@ -1317,21 +1375,31 @@ fn format_system_message_lines(
     state: &DashboardState,
     width: usize,
 ) -> Option<Vec<MessageContentLine>> {
+    let accent = state.theme().accent;
+    let dim = state.theme().dim;
     match message.message_kind.code() {
-        8 => Some(vec![MessageContentLine::accent(truncate_text(
-            &format!("{} boosted the server", message.author),
-            width,
-        ))]),
+        8 => Some(vec![MessageContentLine::accent(
+            truncate_text(&format!("{} boosted the server", message.author), width),
+            accent,
+        )]),
         9..=11 => {
             let tier = message.message_kind.code() - 8;
-            Some(vec![MessageContentLine::accent(truncate_text(
-                &format!("{} boosted the server to Level {tier}", message.author),
-                width,
-            ))])
+            Some(vec![MessageContentLine::accent(
+                truncate_text(
+                    &format!("{} boosted the server to Level {tier}", message.author),
+                    width,
+                ),
+                accent,
+            )])
         }
         18 => Some(format_thread_created_lines(message, state, width)),
         21 => Some(format_thread_starter_lines(message, state, width)),
-        46 => Some(format_poll_result_lines(message.poll.as_ref(), width)),
+        46 => Some(format_poll_result_lines(
+            message.poll.as_ref(),
+            width,
+            accent,
+            dim,
+        )),
         _ => None,
     }
 }
@@ -1358,6 +1426,8 @@ fn format_thread_created_lines(
         summary.as_ref(),
         message.id,
         width,
+        state.theme().accent,
+        state.theme().dim,
     ));
     lines
 }
@@ -1374,7 +1444,7 @@ fn format_thread_created_starter_line(
             Color::White,
         ))
         .bold();
-    let thread_style = Style::default().fg(ACCENT).bold();
+    let thread_style = Style::default().fg(state.theme().accent).bold();
     let base_style = Style::default().fg(Color::White);
 
     let author = message.author.as_str();
@@ -1402,23 +1472,28 @@ fn format_thread_card_lines(
     summary: Option<&ThreadSummary>,
     message_id: Id<MessageMarker>,
     width: usize,
+    accent: Color,
+    dim: Color,
 ) -> Vec<MessageContentLine> {
     let card_width = thread_card_width(width);
     let inner_width = thread_card_inner_width(width);
     vec![
-        MessageContentLine::accent(thread_card_border('╭', '╮', width)),
+        MessageContentLine::accent(thread_card_border('╭', '╮', width), accent),
         thread_card_line(
-            format_thread_card_title_line(thread_name, summary, inner_width),
+            format_thread_card_title_line(thread_name, summary, inner_width, accent),
             inner_width,
         ),
         thread_card_line(
-            format_thread_latest_line(summary, message_id, inner_width),
+            format_thread_latest_line(summary, message_id, inner_width, dim),
             inner_width,
         ),
-        MessageContentLine::accent(format!(
-            "{THREAD_CARD_INDENT}╰{}╯",
-            "─".repeat(card_width.saturating_sub(2))
-        )),
+        MessageContentLine::accent(
+            format!(
+                "{THREAD_CARD_INDENT}╰{}╯",
+                "─".repeat(card_width.saturating_sub(2))
+            ),
+            accent,
+        ),
     ]
 }
 
@@ -1426,14 +1501,15 @@ fn format_thread_card_title_line(
     thread_name: &str,
     summary: Option<&ThreadSummary>,
     width: usize,
+    accent: Color,
 ) -> MessageContentLine {
     let Some(count_label) = summary.and_then(thread_message_count_label) else {
-        return MessageContentLine::accent(truncate_display_width(thread_name, width));
+        return MessageContentLine::accent(truncate_display_width(thread_name, width), accent);
     };
 
     let count_width = count_label.width();
     if count_width.saturating_add(2) >= width {
-        return MessageContentLine::accent(truncate_display_width(thread_name, width));
+        return MessageContentLine::accent(truncate_display_width(thread_name, width), accent);
     }
 
     let name_width = width.saturating_sub(count_width).saturating_sub(2);
@@ -1441,7 +1517,10 @@ fn format_thread_card_title_line(
     let padding = width
         .saturating_sub(name.width())
         .saturating_sub(count_width);
-    MessageContentLine::accent(format!("{name}{}{count_label}", " ".repeat(padding)))
+    MessageContentLine::accent(
+        format!("{name}{}{count_label}", " ".repeat(padding)),
+        accent,
+    )
 }
 
 fn thread_message_count_label(summary: &ThreadSummary) -> Option<String> {
@@ -1484,6 +1563,7 @@ fn format_thread_latest_line(
     summary: Option<&ThreadSummary>,
     message_id: Id<MessageMarker>,
     width: usize,
+    dim: Color,
 ) -> MessageContentLine {
     let mut metadata = Vec::new();
     if let Some(summary) = summary {
@@ -1502,12 +1582,10 @@ fn format_thread_latest_line(
             format!("{age} · {}", statuses.join(" · "))
         };
         if let Some(preview) = summary.latest_message_preview.as_ref() {
-            return MessageContentLine::dim(format_latest_message_preview(
-                &preview.author,
-                &preview.content,
-                &suffix,
-                width,
-            ));
+            return MessageContentLine::dim(
+                format_latest_message_preview(&preview.author, &preview.content, &suffix, width),
+                dim,
+            );
         }
         metadata.push(suffix);
     } else {
@@ -1515,7 +1593,7 @@ fn format_thread_latest_line(
         metadata.push("Thread details unavailable".to_owned());
     }
 
-    MessageContentLine::dim(truncate_display_width(&metadata.join(" · "), width))
+    MessageContentLine::dim(truncate_display_width(&metadata.join(" · "), width), dim)
 }
 
 fn format_latest_message_preview(
@@ -1586,17 +1664,17 @@ fn format_thread_starter_lines(
     state: &DashboardState,
     width: usize,
 ) -> Vec<MessageContentLine> {
-    let mut lines = vec![MessageContentLine::accent(truncate_text(
-        "Thread starter message",
-        width,
-    ))];
+    let mut lines = vec![MessageContentLine::accent(
+        truncate_text("Thread starter message", width),
+        state.theme().accent,
+    )];
     if let Some(reply) = message.reply.as_ref() {
         lines.push(format_reply_line(reply, message.guild_id, state, width));
     } else {
-        lines.push(MessageContentLine::dim(truncate_text(
-            "Started from an unavailable message",
-            width,
-        )));
+        lines.push(MessageContentLine::dim(
+            truncate_text("Started from an unavailable message", width),
+            state.theme().dim,
+        ));
     }
     lines
 }
@@ -1628,16 +1706,18 @@ fn format_forwarded_snapshot(
                 content_width,
                 Style::default(),
                 loaded_custom_emoji_urls,
+                state.theme().self_mention_style(),
+                state.theme().other_mention_style(),
             )
             .into_iter()
             .map(|line| prefix_message_content_line_without_underline("│ ", line)),
         );
     }
     for attachment in attachment_summary_lines {
-        lines.push(MessageContentLine::accent(truncate_text(
-            &format!("│ {attachment}"),
-            width,
-        )));
+        lines.push(MessageContentLine::accent(
+            truncate_text(&format!("│ {attachment}"), width),
+            state.theme().accent,
+        ));
     }
     lines.extend(
         format_embed_lines(
@@ -1646,6 +1726,7 @@ fn format_forwarded_snapshot(
             state.show_custom_emoji(),
             width.saturating_sub(2).max(1),
             loaded_custom_emoji_urls,
+            state.theme().dim,
         )
         .into_iter()
         .map(|line| prefix_message_content_line_without_underline("│ ", line)),
@@ -1661,10 +1742,10 @@ fn format_forwarded_snapshot(
         metadata.push(format_forwarded_time(timestamp));
     }
     if !metadata.is_empty() {
-        lines.push(MessageContentLine::dim(truncate_text(
-            &format!("│ {}", metadata.join(" · ")),
-            width,
-        )));
+        lines.push(MessageContentLine::dim(
+            truncate_text(&format!("│ {}", metadata.join(" · ")), width),
+            state.theme().dim,
+        ));
     }
 
     lines
@@ -1736,6 +1817,8 @@ mod tests {
                 style: Style::default().fg(Color::Red),
             }],
             image_slots: Vec::new(),
+            self_mention_style: mention_highlight_style(TextHighlightKind::SelfMention),
+            other_mention_style: mention_highlight_style(TextHighlightKind::OtherMention),
         };
 
         let spans = line.spans();

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -16,6 +16,7 @@ mod runtime;
 mod selection;
 mod state;
 mod terminal;
+pub(crate) mod theme;
 mod ui;
 
 use tokio::sync::{mpsc, watch};

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -56,6 +56,14 @@ pub(super) async fn run_dashboard(
         }
     };
     state.set_key_bindings(key_bindings);
+    let color_scheme = match config::load_theme() {
+        Ok(theme) => crate::tui::theme::ColorScheme::from_theme(&theme),
+        Err(error) => {
+            logging::error("config", format!("failed to load theme: {error}"));
+            crate::tui::theme::ColorScheme::default()
+        }
+    };
+    state.set_theme(color_scheme);
     drop(snapshots.borrow_and_update());
     let initial_snapshot = client.current_discord_snapshot();
     let mut current_snapshot_revision = initial_snapshot.revision;
@@ -72,7 +80,8 @@ pub(super) async fn run_dashboard(
     let mut member_requests = MemberRequests::default();
     let mut thread_preview_requests = ThreadPreviewRequests::default();
     let mut last_member_subscription: Option<(Id<GuildMarker>, Id<ChannelMarker>, u32)> = None;
-    let mut requested_author_profiles: HashSet<(Id<UserMarker>, Id<GuildMarker>)> = HashSet::new();
+    let mut requested_author_profiles: HashSet<(Id<UserMarker>, Option<Id<GuildMarker>>)> =
+        HashSet::new();
     let mut image_targets = Vec::new();
     let mut avatar_targets = Vec::new();
     let mut emoji_targets = Vec::new();
@@ -522,15 +531,16 @@ pub(super) async fn run_dashboard(
             }
         }
 
-        for (user_id, guild_id) in state.missing_message_author_profile_requests() {
+        let profile_requests = state
+            .missing_message_author_profile_requests()
+            .into_iter()
+            .chain(state.missing_visible_member_profile_requests());
+        for (user_id, guild_id) in profile_requests {
             if !requested_author_profiles.insert((user_id, guild_id)) {
                 continue;
             }
             if commands
-                .send(AppCommand::LoadUserProfile {
-                    user_id,
-                    guild_id: Some(guild_id),
-                })
+                .send(AppCommand::LoadUserProfile { user_id, guild_id })
                 .await
                 .is_err()
             {

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -14,6 +14,7 @@ use crate::discord::{
     ForumPostArchiveState, MentionInfo, MessageAttachmentUpload, MessageInfo, MessageSnapshotInfo,
     MessageState, MuteDuration, PresenceStatus,
 };
+use crate::tui::theme::ColorScheme;
 use unicode_width::UnicodeWidthStr;
 
 use super::format::{
@@ -76,7 +77,7 @@ pub use options::DisplayOptionItem;
 pub use popups::{
     EmojiReactionPickerState, MessageActionMenuState, PollVotePickerState, ReactionUsersPopupState,
 };
-pub use presentation::{discord_color, folder_color, presence_color, presence_marker};
+pub use presentation::{discord_color, presence_marker};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum OlderHistoryRequestState {
@@ -261,6 +262,7 @@ pub struct DashboardState {
     collapsed_channel_categories: HashSet<Id<ChannelMarker>>,
     pending_read_acks: HashMap<Id<ChannelMarker>, PendingReadAck>,
     pending_commands: VecDeque<AppCommand>,
+    theme: ColorScheme,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -392,6 +394,7 @@ impl DashboardState {
             collapsed_channel_categories: HashSet::new(),
             pending_read_acks: HashMap::new(),
             pending_commands: VecDeque::new(),
+            theme: ColorScheme::default(),
         }
     }
 

--- a/src/tui/state/options.rs
+++ b/src/tui/state/options.rs
@@ -1,5 +1,6 @@
 use crate::config::{DisplayOptions, ImagePreviewQualityPreset};
 use crate::tui::keybinding::ActiveKeyBindings;
+use crate::tui::theme::ColorScheme;
 
 use super::{DashboardState, FocusPane, popups::OptionsPopupState};
 
@@ -22,6 +23,14 @@ impl DashboardState {
             display_options,
             ..Self::new()
         }
+    }
+
+    pub fn set_theme(&mut self, theme: ColorScheme) {
+        self.theme = theme;
+    }
+
+    pub fn theme(&self) -> &ColorScheme {
+        &self.theme
     }
 
     pub fn set_key_bindings(&mut self, key_bindings: ActiveKeyBindings) {

--- a/src/tui/state/presentation.rs
+++ b/src/tui/state/presentation.rs
@@ -5,13 +5,6 @@ use crate::discord::{
     ChannelRecipientState, ChannelState, GuildMemberState, PresenceStatus, RoleState,
 };
 
-/// Convert a Discord folder color (24-bit RGB integer) to a ratatui color.
-/// Falls back to a neutral cyan when the color is missing or zero so
-/// uncolored folders still read as folder headers.
-pub fn folder_color(color: Option<u32>) -> Color {
-    discord_color(color, Color::Cyan)
-}
-
 pub fn discord_color(color: Option<u32>, fallback: Color) -> Color {
     match color {
         Some(value) if value != 0 => {
@@ -21,16 +14,6 @@ pub fn discord_color(color: Option<u32>, fallback: Color) -> Color {
             Color::Rgb(r, g, b)
         }
         _ => fallback,
-    }
-}
-
-pub fn presence_color(status: PresenceStatus) -> Color {
-    match status {
-        PresenceStatus::Online => Color::Green,
-        PresenceStatus::Idle => Color::Rgb(180, 140, 0),
-        PresenceStatus::DoNotDisturb => Color::Red,
-        PresenceStatus::Offline => Color::DarkGray,
-        PresenceStatus::Unknown => Color::DarkGray,
     }
 }
 

--- a/src/tui/state/tests/mod.rs
+++ b/src/tui/state/tests/mod.rs
@@ -1930,6 +1930,7 @@ fn reply_preview_reserves_connector_row_without_extra_type_label() {
         message_kind: MessageKind::new(19),
         reference: None,
         reply: Some(ReplyInfo {
+            author_id: None,
             author: "casey".to_owned(),
             content: Some("looks good".to_owned()),
             sticker_names: Vec::new(),
@@ -2026,6 +2027,7 @@ fn thread_starter_message_reserves_system_card_rows() {
     let mut message = height_test_message("");
     message.message_kind = MessageKind::new(21);
     message.reply = Some(ReplyInfo {
+        author_id: None,
         author: "alice".to_owned(),
         content: Some("original topic".to_owned()),
         sticker_names: Vec::new(),
@@ -2396,6 +2398,7 @@ fn push_reply_message_with_attachments(
             message_id: Some(Id::new(42)),
         }),
         reply: Some(ReplyInfo {
+            author_id: None,
             author: "original".to_owned(),
             content: Some("original message".to_owned()),
             sticker_names: Vec::new(),
@@ -5416,7 +5419,7 @@ fn missing_message_author_profile_requests_include_visible_forum_preview_authors
 
     assert_eq!(
         state.missing_message_author_profile_requests(),
-        vec![(Id::new(99), guild_id)]
+        vec![(Id::new(99), Some(guild_id))]
     );
 
     state.push_event(AppEvent::UserProfileLoaded {

--- a/src/tui/state/user.rs
+++ b/src/tui/state/user.rs
@@ -289,7 +289,7 @@ impl DashboardState {
 
     pub fn missing_message_author_profile_requests(
         &self,
-    ) -> Vec<(Id<UserMarker>, Id<GuildMarker>)> {
+    ) -> Vec<(Id<UserMarker>, Option<Id<GuildMarker>>)> {
         let mut seen = HashSet::new();
         let mut requests = Vec::new();
 
@@ -327,20 +327,20 @@ impl DashboardState {
 
     fn push_missing_author_profile_request(
         &self,
-        requests: &mut Vec<(Id<UserMarker>, Id<GuildMarker>)>,
-        seen: &mut HashSet<(Id<UserMarker>, Id<GuildMarker>)>,
+        requests: &mut Vec<(Id<UserMarker>, Option<Id<GuildMarker>>)>,
+        seen: &mut HashSet<(Id<UserMarker>, Option<Id<GuildMarker>>)>,
         user_id: Id<UserMarker>,
         guild_id: Option<Id<GuildMarker>>,
     ) {
-        let Some(guild_id) = guild_id else {
-            return;
-        };
-        if self
-            .discord
-            .member_display_name(guild_id, user_id)
-            .is_some()
-            || self.discord.user_profile(user_id, Some(guild_id)).is_some()
-            || !seen.insert((user_id, guild_id))
+        if let Some(guild_id) = guild_id {
+            if self.discord.member_has_known_name(guild_id, user_id)
+                || self.discord.user_profile(user_id, Some(guild_id)).is_some()
+                || !seen.insert((user_id, Some(guild_id)))
+            {
+                return;
+            }
+        } else if self.discord.user_profile(user_id, None).is_some()
+            || !seen.insert((user_id, None))
         {
             return;
         }
@@ -350,6 +350,49 @@ impl DashboardState {
     pub fn member_role_color(&self, member: MemberEntry<'_>) -> Option<u32> {
         let guild_id = self.selected_guild_id()?;
         self.discord.member_role_color(guild_id, member.user_id())
+    }
+
+    /// Resolved display name for a member panel entry. Falls through to the
+    /// profile cache when the guild member entry only has fallback data.
+    pub fn member_display_name(&self, entry: MemberEntry<'_>) -> String {
+        let name = entry.display_name();
+        if entry.username().is_none() && name == "unknown" {
+            if let Some(guild_id) = self.selected_guild_id() {
+                if let Some(profile) = self.discord.user_profile(entry.user_id(), Some(guild_id)) {
+                    return profile.display_name().to_owned();
+                }
+            }
+        }
+        name
+    }
+
+    /// Profile requests for visible members in the member panel whose name is
+    /// still a fallback placeholder. Complements
+    /// `missing_message_author_profile_requests` which only covers messages.
+    pub fn missing_visible_member_profile_requests(
+        &self,
+    ) -> Vec<(Id<UserMarker>, Option<Id<GuildMarker>>)> {
+        let Some(guild_id) = self.selected_guild_id() else {
+            return Vec::new();
+        };
+        let members = self.flattened_members();
+        let start = self.member_scroll();
+        let end = (start + self.member_content_height()).min(members.len());
+        let mut seen = HashSet::new();
+        let mut requests = Vec::new();
+        for entry in &members[start..end] {
+            if entry.username().is_some() {
+                continue;
+            }
+            let user_id = entry.user_id();
+            if self.discord.user_profile(user_id, Some(guild_id)).is_some() {
+                continue;
+            }
+            if seen.insert((user_id, Some(guild_id))) {
+                requests.push((user_id, Some(guild_id)));
+            }
+        }
+        requests
     }
 
     pub fn member_panel_title(&self) -> Line<'static> {

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -147,16 +147,14 @@ mod tests {
 
     #[test]
     fn from_theme_uses_parsed_hex() {
-        let mut theme = Theme::default();
-        theme.accent = "#FF6600".to_owned();
+        let theme = Theme { accent: "#FF6600".to_owned(), ..Default::default() };
         let scheme = ColorScheme::from_theme(&theme);
         assert_eq!(scheme.accent, Color::Rgb(255, 102, 0));
     }
 
     #[test]
     fn from_theme_falls_back_on_invalid_hex() {
-        let mut theme = Theme::default();
-        theme.accent = "not-a-color".to_owned();
+        let theme = Theme { accent: "not-a-color".to_owned(), ..Default::default() };
         let scheme = ColorScheme::from_theme(&theme);
         assert_eq!(scheme.accent, ColorScheme::default().accent);
     }

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -147,14 +147,20 @@ mod tests {
 
     #[test]
     fn from_theme_uses_parsed_hex() {
-        let theme = Theme { accent: "#FF6600".to_owned(), ..Default::default() };
+        let theme = Theme {
+            accent: "#FF6600".to_owned(),
+            ..Default::default()
+        };
         let scheme = ColorScheme::from_theme(&theme);
         assert_eq!(scheme.accent, Color::Rgb(255, 102, 0));
     }
 
     #[test]
     fn from_theme_falls_back_on_invalid_hex() {
-        let theme = Theme { accent: "not-a-color".to_owned(), ..Default::default() };
+        let theme = Theme {
+            accent: "not-a-color".to_owned(),
+            ..Default::default()
+        };
         let scheme = ColorScheme::from_theme(&theme);
         assert_eq!(scheme.accent, ColorScheme::default().accent);
     }

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -1,0 +1,163 @@
+use ratatui::style::{Color, Style};
+
+use crate::config::Theme;
+use crate::discord::PresenceStatus;
+
+/// Resolved color scheme used throughout the TUI. All fields are concrete
+/// ratatui `Color` values derived from the `[theme]` section of `config.toml`
+/// (or from built-in defaults when the section is absent).
+#[derive(Clone, Debug)]
+pub(crate) struct ColorScheme {
+    pub background: Color,
+    pub accent: Color,
+    pub dim: Color,
+    pub scrollbar_thumb: Color,
+    pub selection_border: Color,
+    pub mention_badge: Color,
+    pub channel_read: Color,
+    pub channel_unread: Color,
+    pub self_reaction: Color,
+    pub self_mention_bg: Color,
+    pub self_mention_fg: Color,
+    pub other_mention_bg: Color,
+    pub other_mention_fg: Color,
+    pub presence_online: Color,
+    pub presence_idle: Color,
+    pub presence_dnd: Color,
+    pub presence_offline: Color,
+    pub folder_default: Color,
+}
+
+impl Default for ColorScheme {
+    fn default() -> Self {
+        Self {
+            background: Color::Reset,
+            accent: Color::Cyan,
+            dim: Color::DarkGray,
+            scrollbar_thumb: Color::Rgb(170, 170, 170),
+            selection_border: Color::Green,
+            mention_badge: Color::Rgb(255, 165, 0),
+            channel_read: Color::Rgb(130, 130, 130),
+            channel_unread: Color::Rgb(255, 255, 255),
+            self_reaction: Color::Yellow,
+            self_mention_bg: Color::Rgb(92, 76, 35),
+            self_mention_fg: Color::Yellow,
+            other_mention_bg: Color::Rgb(40, 50, 92),
+            other_mention_fg: Color::Rgb(193, 206, 247),
+            presence_online: Color::Green,
+            presence_idle: Color::Rgb(180, 140, 0),
+            presence_dnd: Color::Red,
+            presence_offline: Color::DarkGray,
+            folder_default: Color::Cyan,
+        }
+    }
+}
+
+impl ColorScheme {
+    pub fn from_theme(theme: &Theme) -> Self {
+        let d = Self::default();
+        Self {
+            background: parse_hex(&theme.background).unwrap_or(Color::Reset),
+            accent: parse_hex(&theme.accent).unwrap_or(d.accent),
+            dim: parse_hex(&theme.dim).unwrap_or(d.dim),
+            scrollbar_thumb: parse_hex(&theme.scrollbar_thumb).unwrap_or(d.scrollbar_thumb),
+            selection_border: parse_hex(&theme.selection_border).unwrap_or(d.selection_border),
+            mention_badge: parse_hex(&theme.mention_badge).unwrap_or(d.mention_badge),
+            channel_read: parse_hex(&theme.channel_read).unwrap_or(d.channel_read),
+            channel_unread: parse_hex(&theme.channel_unread).unwrap_or(d.channel_unread),
+            self_reaction: parse_hex(&theme.self_reaction).unwrap_or(d.self_reaction),
+            self_mention_bg: parse_hex(&theme.self_mention_bg).unwrap_or(d.self_mention_bg),
+            self_mention_fg: parse_hex(&theme.self_mention_fg).unwrap_or(d.self_mention_fg),
+            other_mention_bg: parse_hex(&theme.other_mention_bg).unwrap_or(d.other_mention_bg),
+            other_mention_fg: parse_hex(&theme.other_mention_fg).unwrap_or(d.other_mention_fg),
+            presence_online: parse_hex(&theme.presence_online).unwrap_or(d.presence_online),
+            presence_idle: parse_hex(&theme.presence_idle).unwrap_or(d.presence_idle),
+            presence_dnd: parse_hex(&theme.presence_dnd).unwrap_or(d.presence_dnd),
+            presence_offline: parse_hex(&theme.presence_offline).unwrap_or(d.presence_offline),
+            folder_default: parse_hex(&theme.folder_default).unwrap_or(d.folder_default),
+        }
+    }
+
+    pub fn presence_color(&self, status: PresenceStatus) -> Color {
+        match status {
+            PresenceStatus::Online => self.presence_online,
+            PresenceStatus::Idle => self.presence_idle,
+            PresenceStatus::DoNotDisturb => self.presence_dnd,
+            PresenceStatus::Offline | PresenceStatus::Unknown => self.presence_offline,
+        }
+    }
+
+    pub fn folder_color(&self, color: Option<u32>) -> Color {
+        match color {
+            Some(value) if value != 0 => {
+                let r = ((value >> 16) & 0xFF) as u8;
+                let g = ((value >> 8) & 0xFF) as u8;
+                let b = (value & 0xFF) as u8;
+                Color::Rgb(r, g, b)
+            }
+            _ => self.folder_default,
+        }
+    }
+
+    pub fn self_mention_style(&self) -> Style {
+        Style::default()
+            .bg(self.self_mention_bg)
+            .fg(self.self_mention_fg)
+    }
+
+    pub fn other_mention_style(&self) -> Style {
+        Style::default()
+            .bg(self.other_mention_bg)
+            .fg(self.other_mention_fg)
+    }
+}
+
+fn parse_hex(hex: &str) -> Option<Color> {
+    let hex = hex.trim().trim_start_matches('#');
+    if hex.len() == 6 {
+        let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
+        let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
+        let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
+        Some(Color::Rgb(r, g, b))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_hex_valid_with_hash() {
+        assert_eq!(parse_hex("#00FFFF"), Some(Color::Rgb(0, 255, 255)));
+    }
+
+    #[test]
+    fn parse_hex_valid_without_hash() {
+        assert_eq!(parse_hex("FF6600"), Some(Color::Rgb(255, 102, 0)));
+    }
+
+    #[test]
+    fn parse_hex_invalid_returns_none() {
+        assert_eq!(parse_hex("ZZZZZZ"), None);
+        assert_eq!(parse_hex("#FFF"), None);
+        assert_eq!(parse_hex(""), None);
+    }
+
+    #[test]
+    fn from_theme_uses_parsed_hex() {
+        let mut theme = Theme::default();
+        theme.accent = "#FF6600".to_owned();
+        let scheme = ColorScheme::from_theme(&theme);
+        assert_eq!(scheme.accent, Color::Rgb(255, 102, 0));
+    }
+
+    #[test]
+    fn from_theme_falls_back_on_invalid_hex() {
+        let mut theme = Theme::default();
+        theme.accent = "not-a-color".to_owned();
+        let scheme = ColorScheme::from_theme(&theme);
+        assert_eq!(scheme.accent, ColorScheme::default().accent);
+    }
+}

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -5,7 +5,7 @@ use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{
-        Block, BorderType, Borders, Clear, ListItem, Paragraph, Scrollbar, ScrollbarOrientation,
+        Block, BorderType, Borders, ListItem, Paragraph, Scrollbar, ScrollbarOrientation,
         ScrollbarState, Wrap,
     },
 };
@@ -26,8 +26,7 @@ use super::{
         ChannelSwitcherItem, ChannelThreadItem, DashboardState, DisplayOptionItem,
         EmojiReactionItem, FORUM_POST_CARD_HEIGHT, FocusPane, ImageViewerItem, MessageActionItem,
         PollVotePickerItem, channel_action_shortcut, discord_color, guild_action_shortcut,
-        indexed_shortcut, member_action_shortcut, message_action_shortcut, presence_color,
-        presence_marker,
+        indexed_shortcut, member_action_shortcut, message_action_shortcut, presence_marker,
     },
 };
 use crate::discord::{
@@ -36,14 +35,17 @@ use crate::discord::{
 };
 
 /// Discord's "you were mentioned" orange, `#FFA500`.
+#[cfg(test)]
 const MENTION_ORANGE: Color = Color::Rgb(255, 165, 0);
 
 /// Explicit RGB instead of `Modifier::DIM` so CJK wide characters dim
 /// uniformly with ASCII (most terminals ignore SGR dim on wide glyphs).
+#[cfg(test)]
 const READ_DIM: Color = Color::Rgb(130, 130, 130);
 
 /// Explicit RGB instead of relying on `Modifier::BOLD` alone, which most
 /// monospace fonts can't apply to CJK glyphs.
+#[cfg(test)]
 const UNREAD_BRIGHT: Color = Color::Rgb(255, 255, 255);
 
 mod activity;
@@ -79,10 +81,11 @@ use self::popups::{
     render_user_profile_popup, user_profile_popup_has_avatar, user_profile_popup_text_geometry,
     user_profile_popup_total_lines,
 };
+#[cfg(test)]
+use self::types::DIM;
 use self::types::{
-    ACCENT, DIM, EMBED_PREVIEW_GUTTER_PREFIX, MESSAGE_AVATAR_OFFSET, MESSAGE_AVATAR_PLACEHOLDER,
-    MESSAGE_SELECTION_PREFIX_WIDTH, MessageViewportLayout, SCROLLBAR_THUMB,
-    SELECTED_FORUM_POST_BORDER, SELECTED_MESSAGE_BORDER, UserProfilePopupText,
+    ACCENT, EMBED_PREVIEW_GUTTER_PREFIX, MESSAGE_AVATAR_OFFSET, MESSAGE_AVATAR_PLACEHOLDER,
+    MESSAGE_SELECTION_PREFIX_WIDTH, MessageViewportLayout, RenderCtx, UserProfilePopupText,
 };
 pub(crate) use self::types::{ActionMenuTarget, MouseTarget};
 pub use self::types::{
@@ -177,6 +180,11 @@ pub fn render(
     emoji_images: Vec<EmojiImage<'_>>,
     profile_avatar: Option<AvatarImage>,
 ) {
+    let ctx = RenderCtx::new(state.theme());
+    frame.render_widget(
+        Block::default().style(Style::default().bg(ctx.theme.background)),
+        frame.area(),
+    );
     let areas = dashboard_areas(frame.area(), state);
     let mut inline_image_previews = Vec::new();
     let mut viewer_image_preview = None;
@@ -237,11 +245,11 @@ fn styled_list_item<'a>(item: ListItem<'a>, selected: bool) -> ListItem<'a> {
     }
 }
 
-fn selection_marker(selected: bool) -> Span<'static> {
+fn selection_marker(selected: bool, accent: Color) -> Span<'static> {
     if selected {
         Span::styled(
             "▸ ",
-            Style::default().fg(ACCENT).add_modifier(Modifier::BOLD),
+            Style::default().fg(accent).add_modifier(Modifier::BOLD),
         )
     } else {
         Span::raw("  ")
@@ -257,7 +265,7 @@ fn active_text_style(active: bool, style: Style) -> Style {
 }
 
 fn panel_content_height(area: Rect, title: &'static str) -> usize {
-    panel_block(title, false).inner(area).height.max(1) as usize
+    panel_block(title, false, ACCENT).inner(area).height.max(1) as usize
 }
 
 fn visible_panel_content_height(area: Rect, title: &'static str, visible: bool) -> usize {
@@ -274,6 +282,7 @@ fn render_vertical_scrollbar(
     position: usize,
     viewport_len: usize,
     content_len: usize,
+    ctx: &RenderCtx<'_>,
 ) {
     if !vertical_scrollbar_visible(area, viewport_len, content_len) {
         return;
@@ -290,8 +299,8 @@ fn render_vertical_scrollbar(
         .end_symbol(None)
         .track_symbol(Some("│"))
         .thumb_symbol("┃")
-        .thumb_style(Style::default().fg(SCROLLBAR_THUMB))
-        .track_style(Style::default().fg(DIM));
+        .thumb_style(Style::default().fg(ctx.theme.scrollbar_thumb))
+        .track_style(Style::default().fg(ctx.theme.dim));
 
     frame.render_stateful_widget(scrollbar, area, &mut state);
 }
@@ -318,11 +327,11 @@ fn channel_prefix(kind: &str) -> &'static str {
     }
 }
 
-fn dm_presence_dot_span(channel: &ChannelState) -> Option<Span<'static>> {
+fn dm_presence_dot_span(channel: &ChannelState, ctx: &RenderCtx<'_>) -> Option<Span<'static>> {
     let status = one_to_one_dm_recipient_status(channel)?;
     Some(Span::styled(
         format!("{} ", presence_marker(status)),
-        Style::default().fg(presence_color(status)),
+        Style::default().fg(ctx.theme.presence_color(status)),
     ))
 }
 
@@ -332,21 +341,30 @@ fn channel_unread_decoration(
     unread: ChannelUnreadState,
     base: Style,
     active: bool,
+    ctx: &RenderCtx<'_>,
 ) -> (Option<Span<'static>>, Style) {
     if active {
         return (None, base);
     }
     match unread {
         ChannelUnreadState::Mentioned(count) => {
-            let style = base.fg(MENTION_ORANGE).add_modifier(Modifier::BOLD);
+            let style = base
+                .fg(ctx.theme.mention_badge)
+                .add_modifier(Modifier::BOLD);
             (Some(Span::styled(format!("({count}) "), style)), style)
         }
         ChannelUnreadState::Notified(count) => {
-            let style = base.fg(UNREAD_BRIGHT).add_modifier(Modifier::BOLD);
+            let style = base
+                .fg(ctx.theme.channel_unread)
+                .add_modifier(Modifier::BOLD);
             (Some(Span::styled(format!("({count}) "), style)), style)
         }
-        ChannelUnreadState::Unread => (None, base.fg(UNREAD_BRIGHT).add_modifier(Modifier::BOLD)),
-        ChannelUnreadState::Seen => (None, base.fg(READ_DIM)),
+        ChannelUnreadState::Unread => (
+            None,
+            base.fg(ctx.theme.channel_unread)
+                .add_modifier(Modifier::BOLD),
+        ),
+        ChannelUnreadState::Seen => (None, base.fg(ctx.theme.channel_read)),
     }
 }
 
@@ -358,6 +376,23 @@ fn one_to_one_dm_recipient_status(channel: &ChannelState) -> Option<PresenceStat
     channel.recipients.first().map(|recipient| recipient.status)
 }
 
+pub(super) struct BgClear(Color);
+
+impl ratatui::widgets::Widget for BgClear {
+    fn render(self, area: Rect, buf: &mut ratatui::buffer::Buffer) {
+        for x in area.left()..area.right() {
+            for y in area.top()..area.bottom() {
+                buf[(x, y)].reset();
+                buf[(x, y)].set_bg(self.0);
+            }
+        }
+    }
+}
+
+pub(super) fn bg_clear(bg: Color) -> BgClear {
+    BgClear(bg)
+}
+
 fn highlight_style() -> Style {
     Style::default()
         .bg(Color::Rgb(24, 54, 65))
@@ -365,12 +400,12 @@ fn highlight_style() -> Style {
         .add_modifier(Modifier::BOLD)
 }
 
-fn panel_block(title: &'static str, focused: bool) -> Block<'static> {
-    panel_block_owned(title.to_owned(), focused)
+fn panel_block(title: &'static str, focused: bool, accent: Color) -> Block<'static> {
+    panel_block_owned(title.to_owned(), focused, accent)
 }
 
-fn panel_block_owned(title: String, focused: bool) -> Block<'static> {
-    let border = if focused { ACCENT } else { Color::DarkGray };
+fn panel_block_owned(title: String, focused: bool, accent: Color) -> Block<'static> {
+    let border = if focused { accent } else { Color::DarkGray };
 
     Block::default()
         .title(format!(" {title} "))
@@ -380,8 +415,12 @@ fn panel_block_owned(title: String, focused: bool) -> Block<'static> {
         .title_style(Style::default().fg(Color::White).bold())
 }
 
-pub(super) fn panel_block_line(title: Line<'static>, focused: bool) -> Block<'static> {
-    let border = if focused { ACCENT } else { Color::DarkGray };
+pub(super) fn panel_block_line(
+    title: Line<'static>,
+    focused: bool,
+    accent: Color,
+) -> Block<'static> {
+    let border = if focused { accent } else { Color::DarkGray };
 
     Block::default()
         .title(title)

--- a/src/tui/ui/forum.rs
+++ b/src/tui/ui/forum.rs
@@ -8,15 +8,29 @@ pub(super) fn forum_post_viewport_lines(
     width: usize,
     is_loading: bool,
 ) -> Vec<Line<'static>> {
-    forum_post_viewport_lines_with_custom_emoji_images(posts, selected, width, is_loading, true)
+    let scheme = crate::tui::theme::ColorScheme::default();
+    forum_post_viewport_lines_with_custom_emoji_images(
+        posts,
+        selected,
+        width,
+        is_loading,
+        true,
+        scheme.accent,
+        scheme.dim,
+        scheme.selection_border,
+    )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn forum_post_viewport_lines_with_custom_emoji_images(
     posts: &[ChannelThreadItem],
     selected: Option<usize>,
     width: usize,
     is_loading: bool,
     show_custom_emoji: bool,
+    accent: Color,
+    dim: Color,
+    selection_border: Color,
 ) -> Vec<Line<'static>> {
     let width = width.max(1);
     if posts.is_empty() {
@@ -25,7 +39,7 @@ pub(super) fn forum_post_viewport_lines_with_custom_emoji_images(
         } else {
             "No forum posts."
         };
-        return vec![Line::from(Span::styled(message, Style::default().fg(DIM)))];
+        return vec![Line::from(Span::styled(message, Style::default().fg(dim)))];
     }
 
     let mut lines = Vec::new();
@@ -38,6 +52,9 @@ pub(super) fn forum_post_viewport_lines_with_custom_emoji_images(
             selected == Some(index),
             width,
             show_custom_emoji,
+            accent,
+            dim,
+            selection_border,
         ));
     }
     lines
@@ -52,15 +69,21 @@ fn forum_post_card_lines(
     selected: bool,
     width: usize,
     show_custom_emoji: bool,
+    accent: Color,
+    dim: Color,
+    selection_border: Color,
 ) -> [Line<'static>; FORUM_POST_CARD_HEIGHT] {
     let marker = if selected { "› " } else { "  " };
     let card_width = width.saturating_sub(marker.width()).max(4);
     let inner_width = card_width.saturating_sub(4).max(1);
-    let border_style = forum_post_border_style(selected);
+    let border_style = forum_post_border_style(selected, accent, selection_border);
 
     [
         Line::from(vec![
-            Span::styled(marker, forum_post_marker_style(selected)),
+            Span::styled(
+                marker,
+                forum_post_marker_style(selected, accent, selection_border),
+            ),
             Span::styled(
                 format!("╭{}╮", "─".repeat(card_width.saturating_sub(2))),
                 border_style,
@@ -71,18 +94,24 @@ fn forum_post_card_lines(
             forum_post_title_spans(post, inner_width),
             inner_width,
             selected,
+            accent,
+            selection_border,
         ),
         forum_post_inner_line(
             "  ",
-            forum_post_preview_spans(post, inner_width),
+            forum_post_preview_spans(post, inner_width, dim),
             inner_width,
             selected,
+            accent,
+            selection_border,
         ),
         forum_post_inner_line(
             "  ",
-            forum_post_metadata_spans(post, inner_width, show_custom_emoji),
+            forum_post_metadata_spans(post, inner_width, show_custom_emoji, accent, dim),
             inner_width,
             selected,
+            accent,
+            selection_border,
         ),
         Line::from(vec![
             Span::raw("  "),
@@ -126,18 +155,22 @@ fn forum_post_title_spans(post: &ChannelThreadItem, inner_width: usize) -> Vec<S
     ]
 }
 
-fn forum_post_preview_spans(post: &ChannelThreadItem, inner_width: usize) -> Vec<Span<'static>> {
+fn forum_post_preview_spans(
+    post: &ChannelThreadItem,
+    inner_width: usize,
+    dim: Color,
+) -> Vec<Span<'static>> {
     let preview_style = Style::default().fg(Color::White);
     let Some(author) = post.preview_author.as_deref() else {
         return vec![Span::styled(
             "Preview unavailable",
-            Style::default().fg(DIM),
+            Style::default().fg(dim),
         )];
     };
     let Some(content) = post.preview_content.as_deref() else {
         return vec![Span::styled(
             "Preview unavailable",
-            Style::default().fg(DIM),
+            Style::default().fg(dim),
         )];
     };
 
@@ -161,10 +194,12 @@ fn forum_post_metadata_spans(
     post: &ChannelThreadItem,
     width: usize,
     show_custom_emoji: bool,
+    accent: Color,
+    dim: Color,
 ) -> Vec<Span<'static>> {
     let primary_style = Style::default().fg(Color::White);
-    let reaction_style = Style::default().fg(ACCENT);
-    let muted_style = Style::default().fg(DIM);
+    let reaction_style = Style::default().fg(accent);
+    let muted_style = Style::default().fg(dim);
     let mut spans = Vec::new();
     let mut used_width = 0usize;
 
@@ -176,6 +211,7 @@ fn forum_post_metadata_spans(
             width,
             format!("{count} {label}"),
             primary_style,
+            dim,
         );
     }
     if let Some(layout) =
@@ -187,6 +223,7 @@ fn forum_post_metadata_spans(
             width,
             reaction_style,
             layout,
+            dim,
         );
     }
     if let Some(message_id) = post.last_activity_message_id {
@@ -196,6 +233,7 @@ fn forum_post_metadata_spans(
             width,
             format_message_relative_age(message_id),
             primary_style,
+            dim,
         );
     }
     if post.archived {
@@ -205,6 +243,7 @@ fn forum_post_metadata_spans(
             width,
             "archived".to_owned(),
             muted_style,
+            dim,
         );
     }
     if post.locked {
@@ -214,6 +253,7 @@ fn forum_post_metadata_spans(
             width,
             "locked".to_owned(),
             muted_style,
+            dim,
         );
     }
 
@@ -230,6 +270,7 @@ fn push_forum_metadata_part(
     max_width: usize,
     text: String,
     style: Style,
+    dim: Color,
 ) {
     if *used_width >= max_width {
         return;
@@ -242,7 +283,7 @@ fn push_forum_metadata_part(
         }
         let separator = truncate_display_width(separator, remaining);
         *used_width = used_width.saturating_add(separator.width());
-        spans.push(Span::styled(separator, Style::default().fg(DIM)));
+        spans.push(Span::styled(separator, Style::default().fg(dim)));
     }
 
     let remaining = max_width.saturating_sub(*used_width);
@@ -260,6 +301,7 @@ fn push_forum_metadata_reaction_part(
     max_width: usize,
     style: Style,
     layout: ReactionLayout,
+    dim: Color,
 ) {
     let Some(line) = layout.lines.first() else {
         return;
@@ -276,7 +318,7 @@ fn push_forum_metadata_reaction_part(
         }
         let separator = truncate_display_width(separator, remaining);
         *used_width = used_width.saturating_add(separator.width());
-        spans.push(Span::styled(separator, Style::default().fg(DIM)));
+        spans.push(Span::styled(separator, Style::default().fg(dim)));
     }
 
     let remaining = max_width.saturating_sub(*used_width);
@@ -417,13 +459,15 @@ fn forum_post_inner_line(
     mut content: Vec<Span<'static>>,
     inner_width: usize,
     selected: bool,
+    accent: Color,
+    selection_border: Color,
 ) -> Line<'static> {
     let content_width = content
         .iter()
         .map(|span| span.content.width())
         .sum::<usize>();
     let padding = inner_width.saturating_sub(content_width);
-    let border_style = forum_post_border_style(selected);
+    let border_style = forum_post_border_style(selected, accent, selection_border);
     let fill_style = Style::default();
     let mut spans = vec![
         Span::raw(marker.to_owned()),
@@ -435,22 +479,22 @@ fn forum_post_inner_line(
     Line::from(spans)
 }
 
-fn forum_post_border_style(selected: bool) -> Style {
+fn forum_post_border_style(selected: bool, accent: Color, selection_border: Color) -> Style {
     if selected {
         Style::default()
-            .fg(SELECTED_FORUM_POST_BORDER)
+            .fg(selection_border)
             .add_modifier(Modifier::BOLD)
     } else {
-        Style::default().fg(ACCENT)
+        Style::default().fg(accent)
     }
 }
 
-fn forum_post_marker_style(selected: bool) -> Style {
+fn forum_post_marker_style(selected: bool, accent: Color, selection_border: Color) -> Style {
     if selected {
         Style::default()
-            .fg(SELECTED_FORUM_POST_BORDER)
+            .fg(selection_border)
             .add_modifier(Modifier::BOLD)
     } else {
-        Style::default().fg(ACCENT)
+        Style::default().fg(accent)
     }
 }

--- a/src/tui/ui/interaction.rs
+++ b/src/tui/ui/interaction.rs
@@ -7,7 +7,7 @@ use super::{
     popups::{
         channel_switcher_item_index_at, channel_switcher_popup_area, user_profile_popup_area,
     },
-    types::{ActionMenuTarget, MouseTarget},
+    types::{ACCENT, ActionMenuTarget, MouseTarget},
 };
 
 pub(crate) fn focus_pane_at(
@@ -134,7 +134,7 @@ fn action_menu_row_target(
     if !rect_contains(popup, column, row) {
         return Some(MouseTarget::ModalBackdrop);
     }
-    let inner = panel_block("", false).inner(popup);
+    let inner = panel_block("", false, ACCENT).inner(popup);
     if rect_contains(inner, column, row) {
         let row = row.saturating_sub(inner.y) as usize;
         if row < item_count {
@@ -159,7 +159,7 @@ fn pane_row_mouse_target(
     if !rect_contains(area, column, row) {
         return None;
     }
-    let inner = panel_block("", false).inner(area);
+    let inner = panel_block("", false, ACCENT).inner(area);
     // When the filter bar occupies the last row of the inner area, shrink the
     // list hit region so clicks on that row don't resolve to a list entry.
     let list_height = if filter_active && inner.height >= 2 {
@@ -189,7 +189,7 @@ fn message_mouse_target(
     if !rect_contains(area, column, row) {
         return None;
     }
-    let inner = panel_block_owned(String::new(), false).inner(area);
+    let inner = panel_block_owned(String::new(), false, ACCENT).inner(area);
     let message_areas = message_areas(inner, state);
     if rect_contains(message_areas.composer, column, row) {
         return Some(MouseTarget::Composer);

--- a/src/tui/ui/message_list.rs
+++ b/src/tui/ui/message_list.rs
@@ -23,6 +23,7 @@ struct MessageItemLinesInput<'a> {
     preview_spacers: &'a [InlinePreviewSpacer],
     bottom_gap: bool,
     line_offset: usize,
+    dim: Color,
 }
 
 pub(super) fn render_messages(
@@ -33,9 +34,11 @@ pub(super) fn render_messages(
     avatar_images: Vec<AvatarImage>,
     emoji_images: &[EmojiImage<'_>],
 ) {
+    let ctx = RenderCtx::new(state.theme());
     let block = panel_block_owned(
         state.message_pane_title(),
         state.focus() == FocusPane::Messages,
+        ctx.theme.accent,
     );
     let inner = block.inner(area);
     frame.render_widget(block, area);
@@ -63,6 +66,9 @@ pub(super) fn render_messages(
                 forum_card_width,
                 is_loading,
                 state.show_custom_emoji(),
+                ctx.theme.accent,
+                ctx.theme.dim,
+                ctx.theme.selection_border,
             )),
             message_areas.list,
         );
@@ -81,6 +87,7 @@ pub(super) fn render_messages(
             state.message_scroll_row_position(content_width, 0, 0),
             forum_viewport_len,
             forum_total_rows,
+            &ctx,
         );
         render_typing_footer(frame, message_areas.typing, state);
         render_composer(frame, message_areas.composer, state, emoji_images);
@@ -190,7 +197,7 @@ pub(super) fn render_messages(
             image_preview.preview_height,
             image_preview.accent_color,
         ) {
-            render_image_preview(frame, preview_area, image_preview.state);
+            render_image_preview(frame, preview_area, image_preview.state, ctx.theme.dim);
             render_image_preview_overflow_marker(
                 frame,
                 preview_area,
@@ -204,6 +211,7 @@ pub(super) fn render_messages(
         state.message_scroll_row_position(content_width, preview_width, max_preview_height),
         message_areas.list.height as usize,
         message_total_rows,
+        &ctx,
     );
     render_new_messages_notice(frame, message_areas.list, state);
     render_typing_footer(frame, message_areas.typing, state);
@@ -232,9 +240,13 @@ fn render_new_messages_notice(frame: &mut Frame, list: Rect, state: &DashboardSt
         height: 1,
     };
 
-    frame.render_widget(Clear, area);
+    frame.render_widget(bg_clear(state.theme().background), area);
     frame.render_widget(
-        Paragraph::new(new_messages_notice_line(count, area.width as usize)),
+        Paragraph::new(new_messages_notice_line(
+            count,
+            area.width as usize,
+            state.theme().accent,
+        )),
         area,
     );
 }
@@ -250,7 +262,10 @@ fn render_typing_footer(frame: &mut Frame, area: Rect, state: &DashboardState) {
         return;
     };
     frame.render_widget(
-        Paragraph::new(Line::from(Span::styled(text, Style::default().fg(DIM)))),
+        Paragraph::new(Line::from(Span::styled(
+            text,
+            Style::default().fg(state.theme().dim),
+        ))),
         area,
     );
 }
@@ -580,11 +595,12 @@ pub(super) fn render_image_preview(
     frame: &mut Frame,
     area: Rect,
     image_preview: ImagePreviewState<'_>,
+    dim: Color,
 ) {
     match image_preview {
         ImagePreviewState::Loading { filename } => frame.render_widget(
             Paragraph::new(format!("loading {filename}..."))
-                .style(Style::default().fg(DIM))
+                .style(Style::default().fg(dim))
                 .wrap(Wrap { trim: false }),
             area,
         ),
@@ -658,7 +674,11 @@ pub(super) fn message_viewport_lines(
         };
         let mut top_lines = Vec::new();
         if has_state_message && state.message_starts_new_day_at(global_index) {
-            top_lines.push(date_separator_line(message.id, layout.list_width));
+            top_lines.push(date_separator_line(
+                message.id,
+                layout.list_width,
+                state.theme().dim,
+            ));
         }
         if has_state_message && state.should_draw_unread_divider_at(global_index) {
             top_lines.push(unread_divider_line(layout.list_width));
@@ -698,6 +718,7 @@ pub(super) fn message_viewport_lines(
             preview_spacers: &preview_spacers,
             bottom_gap,
             line_offset: item_line_offset,
+            dim: state.theme().dim,
         });
         if selected == Some(index) {
             lines.extend(selected_message_lines(
@@ -707,6 +728,8 @@ pub(super) fn message_viewport_lines(
                 body_skip == 0,
                 bottom_gap,
                 show_header,
+                state.theme().dim,
+                state.theme().selection_border,
             ));
         } else {
             lines.extend(item_lines);
@@ -752,6 +775,7 @@ pub(super) fn message_item_lines(
         })
         .into_iter()
         .collect::<Vec<_>>();
+    let scheme = crate::tui::theme::ColorScheme::default();
     message_item_lines_with_previews(MessageItemLinesInput {
         author,
         author_style,
@@ -763,6 +787,7 @@ pub(super) fn message_item_lines(
         preview_spacers: &preview_spacers,
         bottom_gap: true,
         line_offset,
+        dim: scheme.dim,
     })
 }
 
@@ -778,6 +803,7 @@ fn message_item_lines_with_previews(input: MessageItemLinesInput<'_>) -> Vec<Lin
         preview_spacers,
         bottom_gap,
         line_offset,
+        dim,
     } = input;
     let sent_time_width = sent_time.as_str().width();
     let author_width = content_width
@@ -787,17 +813,17 @@ fn message_item_lines_with_previews(input: MessageItemLinesInput<'_>) -> Vec<Lin
     let author = truncate_display_width(&author, author_width);
     let mut lines = if show_header {
         vec![Line::from(vec![
-            message_avatar_span(),
+            message_avatar_span(dim),
             Span::styled(author, author_style),
             Span::raw(" "),
-            Span::styled(sent_time, Style::default().fg(DIM)),
+            Span::styled(sent_time, Style::default().fg(dim)),
         ])]
     } else {
         Vec::new()
     };
     lines.extend(content.into_iter().enumerate().map(|(index, line)| {
         let mut spans = vec![if show_header && index == 0 {
-            message_avatar_span()
+            message_avatar_span(dim)
         } else {
             message_avatar_spacer_span()
         }];
@@ -849,7 +875,7 @@ pub(super) fn message_avatar_area(
     })
 }
 
-fn message_avatar_span() -> Span<'static> {
+fn message_avatar_span(dim: Color) -> Span<'static> {
     let prefix = " ".repeat(MESSAGE_SELECTION_PREFIX_WIDTH as usize);
     let padding = (MESSAGE_AVATAR_OFFSET as usize)
         .saturating_sub(MESSAGE_SELECTION_PREFIX_WIDTH as usize)
@@ -859,7 +885,7 @@ fn message_avatar_span() -> Span<'static> {
             "{prefix}{MESSAGE_AVATAR_PLACEHOLDER}{}",
             " ".repeat(padding)
         ),
-        Style::default().fg(DIM),
+        Style::default().fg(dim),
     )
 }
 
@@ -867,6 +893,7 @@ fn message_avatar_spacer_span() -> Span<'static> {
     Span::raw(" ".repeat(MESSAGE_AVATAR_OFFSET as usize))
 }
 
+#[allow(clippy::too_many_arguments)]
 fn selected_message_lines(
     lines: Vec<Line<'static>>,
     sent_time: &str,
@@ -874,16 +901,21 @@ fn selected_message_lines(
     top_visible: bool,
     has_bottom_gap: bool,
     has_header: bool,
+    dim: Color,
+    selection_border: Color,
 ) -> Vec<Line<'static>> {
     let last_index = lines.len().saturating_sub(1);
     let mut stamped = false;
     let mut selected_lines = Vec::new();
     if top_visible && !has_header {
-        selected_lines.push(selected_message_empty_top_line(card_width));
+        selected_lines.push(selected_message_empty_top_line(
+            card_width,
+            selection_border,
+        ));
     }
     selected_lines.extend(lines.into_iter().enumerate().map(|(index, line)| {
         if has_bottom_gap && index == last_index {
-            selected_message_bottom_line(card_width)
+            selected_message_bottom_line(card_width, selection_border)
         } else {
             let show_time = !stamped && !has_header && line_has_gutter(&line);
             if show_time {
@@ -894,11 +926,13 @@ fn selected_message_lines(
                 card_width,
                 index == 0 && top_visible && has_header,
                 show_time.then_some(sent_time),
+                dim,
+                selection_border,
             )
         }
     }));
     if !has_bottom_gap {
-        selected_lines.push(selected_message_bottom_line(card_width));
+        selected_lines.push(selected_message_bottom_line(card_width, selection_border));
     }
     selected_lines
 }
@@ -909,14 +943,14 @@ fn line_has_gutter(line: &Line<'_>) -> bool {
         .is_some_and(|span| span.content.width() == MESSAGE_AVATAR_OFFSET as usize)
 }
 
-fn selected_time_gutter_span(sent_time: &str) -> Span<'static> {
+fn selected_time_gutter_span(sent_time: &str, dim: Color) -> Span<'static> {
     let gutter_width =
         (MESSAGE_AVATAR_OFFSET as usize).saturating_sub(MESSAGE_SELECTION_PREFIX_WIDTH as usize);
     let time = truncate_display_width(sent_time, gutter_width);
     let padding = gutter_width.saturating_sub(time.width());
     Span::styled(
         format!("{time}{}", " ".repeat(padding)),
-        Style::default().fg(DIM),
+        Style::default().fg(dim),
     )
 }
 
@@ -925,9 +959,17 @@ fn selected_message_content_line(
     card_width: usize,
     top_line: bool,
     sent_time: Option<&str>,
+    dim: Color,
+    selection_border: Color,
 ) -> Line<'static> {
     let mut spans = line.spans;
-    replace_selection_prefix(&mut spans, if top_line { "╭─" } else { "│ " }, sent_time);
+    replace_selection_prefix(
+        &mut spans,
+        if top_line { "╭─" } else { "│ " },
+        sent_time,
+        dim,
+        selection_border,
+    );
     let used_width = spans.iter().map(|span| span.content.width()).sum::<usize>();
     let right_border = if top_line { "╮" } else { " │" };
     let fill_char = if top_line { '─' } else { ' ' };
@@ -937,26 +979,26 @@ fn selected_message_content_line(
         .saturating_sub(right_border_width);
     spans.push(Span::styled(
         fill_char.to_string().repeat(padding),
-        selected_message_border_style(),
+        selected_message_border_style(selection_border),
     ));
     spans.push(Span::styled(
         right_border.to_owned(),
-        selected_message_border_style(),
+        selected_message_border_style(selection_border),
     ));
     Line::from(spans)
 }
 
-fn selected_message_empty_top_line(card_width: usize) -> Line<'static> {
+fn selected_message_empty_top_line(card_width: usize, selection_border: Color) -> Line<'static> {
     Line::from(Span::styled(
         format!("╭{}╮", "─".repeat(card_width.saturating_sub(2))),
-        selected_message_border_style(),
+        selected_message_border_style(selection_border),
     ))
 }
 
-fn selected_message_bottom_line(card_width: usize) -> Line<'static> {
+fn selected_message_bottom_line(card_width: usize, selection_border: Color) -> Line<'static> {
     Line::from(Span::styled(
         format!("╰{}╯", "─".repeat(card_width.saturating_sub(2))),
-        selected_message_border_style(),
+        selected_message_border_style(selection_border),
     ))
 }
 
@@ -964,6 +1006,8 @@ fn replace_selection_prefix(
     spans: &mut Vec<Span<'static>>,
     replacement: &str,
     sent_time: Option<&str>,
+    dim: Color,
+    selection_border: Color,
 ) {
     if spans.first().is_some_and(|span| {
         span.content.width() >= MESSAGE_SELECTION_PREFIX_WIDTH as usize
@@ -975,7 +1019,7 @@ fn replace_selection_prefix(
     }) {
         let original = spans.remove(0);
         let remaining = if let Some(time) = sent_time {
-            selected_time_gutter_span(time)
+            selected_time_gutter_span(time, dim)
         } else {
             Span::styled(
                 original
@@ -990,13 +1034,16 @@ fn replace_selection_prefix(
     }
     spans.insert(
         0,
-        Span::styled(replacement.to_owned(), selected_message_border_style()),
+        Span::styled(
+            replacement.to_owned(),
+            selected_message_border_style(selection_border),
+        ),
     );
 }
 
-fn selected_message_border_style() -> Style {
+fn selected_message_border_style(selection_border: Color) -> Style {
     Style::default()
-        .fg(SELECTED_MESSAGE_BORDER)
+        .fg(selection_border)
         .add_modifier(Modifier::BOLD)
 }
 
@@ -1057,10 +1104,14 @@ pub(super) fn format_message_sent_time(message_id: Id<MessageMarker>) -> String 
     format_message_local_time(message_id)
 }
 
-pub(super) fn date_separator_line(message_id: Id<MessageMarker>, width: usize) -> Line<'static> {
+pub(super) fn date_separator_line(
+    message_id: Id<MessageMarker>,
+    width: usize,
+    dim: Color,
+) -> Line<'static> {
     let date = message_local_date(message_id);
     let label = format!(" {} ", date.format("%Y-%m-%d"));
-    separator_line(&label, width, Style::default().fg(DIM))
+    separator_line(&label, width, Style::default().fg(dim))
 }
 
 pub(super) fn unread_divider_line(width: usize) -> Line<'static> {
@@ -1084,7 +1135,7 @@ pub(super) fn unread_divider_line(width: usize) -> Line<'static> {
     ])
 }
 
-pub(super) fn new_messages_notice_line(count: usize, width: usize) -> Line<'static> {
+pub(super) fn new_messages_notice_line(count: usize, width: usize, accent: Color) -> Line<'static> {
     let label = new_messages_notice_label(count);
     let text = if label.as_str().width() > width {
         truncate_display_width(&label, width)
@@ -1094,7 +1145,7 @@ pub(super) fn new_messages_notice_line(count: usize, width: usize) -> Line<'stat
         let right = padding.saturating_sub(left);
         format!("{}{}{}", " ".repeat(left), label, " ".repeat(right))
     };
-    Line::from(Span::styled(text, Style::default().fg(ACCENT).bold()))
+    Line::from(Span::styled(text, Style::default().fg(accent).bold()))
 }
 
 fn new_messages_notice_label(count: usize) -> String {

--- a/src/tui/ui/panes.rs
+++ b/src/tui/ui/panes.rs
@@ -3,7 +3,7 @@ use ratatui::{
     layout::{Alignment, Position, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, BorderType, Borders, Clear, List, ListItem, Paragraph},
+    widgets::{Block, BorderType, Borders, List, ListItem, Paragraph},
 };
 use ratatui_image::Image as RatatuiImage;
 use unicode_width::UnicodeWidthStr;
@@ -19,28 +19,29 @@ use super::super::{
     state::{
         ChannelPaneEntry, DashboardState, EmojiPickerEntry, FocusPane, GuildPaneEntry,
         MAX_MENTION_PICKER_VISIBLE, MemberEntry, MemberGroup, MentionPickerEntry, discord_color,
-        folder_color, presence_color, presence_marker,
+        presence_marker,
     },
 };
 use super::{
     active_text_style,
     activity::{ActivityLeading, ActivityRender, build_activity_render},
-    channel_prefix, channel_unread_decoration, dm_presence_dot_span, highlight_style,
+    bg_clear, channel_prefix, channel_unread_decoration, dm_presence_dot_span, highlight_style,
     layout::{composer_inner_width, panel_scrollbar_area, prefixed_composer_input},
     panel_block, panel_block_line, panel_content_height, render_vertical_scrollbar,
     selection_marker, styled_list_item,
-    types::{ACCENT, DIM, EmojiImage, MessageAreas},
+    types::{EmojiImage, MessageAreas, RenderCtx},
 };
 
 pub(super) fn render_guilds(frame: &mut Frame, area: Rect, state: &DashboardState) {
     let dashboard = state;
+    let ctx = RenderCtx::new(dashboard.theme());
     let focused = state.focus() == FocusPane::Guilds;
     let filter_query = state.guild_pane_filter_query();
 
     // When the filter is active split off one row at the bottom for the search
     // bar, rendering the border block separately so we can carve up the inner.
     let (list_area, filter_area) = if filter_query.is_some() && area.height >= 4 {
-        let block = panel_block("Servers", focused);
+        let block = panel_block("Servers", focused, dashboard.theme().accent);
         let inner = block.inner(area);
         frame.render_widget(block, area);
         let list_h = inner.height.saturating_sub(1);
@@ -79,14 +80,18 @@ pub(super) fn render_guilds(frame: &mut Frame, area: Rect, state: &DashboardStat
                         );
                         let unread_count = state.direct_message_unread_count();
                         let badge = (unread_count > 0).then(|| {
-                            notification_count_badge(ChannelUnreadState::Notified(
-                                u32::try_from(unread_count).unwrap_or(u32::MAX),
-                            ))
+                            notification_count_badge(
+                                ChannelUnreadState::Notified(
+                                    u32::try_from(unread_count).unwrap_or(u32::MAX),
+                                ),
+                                &ctx,
+                            )
                         });
                         let badge_width =
                             badge.as_ref().map(|span| span.content.width()).unwrap_or(0);
                         let label_width = max_width.saturating_sub(badge_width);
-                        let mut spans = vec![selection_marker(is_selected)];
+                        let mut spans =
+                            vec![selection_marker(is_selected, dashboard.theme().accent)];
                         if let Some(badge) = badge {
                             spans.push(badge);
                         }
@@ -103,7 +108,7 @@ pub(super) fn render_guilds(frame: &mut Frame, area: Rect, state: &DashboardStat
                     GuildPaneEntry::FolderHeader { folder, collapsed } => {
                         let arrow = if *collapsed { "▶ " } else { "▼ " };
                         let icon = if *collapsed { "📁" } else { "📂" };
-                        let color = folder_color(folder.color);
+                        let color = dashboard.theme().folder_color(folder.color);
                         let label = folder.name.as_deref().unwrap_or_default();
                         let title = if label.is_empty() {
                             icon.to_owned()
@@ -112,7 +117,7 @@ pub(super) fn render_guilds(frame: &mut Frame, area: Rect, state: &DashboardStat
                         };
                         let label_width = max_width.saturating_sub(arrow.width());
                         ListItem::new(Line::from(vec![
-                            selection_marker(is_selected),
+                            selection_marker(is_selected, dashboard.theme().accent),
                             Span::styled(arrow, Style::default().fg(color)),
                             Span::styled(
                                 truncate_display_width_from(&title, horizontal_scroll, label_width),
@@ -129,12 +134,13 @@ pub(super) fn render_guilds(frame: &mut Frame, area: Rect, state: &DashboardStat
                         let is_muted = dashboard.guild_notification_muted(guild.id);
                         let unread = dashboard.sidebar_guild_unread(guild.id);
                         let (badge, mut name_style) = if is_active {
-                            let (badge, _) = channel_unread_decoration(unread, base_style, false);
+                            let (badge, _) =
+                                channel_unread_decoration(unread, base_style, false, &ctx);
                             (badge, base_style)
                         } else if unread == ChannelUnreadState::Seen {
                             (None, base_style)
                         } else {
-                            channel_unread_decoration(unread, base_style, false)
+                            channel_unread_decoration(unread, base_style, false, &ctx)
                         };
                         if is_muted {
                             name_style = name_style.add_modifier(Modifier::DIM);
@@ -145,8 +151,8 @@ pub(super) fn render_guilds(frame: &mut Frame, area: Rect, state: &DashboardStat
                             .saturating_sub(prefix.width())
                             .saturating_sub(badge_width);
                         let mut spans = vec![
-                            selection_marker(is_selected),
-                            Span::styled(prefix, Style::default().fg(DIM)),
+                            selection_marker(is_selected, dashboard.theme().accent),
+                            Span::styled(prefix, Style::default().fg(dashboard.theme().dim)),
                         ];
                         if let Some(badge) = badge {
                             spans.push(badge);
@@ -169,7 +175,7 @@ pub(super) fn render_guilds(frame: &mut Frame, area: Rect, state: &DashboardStat
 
     let list = List::new(items).highlight_style(highlight_style());
     let list = if filter_area.is_none() {
-        list.block(panel_block("Servers", focused))
+        list.block(panel_block("Servers", focused, dashboard.theme().accent))
     } else {
         list
     };
@@ -178,7 +184,7 @@ pub(super) fn render_guilds(frame: &mut Frame, area: Rect, state: &DashboardStat
     if let Some(filter_rect) = filter_area {
         let query = filter_query.unwrap_or_default();
         let cursor = state.guild_pane_filter_cursor().unwrap_or(0);
-        let cursor_x = render_pane_filter_bar(frame, filter_rect, query, cursor, focused);
+        let cursor_x = render_pane_filter_bar(frame, filter_rect, query, cursor, focused, &ctx);
         if focused {
             frame.set_cursor_position(Position {
                 x: filter_rect.x.saturating_add(cursor_x as u16),
@@ -193,11 +199,12 @@ pub(super) fn render_guilds(frame: &mut Frame, area: Rect, state: &DashboardStat
         state.guild_scroll(),
         panel_content_height(area, "Servers"),
         state.guild_pane_entries().len(),
+        &ctx,
     );
 }
 
-fn notification_count_badge(unread: ChannelUnreadState) -> Span<'static> {
-    let (badge, _) = channel_unread_decoration(unread, Style::default(), false);
+fn notification_count_badge(unread: ChannelUnreadState, ctx: &RenderCtx<'_>) -> Span<'static> {
+    let (badge, _) = channel_unread_decoration(unread, Style::default(), false, ctx);
     badge.expect("numeric unread state always renders a badge")
 }
 
@@ -209,6 +216,7 @@ fn render_pane_filter_bar(
     query: &str,
     cursor_byte: usize,
     focused: bool,
+    ctx: &RenderCtx<'_>,
 ) -> usize {
     let prompt = "/ ";
     let prompt_width = prompt.width();
@@ -240,9 +248,13 @@ fn render_pane_filter_bar(
     let visible = &query[start..end];
     let cursor_col = prompt_width + query[start..cursor_byte].width();
 
-    let accent = if focused { ACCENT } else { Color::DarkGray };
+    let accent = if focused {
+        ctx.theme.accent
+    } else {
+        ctx.theme.dim
+    };
     let shown_query = if query.is_empty() {
-        Span::styled("search...", Style::default().fg(DIM))
+        Span::styled("search...", Style::default().fg(ctx.theme.dim))
     } else {
         Span::raw(visible.to_owned())
     };
@@ -256,9 +268,10 @@ fn render_pane_filter_bar(
 
 pub(super) fn render_channels(frame: &mut Frame, area: Rect, state: &DashboardState) {
     let dashboard = state;
+    let ctx = RenderCtx::new(dashboard.theme());
     let focused = state.focus() == FocusPane::Channels;
     let filter_query = state.channel_pane_filter_query();
-    let block = panel_block("Channels", focused);
+    let block = panel_block("Channels", focused, ctx.theme.accent);
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
@@ -272,7 +285,9 @@ pub(super) fn render_channels(frame: &mut Frame, area: Rect, state: &DashboardSt
         frame.render_widget(
             Paragraph::new(Line::from(Span::styled(
                 label,
-                Style::default().fg(ACCENT).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(ctx.theme.accent)
+                    .add_modifier(Modifier::BOLD),
             ))),
             header_area,
         );
@@ -315,14 +330,15 @@ pub(super) fn render_channels(frame: &mut Frame, area: Rect, state: &DashboardSt
                     ChannelPaneEntry::CategoryHeader { state, collapsed } => {
                         let arrow = if *collapsed { "▶ " } else { "▼ " };
                         let label_width = max_width.saturating_sub(arrow.width());
-                        let mut label_style =
-                            Style::default().fg(ACCENT).add_modifier(Modifier::BOLD);
+                        let mut label_style = Style::default()
+                            .fg(dashboard.theme().accent)
+                            .add_modifier(Modifier::BOLD);
                         if dashboard.channel_notification_muted(state.id) {
                             label_style = label_style.add_modifier(Modifier::DIM);
                         }
                         ListItem::new(Line::from(vec![
-                            selection_marker(is_selected),
-                            Span::styled(arrow, Style::default().fg(ACCENT)),
+                            selection_marker(is_selected, dashboard.theme().accent),
+                            Span::styled(arrow, Style::default().fg(dashboard.theme().accent)),
                             Span::styled(
                                 truncate_display_width_from(
                                     &state.name,
@@ -335,15 +351,18 @@ pub(super) fn render_channels(frame: &mut Frame, area: Rect, state: &DashboardSt
                     }
                     ChannelPaneEntry::Channel { state, branch } => {
                         let branch_prefix = branch.prefix();
-                        let prefix_span = dm_presence_dot_span(state).unwrap_or_else(|| {
-                            Span::styled(channel_prefix(&state.kind), Style::default().fg(DIM))
+                        let prefix_span = dm_presence_dot_span(state, &ctx).unwrap_or_else(|| {
+                            Span::styled(
+                                channel_prefix(&state.kind),
+                                Style::default().fg(ctx.theme.dim),
+                            )
                         });
                         let prefix_width = prefix_span.content.width();
                         let base_style = active_text_style(is_active, Style::default());
                         let is_muted = dashboard.channel_notification_muted(state.id);
                         let unread = dashboard.sidebar_channel_unread(state.id);
                         let (badge, mut name_style) =
-                            channel_unread_decoration(unread, base_style, is_active);
+                            channel_unread_decoration(unread, base_style, is_active, &ctx);
                         if is_muted {
                             name_style = name_style.add_modifier(Modifier::DIM);
                         }
@@ -354,11 +373,15 @@ pub(super) fn render_channels(frame: &mut Frame, area: Rect, state: &DashboardSt
                             let message_count = dashboard.channel_unread_message_count(state.id);
                             if message_count > 0 {
                                 let count = u32::try_from(message_count).unwrap_or(u32::MAX);
-                                Some(notification_count_badge(ChannelUnreadState::Notified(
-                                    count,
-                                )))
+                                Some(notification_count_badge(
+                                    ChannelUnreadState::Notified(count),
+                                    &ctx,
+                                ))
                             } else if unread == ChannelUnreadState::Unread {
-                                Some(notification_count_badge(ChannelUnreadState::Notified(1)))
+                                Some(notification_count_badge(
+                                    ChannelUnreadState::Notified(1),
+                                    &ctx,
+                                ))
                             } else {
                                 badge
                             }
@@ -372,8 +395,8 @@ pub(super) fn render_channels(frame: &mut Frame, area: Rect, state: &DashboardSt
                             .saturating_sub(prefix_width)
                             .saturating_sub(badge_width);
                         let mut spans = vec![
-                            selection_marker(is_selected),
-                            Span::styled(branch_prefix, Style::default().fg(DIM)),
+                            selection_marker(is_selected, ctx.theme.accent),
+                            Span::styled(branch_prefix, Style::default().fg(ctx.theme.dim)),
                         ];
                         if let Some(badge) = badge {
                             spans.push(badge);
@@ -401,7 +424,7 @@ pub(super) fn render_channels(frame: &mut Frame, area: Rect, state: &DashboardSt
     if let Some(filter_rect) = filter_area {
         let query = filter_query.unwrap_or_default();
         let cursor = state.channel_pane_filter_cursor().unwrap_or(0);
-        let cursor_x = render_pane_filter_bar(frame, filter_rect, query, cursor, focused);
+        let cursor_x = render_pane_filter_bar(frame, filter_rect, query, cursor, focused, &ctx);
         if focused {
             frame.set_cursor_position(Position {
                 x: filter_rect.x.saturating_add(cursor_x as u16),
@@ -416,6 +439,7 @@ pub(super) fn render_channels(frame: &mut Frame, area: Rect, state: &DashboardSt
         state.channel_scroll(),
         list_area.height as usize,
         state.channel_pane_entries().len(),
+        &ctx,
     );
 }
 
@@ -433,17 +457,22 @@ pub(super) fn render_composer(
     state: &DashboardState,
     emoji_images: &[EmojiImage<'_>],
 ) {
+    let ctx = RenderCtx::new(state.theme());
     let inner_width = composer_inner_width(area.width);
     let ready_urls = ready_custom_emoji_urls(emoji_images);
     let prompt = composer_lines_with_loaded_custom_emoji_urls(state, inner_width, &ready_urls);
-    let border_color = if state.is_composing() { ACCENT } else { DIM };
+    let border_color = if state.is_composing() {
+        ctx.theme.accent
+    } else {
+        ctx.theme.dim
+    };
 
     frame.render_widget(
         Paragraph::new(prompt)
             .style(if state.is_composing() {
                 Style::default().fg(Color::White)
             } else {
-                Style::default().fg(DIM)
+                Style::default().fg(ctx.theme.dim)
             })
             .block(
                 Block::default()
@@ -537,22 +566,24 @@ pub(super) fn render_composer_mention_picker(
     let Some(area) = mention_picker_area(message_areas, candidates.len()) else {
         return;
     };
-    frame.render_widget(Clear, area);
+    frame.render_widget(bg_clear(state.theme().background), area);
     let visible_count = picker_visible_count(area, candidates.len());
     let selected = state.composer_mention_selected().min(candidates.len() - 1);
     let window_start = picker_window_start(candidates.len(), selected, visible_count);
     let visible_candidates = &candidates[window_start..window_start + visible_count];
     let shows_scrollbar = candidates.len() > visible_count;
     let inner_width = picker_inner_width(area, shows_scrollbar);
+    let ctx = RenderCtx::new(state.theme());
     let lines = mention_picker_lines(
         visible_candidates,
         selected.saturating_sub(window_start),
         inner_width,
+        &ctx,
     );
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Plain)
-        .border_style(Style::default().fg(DIM))
+        .border_style(Style::default().fg(ctx.theme.dim))
         .title(" mention ")
         .title_style(Style::default().fg(Color::White).bold());
     frame.render_widget(Paragraph::new(lines).block(block), area);
@@ -562,6 +593,7 @@ pub(super) fn render_composer_mention_picker(
         window_start,
         visible_count,
         candidates.len(),
+        &ctx,
     );
 }
 
@@ -581,7 +613,7 @@ pub(super) fn render_composer_emoji_picker(
     let Some(area) = mention_picker_area(message_areas, candidates.len()) else {
         return;
     };
-    frame.render_widget(Clear, area);
+    frame.render_widget(bg_clear(state.theme().background), area);
     let visible_count = picker_visible_count(area, candidates.len());
     let selected = state.composer_emoji_selected().min(candidates.len() - 1);
     let window_start = picker_window_start(candidates.len(), selected, visible_count);
@@ -592,17 +624,19 @@ pub(super) fn render_composer_emoji_picker(
         .iter()
         .map(|image| image.url.clone())
         .collect::<Vec<_>>();
+    let ctx = RenderCtx::new(state.theme());
     let lines = emoji_picker_lines(
         visible_candidates,
         selected.saturating_sub(window_start),
         inner_width,
         &ready_urls,
         state.show_custom_emoji(),
+        &ctx,
     );
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Plain)
-        .border_style(Style::default().fg(DIM))
+        .border_style(Style::default().fg(ctx.theme.dim))
         .title(" emoji ")
         .title_style(Style::default().fg(Color::White).bold());
     frame.render_widget(Paragraph::new(lines).block(block), area);
@@ -615,6 +649,7 @@ pub(super) fn render_composer_emoji_picker(
         window_start,
         visible_count,
         candidates.len(),
+        &ctx,
     );
 }
 
@@ -671,6 +706,7 @@ fn mention_picker_lines(
     candidates: &[MentionPickerEntry],
     selected: usize,
     width: usize,
+    ctx: &RenderCtx<'_>,
 ) -> Vec<Line<'static>> {
     let max_label_width = width.saturating_sub(4).max(1);
     candidates
@@ -690,14 +726,14 @@ fn mention_picker_lines(
                 .unwrap_or_default();
             let label = format!("{}{bot_marker}{username_hint}", entry.display_name);
             let label = truncate_display_width(&label, max_label_width);
-            let mut row_style = Style::default().fg(presence_color(entry.status));
+            let mut row_style = Style::default().fg(ctx.theme.presence_color(entry.status));
             if index == selected {
                 row_style = row_style
                     .bg(Color::Rgb(40, 45, 90))
                     .add_modifier(Modifier::BOLD);
             }
             Line::from(vec![
-                Span::styled(cursor, Style::default().fg(ACCENT)),
+                Span::styled(cursor, Style::default().fg(ctx.theme.accent)),
                 Span::styled(presence_marker(entry.status).to_string(), row_style),
                 Span::styled(" ", row_style),
                 Span::styled(label, row_style),
@@ -712,6 +748,7 @@ pub(super) fn emoji_picker_lines(
     width: usize,
     ready_custom_emoji_urls: &[String],
     show_custom_emoji: bool,
+    ctx: &RenderCtx<'_>,
 ) -> Vec<Line<'static>> {
     candidates
         .iter()
@@ -730,14 +767,16 @@ pub(super) fn emoji_picker_lines(
             let mut row_style = if entry.available {
                 Style::default().fg(Color::White)
             } else {
-                Style::default().fg(DIM).add_modifier(Modifier::CROSSED_OUT)
+                Style::default()
+                    .fg(ctx.theme.dim)
+                    .add_modifier(Modifier::CROSSED_OUT)
             };
             if index == selected {
                 row_style = row_style
                     .bg(Color::Rgb(40, 45, 90))
                     .add_modifier(Modifier::BOLD);
             }
-            let mut spans = vec![Span::styled(cursor, Style::default().fg(ACCENT))];
+            let mut spans = vec![Span::styled(cursor, Style::default().fg(ctx.theme.accent))];
             spans.extend(emoji_picker_entry_prefix(
                 entry,
                 custom_image_ready,
@@ -839,7 +878,7 @@ pub(super) fn composer_lines_with_loaded_custom_emoji_urls(
         {
             lines.push(Line::from(Span::styled(
                 reply_target_hint(message, state, width),
-                Style::default().fg(DIM),
+                Style::default().fg(state.theme().dim),
             )));
         }
         let prefixed_input = prefixed_composer_input(&display_input.input);
@@ -1032,9 +1071,10 @@ fn composer_custom_emoji_image_position(
 }
 
 fn pending_upload_lines(state: &DashboardState, width: u16) -> Vec<Line<'static>> {
+    let accent = state.theme().accent;
     pending_upload_texts(state, width)
         .into_iter()
-        .map(|label| Line::from(Span::styled(label, Style::default().fg(ACCENT))))
+        .map(|label| Line::from(Span::styled(label, Style::default().fg(accent))))
         .collect()
 }
 
@@ -1143,6 +1183,7 @@ pub(super) fn render_members(
     state: &DashboardState,
     emoji_images: &[EmojiImage<'_>],
 ) {
+    let ctx = RenderCtx::new(state.theme());
     let groups = state.members_grouped();
     let mut lines: Vec<Line<'static>> = Vec::new();
     // (absolute_line_index, cdn_url) for activity rows that have a loaded emoji image.
@@ -1158,7 +1199,7 @@ pub(super) fn render_members(
     if groups.is_empty() {
         lines.push(Line::from(Span::styled(
             "No members loaded yet.",
-            Style::default().fg(DIM),
+            Style::default().fg(ctx.theme.dim),
         )));
     }
 
@@ -1167,17 +1208,22 @@ pub(super) fn render_members(
             lines.push(Line::from(""));
             line_index += 1;
         }
-        lines.push(member_group_header(group, content_width));
+        lines.push(member_group_header(group, content_width, ctx.theme.dim));
         line_index += 1;
         for member in &group.entries {
             let member = *member;
             let is_selected = focused && selected_line == Some(line_index);
-            let marker_style = Style::default().fg(presence_color(member.status()));
+            let marker_style = Style::default().fg(ctx.theme.presence_color(member.status()));
             let name_style =
                 member_name_style(member, state.member_role_color(member), is_selected);
 
-            let display =
-                member_display_label(member, state.member_horizontal_scroll(), max_name_width);
+            let display_name = state.member_display_name(member);
+            let display = member_display_label(
+                member,
+                &display_name,
+                state.member_horizontal_scroll(),
+                max_name_width,
+            );
             lines.push(Line::from(vec![
                 Span::styled(
                     format!(" {} ", presence_marker(member.status())),
@@ -1204,7 +1250,7 @@ pub(super) fn render_members(
                             emoji_line_urls.push((line_index, url));
                             Line::from(vec![
                                 Span::raw("     "),
-                                Span::styled(body, Style::default().fg(DIM)),
+                                Span::styled(body, Style::default().fg(ctx.theme.dim)),
                             ])
                         }
                         ActivityLeading::Icon(icon) => {
@@ -1217,7 +1263,7 @@ pub(super) fn render_members(
                                 Span::raw("   "),
                                 Span::styled(icon.to_string(), Style::default().fg(Color::Green)),
                                 Span::raw(" "),
-                                Span::styled(body, Style::default().fg(DIM)),
+                                Span::styled(body, Style::default().fg(ctx.theme.dim)),
                             ])
                         }
                         ActivityLeading::None => {
@@ -1225,7 +1271,7 @@ pub(super) fn render_members(
                                 truncate_display_width_from(&render.body, h_scroll, max_name_width);
                             Line::from(vec![
                                 Span::raw("   "),
-                                Span::styled(body, Style::default().fg(DIM)),
+                                Span::styled(body, Style::default().fg(ctx.theme.dim)),
                             ])
                         }
                     };
@@ -1244,7 +1290,7 @@ pub(super) fn render_members(
         .take(content_height)
         .collect();
 
-    let block = panel_block_line(state.member_panel_title(), focused);
+    let block = panel_block_line(state.member_panel_title(), focused, ctx.theme.accent);
     let content_area = block.inner(area);
     frame.render_widget(Paragraph::new(lines).block(block), area);
 
@@ -1274,10 +1320,11 @@ pub(super) fn render_members(
         scroll,
         content_height,
         state.member_line_count(),
+        &ctx,
     );
 }
 
-fn member_group_header(group: &MemberGroup<'_>, content_width: usize) -> Line<'static> {
+fn member_group_header(group: &MemberGroup<'_>, content_width: usize, dim: Color) -> Line<'static> {
     let count_suffix = format!(" - {}", group.entries.len());
     let label_max = content_width.saturating_sub(count_suffix.width());
     let label = truncate_display_width(&group.label, label_max);
@@ -1285,10 +1332,10 @@ fn member_group_header(group: &MemberGroup<'_>, content_width: usize) -> Line<'s
         Span::styled(
             label,
             Style::default()
-                .fg(discord_color(group.color, DIM))
+                .fg(discord_color(group.color, dim))
                 .add_modifier(Modifier::BOLD),
         ),
-        Span::styled(count_suffix, Style::default().fg(DIM)),
+        Span::styled(count_suffix, Style::default().fg(dim)),
     ])
 }
 
@@ -1317,12 +1364,12 @@ pub(super) fn member_name_style(
 
 pub(super) fn member_display_label(
     member: MemberEntry<'_>,
+    display_name: &str,
     horizontal_scroll: usize,
     max_width: usize,
 ) -> String {
-    let display_name = member.display_name();
     if !member.is_bot() {
-        return truncate_display_width_from(&display_name, horizontal_scroll, max_width);
+        return truncate_display_width_from(display_name, horizontal_scroll, max_width);
     }
 
     const BOT_SUFFIX: &str = " [bot]";
@@ -1338,7 +1385,7 @@ pub(super) fn member_display_label(
     format!(
         "{}{}",
         truncate_display_width_from(
-            &display_name,
+            display_name,
             horizontal_scroll,
             max_width.saturating_sub(suffix_width),
         ),
@@ -1384,9 +1431,12 @@ fn activity_priority(kind: ActivityKind) -> u8 {
 
 pub(super) fn render_header(frame: &mut Frame, area: Rect, state: &DashboardState) {
     let title = format!(" Concord - v{} ", env!("CARGO_PKG_VERSION"));
-    let mut spans = vec![Span::styled(title, Style::default().fg(Color::Cyan).bold())];
+    let mut spans = vec![Span::styled(title, Style::default().fg(state.theme().accent).bold())];
     if let Some(user) = state.current_user() {
-        spans.push(Span::styled(" Connected as ", Style::default().fg(DIM)));
+        spans.push(Span::styled(
+            " Connected as ",
+            Style::default().fg(state.theme().dim),
+        ));
         spans.push(Span::styled(
             format!("{user} "),
             Style::default().fg(Color::Green).bold(),

--- a/src/tui/ui/panes.rs
+++ b/src/tui/ui/panes.rs
@@ -1431,7 +1431,10 @@ fn activity_priority(kind: ActivityKind) -> u8 {
 
 pub(super) fn render_header(frame: &mut Frame, area: Rect, state: &DashboardState) {
     let title = format!(" Concord - v{} ", env!("CARGO_PKG_VERSION"));
-    let mut spans = vec![Span::styled(title, Style::default().fg(state.theme().accent).bold())];
+    let mut spans = vec![Span::styled(
+        title,
+        Style::default().fg(state.theme().accent).bold(),
+    )];
     if let Some(user) = state.current_user() {
         spans.push(Span::styled(
             " Connected as ",

--- a/src/tui/ui/popups/action_menu.rs
+++ b/src/tui/ui/popups/action_menu.rs
@@ -15,13 +15,17 @@ pub(in crate::tui::ui) fn render_leader_popup(
 
     let lines = leader_popup_lines(state, area.height.saturating_sub(2) as usize);
     let popup = leader_popup_area(area, lines.len() as u16);
-    frame.render_widget(Clear, popup);
+    frame.render_widget(bg_clear(state.theme().background), popup);
     frame.render_widget(
         Paragraph::new(truncate_leader_lines(
             lines,
             popup.width.saturating_sub(2) as usize,
         ))
-        .block(panel_block_owned(leader_popup_title(state), true))
+        .block(panel_block_owned(
+            leader_popup_title(state),
+            true,
+            state.theme().accent,
+        ))
         .wrap(Wrap { trim: false }),
         popup,
     );
@@ -57,16 +61,17 @@ fn leader_popup_title(state: &DashboardState) -> String {
 }
 
 fn leader_popup_lines(state: &DashboardState, max_lines: usize) -> Vec<Line<'static>> {
+    let dim = state.theme().dim;
     let lines = if state.is_leader_action_mode() {
-        leader_action_lines(state)
+        leader_action_lines(state, dim)
     } else {
         vec![
-            leader_shortcut_line('1', "toggle Servers", true),
-            leader_shortcut_line('2', "toggle Channels", true),
-            leader_shortcut_line('4', "toggle Members", true),
-            leader_shortcut_line('a', "Actions", true),
-            leader_shortcut_line('o', "Options", true),
-            leader_shortcut_text_line("Space", "Switch channels", true),
+            leader_shortcut_line('1', "toggle Servers", true, dim),
+            leader_shortcut_line('2', "toggle Channels", true, dim),
+            leader_shortcut_line('4', "toggle Members", true, dim),
+            leader_shortcut_line('a', "Actions", true, dim),
+            leader_shortcut_line('o', "Options", true, dim),
+            leader_shortcut_text_line("Space", "Switch channels", true, dim),
         ]
     };
     leader_shortcut_grid_lines(lines, max_lines)
@@ -112,7 +117,7 @@ fn leader_line_width(line: &Line<'_>) -> usize {
     line.spans.iter().map(|span| span.content.width()).sum()
 }
 
-fn leader_action_lines(state: &DashboardState) -> Vec<Line<'static>> {
+fn leader_action_lines(state: &DashboardState, dim: Color) -> Vec<Line<'static>> {
     if state.is_message_action_menu_open() {
         let actions = state.selected_message_action_items();
         return actions
@@ -123,6 +128,7 @@ fn leader_action_lines(state: &DashboardState) -> Vec<Line<'static>> {
                     message_action_shortcut(&actions, index).unwrap_or(' '),
                     &action.label,
                     action.enabled,
+                    dim,
                 )
             })
             .collect();
@@ -134,7 +140,12 @@ fn leader_action_lines(state: &DashboardState) -> Vec<Line<'static>> {
                 .iter()
                 .enumerate()
                 .map(|(index, item)| {
-                    leader_shortcut_line(indexed_shortcut(index).unwrap_or(' '), item.label, true)
+                    leader_shortcut_line(
+                        indexed_shortcut(index).unwrap_or(' '),
+                        item.label,
+                        true,
+                        dim,
+                    )
                 })
                 .collect();
         }
@@ -147,6 +158,7 @@ fn leader_action_lines(state: &DashboardState) -> Vec<Line<'static>> {
                     guild_action_shortcut(&actions, index).unwrap_or(' '),
                     &action.label,
                     action.enabled,
+                    dim,
                 )
             })
             .collect();
@@ -157,7 +169,12 @@ fn leader_action_lines(state: &DashboardState) -> Vec<Line<'static>> {
             .into_iter()
             .enumerate()
             .map(|(index, thread)| {
-                leader_shortcut_line(indexed_shortcut(index).unwrap_or(' '), &thread.label, true)
+                leader_shortcut_line(
+                    indexed_shortcut(index).unwrap_or(' '),
+                    &thread.label,
+                    true,
+                    dim,
+                )
             })
             .collect();
     }
@@ -168,7 +185,12 @@ fn leader_action_lines(state: &DashboardState) -> Vec<Line<'static>> {
                 .iter()
                 .enumerate()
                 .map(|(index, item)| {
-                    leader_shortcut_line(indexed_shortcut(index).unwrap_or(' '), item.label, true)
+                    leader_shortcut_line(
+                        indexed_shortcut(index).unwrap_or(' '),
+                        item.label,
+                        true,
+                        dim,
+                    )
                 })
                 .collect();
         }
@@ -181,6 +203,7 @@ fn leader_action_lines(state: &DashboardState) -> Vec<Line<'static>> {
                     channel_action_shortcut(&actions, index).unwrap_or(' '),
                     &action.label,
                     action.enabled,
+                    dim,
                 )
             })
             .collect();
@@ -195,28 +218,29 @@ fn leader_action_lines(state: &DashboardState) -> Vec<Line<'static>> {
                     member_action_shortcut(&actions, index).unwrap_or(' '),
                     &action.label,
                     action.enabled,
+                    dim,
                 )
             })
             .collect();
     }
     vec![Line::from(Span::styled(
         "No actions available",
-        Style::default().fg(DIM),
+        Style::default().fg(dim),
     ))]
 }
 
-fn leader_shortcut_line(key: char, label: &str, enabled: bool) -> Line<'static> {
-    leader_shortcut_text_line(&key.to_string(), label, enabled)
+fn leader_shortcut_line(key: char, label: &str, enabled: bool, dim: Color) -> Line<'static> {
+    leader_shortcut_text_line(&key.to_string(), label, enabled, dim)
 }
 
-fn leader_shortcut_text_line(key: &str, label: &str, enabled: bool) -> Line<'static> {
+fn leader_shortcut_text_line(key: &str, label: &str, enabled: bool, dim: Color) -> Line<'static> {
     let style = if enabled {
         Style::default()
     } else {
-        Style::default().fg(DIM)
+        Style::default().fg(dim)
     };
     Line::from(vec![
-        Span::styled(format!("[{key}] "), Style::default().fg(DIM)),
+        Span::styled(format!("[{key}] "), Style::default().fg(dim)),
         Span::raw(" "),
         Span::styled(label.to_owned(), style),
     ])
@@ -244,10 +268,11 @@ pub(in crate::tui::ui) fn render_message_action_menu(
 
     let selected = state.selected_message_action_index().unwrap_or(0);
     let popup = centered_rect(area, 54, (actions.len() as u16).saturating_add(2));
-    frame.render_widget(Clear, popup);
+    frame.render_widget(bg_clear(state.theme().background), popup);
+    let ctx = RenderCtx::new(state.theme());
     frame.render_widget(
-        Paragraph::new(message_action_menu_lines(&actions, selected))
-            .block(panel_block("Message actions", true))
+        Paragraph::new(message_action_menu_lines(&actions, selected, &ctx))
+            .block(panel_block("Message actions", true, state.theme().accent))
             .wrap(Wrap { trim: false }),
         popup,
     );
@@ -256,6 +281,7 @@ pub(in crate::tui::ui) fn render_message_action_menu(
 pub(in crate::tui::ui) fn message_action_menu_lines(
     actions: &[MessageActionItem],
     selected: usize,
+    ctx: &RenderCtx<'_>,
 ) -> Vec<Line<'static>> {
     actions
         .iter()
@@ -271,7 +297,7 @@ pub(in crate::tui::ui) fn message_action_menu_lines(
             let mut style = if action.enabled {
                 Style::default()
             } else {
-                Style::default().fg(DIM)
+                Style::default().fg(ctx.theme.dim)
             };
             if index == selected {
                 style = style
@@ -279,8 +305,8 @@ pub(in crate::tui::ui) fn message_action_menu_lines(
                     .add_modifier(Modifier::BOLD);
             }
             Line::from(vec![
-                Span::styled(marker, Style::default().fg(ACCENT)),
-                Span::styled(shortcut, Style::default().fg(DIM)),
+                Span::styled(marker, Style::default().fg(ctx.theme.accent)),
+                Span::styled(shortcut, Style::default().fg(ctx.theme.dim)),
                 Span::styled(label, style),
             ])
         })

--- a/src/tui/ui/popups/channel_switcher.rs
+++ b/src/tui/ui/popups/channel_switcher.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::tui::ui::types::{ACCENT, RenderCtx};
 
 const CHANNEL_SWITCHER_POPUP_WIDTH: u16 = 74;
 
@@ -19,7 +20,8 @@ pub(in crate::tui::ui) fn render_channel_switcher_popup(
     let selected = state.selected_channel_switcher_index().unwrap_or(0);
     let popup = channel_switcher_popup_area(area);
     let max_result_lines = usize::from(popup.height.saturating_sub(4)).max(1);
-    frame.render_widget(Clear, popup);
+    frame.render_widget(bg_clear(state.theme().background), popup);
+    let ctx = RenderCtx::new(state.theme());
     frame.render_widget(
         Paragraph::new(channel_switcher_lines(
             &items,
@@ -28,8 +30,9 @@ pub(in crate::tui::ui) fn render_channel_switcher_popup(
             query_cursor,
             max_result_lines,
             popup.width.saturating_sub(2) as usize,
+            &ctx,
         ))
-        .block(panel_block("Channel Switcher", true))
+        .block(panel_block("Channel Switcher", true, ctx.theme.accent))
         .wrap(Wrap { trim: false }),
         popup,
     );
@@ -53,7 +56,7 @@ pub(in crate::tui::ui) fn channel_switcher_item_index_at(
         return None;
     }
     let popup = channel_switcher_popup_area(area);
-    let inner = panel_block("", false).inner(popup);
+    let inner = panel_block("", false, ACCENT).inner(popup);
     if column < inner.x
         || column >= inner.x.saturating_add(inner.width)
         || row < inner.y
@@ -104,39 +107,46 @@ pub(in crate::tui::ui) fn channel_switcher_lines(
     query_cursor: usize,
     max_result_lines: usize,
     width: usize,
+    ctx: &RenderCtx<'_>,
 ) -> Vec<Line<'static>> {
     let mut lines = vec![
-        channel_switcher_search_line(query, query_cursor, width),
+        channel_switcher_search_line(query, query_cursor, width, ctx),
         Line::from(Span::styled(
             "─".repeat(width.max(1)),
-            Style::default().fg(DIM),
+            Style::default().fg(ctx.theme.dim),
         )),
     ];
 
     if items.is_empty() {
         lines.push(Line::from(Span::styled(
             "No channels found",
-            Style::default().fg(DIM),
+            Style::default().fg(ctx.theme.dim),
         )));
     } else {
         lines.extend(channel_switcher_result_lines(
             items,
             selected,
             max_result_lines,
+            ctx,
         ));
     }
 
     lines
 }
 
-fn channel_switcher_search_line(query: &str, query_cursor: usize, width: usize) -> Line<'static> {
+fn channel_switcher_search_line(
+    query: &str,
+    query_cursor: usize,
+    width: usize,
+    ctx: &RenderCtx<'_>,
+) -> Line<'static> {
     let shown_query = if query.is_empty() {
-        Span::styled("search channels", Style::default().fg(DIM))
+        Span::styled("search channels", Style::default().fg(ctx.theme.dim))
     } else {
         Span::raw(visible_channel_switcher_query(query, query_cursor, width).0)
     };
     Line::from(vec![
-        Span::styled("🔎 ", Style::default().fg(ACCENT)),
+        Span::styled("🔎 ", Style::default().fg(ctx.theme.accent)),
         shown_query,
     ])
 }
@@ -186,17 +196,20 @@ fn channel_switcher_result_lines(
     items: &[ChannelSwitcherItem],
     selected: usize,
     max_result_lines: usize,
+    ctx: &RenderCtx<'_>,
 ) -> Vec<Line<'static>> {
     let selected = selected.min(items.len().saturating_sub(1));
     let rows = channel_switcher_visible_result_rows(items, selected, max_result_lines);
     rows.into_iter()
         .map(|row| match row {
             ChannelSwitcherResultRow::Item(index) => {
-                channel_switcher_item_line(&items[index], index == selected)
+                channel_switcher_item_line(&items[index], index == selected, ctx)
             }
             ChannelSwitcherResultRow::Group(label) => Line::from(Span::styled(
                 label,
-                Style::default().fg(ACCENT).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(ctx.theme.accent)
+                    .add_modifier(Modifier::BOLD),
             )),
         })
         .collect()
@@ -239,14 +252,18 @@ fn channel_switcher_visible_start(
     selected.saturating_sub(max_result_lines / 2)
 }
 
-fn channel_switcher_item_line(item: &ChannelSwitcherItem, selected: bool) -> Line<'static> {
+fn channel_switcher_item_line(
+    item: &ChannelSwitcherItem,
+    selected: bool,
+    ctx: &RenderCtx<'_>,
+) -> Line<'static> {
     let style = if selected {
         highlight_style()
     } else {
         Style::default()
     };
-    let badge = channel_switcher_unread_badge(item);
-    let (_, name_style) = channel_unread_decoration(item.unread, style, false);
+    let badge = channel_switcher_unread_badge(item, ctx);
+    let (_, name_style) = channel_unread_decoration(item.unread, style, false, ctx);
     let marker = if selected { "› " } else { "  " };
     let indent = "  ".repeat(item.depth.saturating_add(1));
     let parent = item
@@ -255,9 +272,9 @@ fn channel_switcher_item_line(item: &ChannelSwitcherItem, selected: bool) -> Lin
         .map(|label| format!("{label} / "))
         .unwrap_or_default();
     let mut spans = vec![
-        Span::styled(marker, Style::default().fg(ACCENT)),
+        Span::styled(marker, Style::default().fg(ctx.theme.accent)),
         Span::raw(indent),
-        Span::styled(parent, Style::default().fg(DIM)),
+        Span::styled(parent, Style::default().fg(ctx.theme.dim)),
     ];
     if let Some(badge) = badge {
         spans.push(badge);
@@ -266,8 +283,11 @@ fn channel_switcher_item_line(item: &ChannelSwitcherItem, selected: bool) -> Lin
     Line::from(spans)
 }
 
-fn channel_switcher_unread_badge(item: &ChannelSwitcherItem) -> Option<Span<'static>> {
-    let (badge, _) = channel_unread_decoration(item.unread, Style::default(), false);
+fn channel_switcher_unread_badge(
+    item: &ChannelSwitcherItem,
+    ctx: &RenderCtx<'_>,
+) -> Option<Span<'static>> {
+    let (badge, _) = channel_unread_decoration(item.unread, Style::default(), false, ctx);
     if item.guild_id.is_none() && item.unread != ChannelUnreadState::Seen {
         if item.unread_message_count > 0 {
             let count = u32::try_from(item.unread_message_count).unwrap_or(u32::MAX);
@@ -275,6 +295,7 @@ fn channel_switcher_unread_badge(item: &ChannelSwitcherItem) -> Option<Span<'sta
                 ChannelUnreadState::Notified(count),
                 Style::default(),
                 false,
+                ctx,
             )
             .0;
         }
@@ -283,6 +304,7 @@ fn channel_switcher_unread_badge(item: &ChannelSwitcherItem) -> Option<Span<'sta
                 ChannelUnreadState::Notified(1),
                 Style::default(),
                 false,
+                ctx,
             )
             .0;
         }

--- a/src/tui/ui/popups/debug_log.rs
+++ b/src/tui/ui/popups/debug_log.rs
@@ -17,16 +17,17 @@ pub(in crate::tui::ui) fn render_debug_log_popup(
         state.debug_channel_visibility(),
         visible_log_lines,
         usize::from(popup_width.saturating_sub(2)),
+        &RenderCtx::new(state.theme()),
     );
     let popup = centered_rect(
         area,
         POPUP_TARGET_WIDTH,
         (lines.len() as u16).saturating_add(2),
     );
-    frame.render_widget(Clear, popup);
+    frame.render_widget(bg_clear(state.theme().background), popup);
     frame.render_widget(
         Paragraph::new(lines)
-            .block(panel_block("Debug logs", true))
+            .block(panel_block("Debug logs", true, state.theme().accent))
             .wrap(Wrap { trim: false }),
         popup,
     );
@@ -37,6 +38,7 @@ pub(in crate::tui::ui) fn debug_log_popup_lines(
     channel_visibility: ChannelVisibilityStats,
     visible_log_lines: usize,
     width: usize,
+    ctx: &RenderCtx<'_>,
 ) -> Vec<Line<'static>> {
     let width = width.max(1);
     let visible_log_lines = visible_log_lines.max(1);
@@ -51,14 +53,14 @@ pub(in crate::tui::ui) fn debug_log_popup_lines(
     );
     lines.push(Line::from(Span::styled(
         visibility_text,
-        Style::default().fg(ACCENT),
+        Style::default().fg(ctx.theme.accent),
     )));
     lines.push(Line::from(Span::raw(String::new())));
 
     if entries.is_empty() {
         lines.push(Line::from(Span::styled(
             "No errors recorded in this process.",
-            Style::default().fg(DIM),
+            Style::default().fg(ctx.theme.dim),
         )));
     } else {
         let wrapped = entries

--- a/src/tui/ui/popups/image_viewer.rs
+++ b/src/tui/ui/popups/image_viewer.rs
@@ -15,8 +15,8 @@ pub(in crate::tui::ui) fn render_image_viewer(
     let popup = image_viewer_popup(area);
     let title_width = usize::from(popup.width.saturating_sub(4)).max(1);
     let title = truncate_display_width(&image_viewer_title(&item), title_width);
-    frame.render_widget(Clear, popup);
-    let block = panel_block_owned(title, true);
+    frame.render_widget(bg_clear(state.theme().background), popup);
+    let block = panel_block_owned(title, true, state.theme().accent);
     let inner = block.inner(popup);
     frame.render_widget(block, popup);
     let image_area = Rect {
@@ -36,11 +36,11 @@ pub(in crate::tui::ui) fn render_image_viewer(
     });
 
     if let Some(image_preview) = image_preview {
-        render_image_preview(frame, image_area, image_preview.state);
+        render_image_preview(frame, image_area, image_preview.state, state.theme().dim);
     } else {
         frame.render_widget(
             Paragraph::new(format!("loading {}...", item.filename))
-                .style(Style::default().fg(DIM))
+                .style(Style::default().fg(state.theme().dim))
                 .wrap(Wrap { trim: false }),
             image_area,
         );
@@ -58,7 +58,7 @@ pub(in crate::tui::ui) fn render_image_viewer(
     if let Some(hint_area) = hint_area {
         frame.render_widget(
             Paragraph::new(IMAGE_VIEWER_DOWNLOAD_HINT)
-                .style(Style::default().fg(DIM))
+                .style(Style::default().fg(state.theme().dim))
                 .alignment(Alignment::Center),
             hint_area,
         );

--- a/src/tui/ui/popups/keymap.rs
+++ b/src/tui/ui/popups/keymap.rs
@@ -14,7 +14,7 @@ pub(in crate::tui::ui) fn render_keymap_popup(
     let width: u16 = 52;
     let height = (lines.len() as u16).saturating_add(2);
     let popup = centered_rect(area, width, height);
-    frame.render_widget(Clear, popup);
+    frame.render_widget(bg_clear(state.theme().background), popup);
     let kb = state.key_bindings();
     let title = format!(
         "Default Keymaps  [{}/{}/Esc to close]",
@@ -23,7 +23,7 @@ pub(in crate::tui::ui) fn render_keymap_popup(
     );
     frame.render_widget(
         Paragraph::new(lines)
-            .block(panel_block_owned(title, true))
+            .block(panel_block_owned(title, true, state.theme().accent))
             .wrap(Wrap { trim: false }),
         popup,
     );
@@ -47,18 +47,20 @@ pub fn keymap_popup_lines(state: &DashboardState) -> Vec<Line<'static>> {
     let scroll_viewport_up = kb.label(Action::ScrollViewportUp);
     let open_keymap = kb.label(Action::OpenKeymap);
 
-    fn row(key: String, desc: &'static str) -> Line<'static> {
+    let accent = state.theme().accent;
+    let dim = state.theme().dim;
+    let row = |key: String, desc: &'static str| -> Line<'static> {
         Line::from(vec![
-            Span::styled(format!("{key:<18}"), Style::default().fg(ACCENT)),
+            Span::styled(format!("{key:<18}"), Style::default().fg(accent)),
             Span::raw(desc),
         ])
-    }
-    fn section(label: String) -> Line<'static> {
+    };
+    let section = |label: String| -> Line<'static> {
         Line::from(Span::styled(
             label,
-            Style::default().fg(DIM).add_modifier(Modifier::BOLD),
+            Style::default().fg(dim).add_modifier(Modifier::BOLD),
         ))
-    }
+    };
 
     vec![
         section("Navigation".into()),

--- a/src/tui/ui/popups/options.rs
+++ b/src/tui/ui/popups/options.rs
@@ -12,17 +12,18 @@ pub(in crate::tui::ui) fn render_options_popup(
     let items = state.display_option_items();
     let selected = state.selected_option_index().unwrap_or(0);
     let popup = centered_rect(area, 66, (items.len() as u16).saturating_add(2));
-    let block = panel_block("Options", true);
+    let block = panel_block("Options", true, state.theme().accent);
     let inner = block.inner(popup);
     let visible_items = usize::from(inner.height).max(1);
     let inner_width = usize::from(inner.width).max(1);
-    frame.render_widget(Clear, popup);
+    frame.render_widget(bg_clear(state.theme().background), popup);
     frame.render_widget(
         Paragraph::new(options_popup_lines(
             &items,
             selected,
             visible_items,
             inner_width,
+            &RenderCtx::new(state.theme()),
         ))
         .block(block),
         popup,
@@ -34,6 +35,7 @@ pub(in crate::tui::ui) fn options_popup_lines(
     selected: usize,
     visible_items: usize,
     width: usize,
+    ctx: &RenderCtx<'_>,
 ) -> Vec<Line<'static>> {
     let visible_items = visible_items.max(1);
     let width = width.max(1);
@@ -59,7 +61,7 @@ pub(in crate::tui::ui) fn options_popup_lines(
             let mut style = if item.effective || index == 0 {
                 Style::default()
             } else {
-                Style::default().fg(DIM)
+                Style::default().fg(ctx.theme.dim)
             };
             if index == selected {
                 style = style
@@ -67,11 +69,11 @@ pub(in crate::tui::ui) fn options_popup_lines(
                     .add_modifier(Modifier::BOLD);
             }
             Line::from(vec![
-                Span::styled(marker, Style::default().fg(ACCENT)),
+                Span::styled(marker, Style::default().fg(ctx.theme.accent)),
                 Span::styled(format!("{control} "), style),
                 Span::styled(item.label, style),
-                Span::styled(" - ", Style::default().fg(DIM)),
-                Span::styled(item.description, Style::default().fg(DIM)),
+                Span::styled(" - ", Style::default().fg(ctx.theme.dim)),
+                Span::styled(item.description, Style::default().fg(ctx.theme.dim)),
             ])
         })
         .map(|line| truncate_line_to_display_width(line, width))

--- a/src/tui/ui/popups/polls.rs
+++ b/src/tui/ui/popups/polls.rs
@@ -14,11 +14,15 @@ pub(in crate::tui::ui) fn render_poll_vote_picker(
 
     let selected = state.selected_poll_vote_picker_index().unwrap_or(0);
     let popup = centered_rect(area, 58, (answers.len() as u16).saturating_add(2));
-    frame.render_widget(Clear, popup);
+    frame.render_widget(bg_clear(state.theme().background), popup);
     frame.render_widget(
-        Paragraph::new(poll_vote_picker_lines(answers, selected))
-            .block(panel_block("Choose poll votes", true))
-            .wrap(Wrap { trim: false }),
+        Paragraph::new(poll_vote_picker_lines(
+            answers,
+            selected,
+            &RenderCtx::new(state.theme()),
+        ))
+        .block(panel_block("Choose poll votes", true, state.theme().accent))
+        .wrap(Wrap { trim: false }),
         popup,
     );
 }
@@ -26,6 +30,7 @@ pub(in crate::tui::ui) fn render_poll_vote_picker(
 pub(in crate::tui::ui) fn poll_vote_picker_lines(
     answers: &[PollVotePickerItem],
     selected: usize,
+    ctx: &RenderCtx<'_>,
 ) -> Vec<Line<'static>> {
     answers
         .iter()
@@ -41,8 +46,8 @@ pub(in crate::tui::ui) fn poll_vote_picker_lines(
                     .add_modifier(Modifier::BOLD);
             }
             Line::from(vec![
-                Span::styled(marker, Style::default().fg(ACCENT)),
-                Span::styled(shortcut, Style::default().fg(DIM)),
+                Span::styled(marker, Style::default().fg(ctx.theme.accent)),
+                Span::styled(shortcut, Style::default().fg(ctx.theme.dim)),
                 Span::styled(format!("{checkbox} {}", answer.label), style),
             ])
         })

--- a/src/tui/ui/popups/profile.rs
+++ b/src/tui/ui/popups/profile.rs
@@ -13,9 +13,9 @@ pub(in crate::tui::ui) fn render_user_profile_popup(
 
     const AVATAR_CELL_HEIGHT: u16 = 4;
     let popup = user_profile_popup_area(area);
-    frame.render_widget(Clear, popup);
+    frame.render_widget(bg_clear(state.theme().background), popup);
 
-    let block = panel_block("Profile", true);
+    let block = panel_block("Profile", true, state.theme().accent);
     let inner = block.inner(popup);
     frame.render_widget(block, popup);
 
@@ -39,8 +39,16 @@ pub(in crate::tui::ui) fn render_user_profile_popup(
         .skip(scroll_position)
         .take(viewport)
         .collect::<Vec<_>>();
+    let ctx = RenderCtx::new(state.theme());
     frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), text_area);
-    render_vertical_scrollbar(frame, text_area, scroll_position, viewport, total_lines);
+    render_vertical_scrollbar(
+        frame,
+        text_area,
+        scroll_position,
+        viewport,
+        total_lines,
+        &ctx,
+    );
 
     if state.show_custom_emoji() {
         for (line_idx, url) in &popup_text.emoji_overlays {
@@ -91,7 +99,7 @@ pub(in crate::tui::ui) fn user_profile_popup_area(area: Rect) -> Rect {
 
 pub(in crate::tui::ui) fn user_profile_popup_has_avatar(area: Rect, has_avatar_url: bool) -> bool {
     let popup = user_profile_popup_area(area);
-    let inner = panel_block("Profile", true).inner(popup);
+    let inner = panel_block("Profile", true, ACCENT).inner(popup);
     user_profile_popup_has_avatar_inside(inner, has_avatar_url)
 }
 
@@ -120,7 +128,7 @@ pub(in crate::tui::ui) fn user_profile_popup_text_geometry(
     has_avatar: bool,
 ) -> (u16, u16) {
     let popup = user_profile_popup_area(area);
-    let inner = panel_block("Profile", true).inner(popup);
+    let inner = panel_block("Profile", true, ACCENT).inner(popup);
     let text_area = user_profile_popup_text_area_inside(inner, has_avatar);
     (text_area.width, text_area.height)
 }
@@ -151,7 +159,7 @@ fn user_profile_popup_text_for_render(
         UserProfilePopupText {
             lines: vec![Line::from(Span::styled(
                 "Loading profile...",
-                Style::default().fg(DIM),
+                Style::default().fg(state.theme().dim),
             ))],
             emoji_overlays: Vec::new(),
         }
@@ -199,6 +207,8 @@ pub(in crate::tui::ui) fn user_profile_popup_text(
     activities: &[ActivityInfo],
     emoji_images: &[EmojiImage<'_>],
 ) -> UserProfilePopupText {
+    let accent = state.theme().accent;
+    let dim = state.theme().dim;
     let is_self = state.current_user_id() == Some(profile.user_id);
 
     let inner_width = usize::from(width.max(8));
@@ -207,22 +217,22 @@ pub(in crate::tui::ui) fn user_profile_popup_text(
     let display_name = profile.display_name().to_owned();
     lines.push(Line::from(Span::styled(
         truncate_display_width(&display_name, inner_width),
-        user_profile_display_name_style(status),
+        user_profile_display_name_style(state.theme().presence_color(status)),
     )));
     lines.push(Line::from(Span::styled(
         truncate_display_width(&format!("@{}", profile.username), inner_width),
-        Style::default().fg(DIM),
+        Style::default().fg(dim),
     )));
 
     if let Some(pronouns) = profile.pronouns.as_deref() {
         lines.push(Line::from(Span::styled(
             truncate_display_width(pronouns, inner_width),
-            Style::default().fg(DIM),
+            Style::default().fg(dim),
         )));
     }
 
     if !is_self {
-        let (badge_label, badge_color) = friend_status_badge(profile.friend_status);
+        let (badge_label, badge_color) = friend_status_badge(profile.friend_status, dim);
         lines.push(Line::from(Span::styled(
             badge_label,
             Style::default()
@@ -234,7 +244,7 @@ pub(in crate::tui::ui) fn user_profile_popup_text(
     let mut emoji_overlays: Vec<(usize, String)> = Vec::new();
     if !activities.is_empty() {
         lines.push(Line::from(Span::raw(String::new())));
-        push_section_header(&mut lines, "ACTIVITY");
+        push_section_header(&mut lines, "ACTIVITY", accent);
         let mut sorted_activities: Vec<&ActivityInfo> = activities.iter().collect();
         sorted_activities.sort_by_key(|a| activity_priority(a.kind));
         let mut first = true;
@@ -249,12 +259,13 @@ pub(in crate::tui::ui) fn user_profile_popup_text(
                 activity,
                 inner_width,
                 emoji_images,
+                dim,
             );
         }
     }
 
     lines.push(Line::from(Span::raw(String::new())));
-    push_section_header(&mut lines, "ABOUT ME");
+    push_section_header(&mut lines, "ABOUT ME", accent);
     push_wrapped_paragraph(
         &mut lines,
         profile
@@ -266,7 +277,7 @@ pub(in crate::tui::ui) fn user_profile_popup_text(
     );
 
     lines.push(Line::from(Span::raw(String::new())));
-    push_section_header(&mut lines, "NOTE");
+    push_section_header(&mut lines, "NOTE", accent);
     push_wrapped_paragraph(
         &mut lines,
         profile
@@ -282,11 +293,12 @@ pub(in crate::tui::ui) fn user_profile_popup_text(
         push_section_header(
             &mut lines,
             &format!("MUTUAL SERVERS ({})", profile.mutual_guilds.len()),
+            accent,
         );
         if profile.mutual_guilds.is_empty() {
             lines.push(Line::from(Span::styled(
                 "  (none)".to_owned(),
-                Style::default().fg(DIM),
+                Style::default().fg(dim),
             )));
         } else {
             for entry in &profile.mutual_guilds {
@@ -299,7 +311,7 @@ pub(in crate::tui::ui) fn user_profile_popup_text(
                     None => format!("• {name}"),
                 };
                 lines.push(Line::from(vec![
-                    Span::styled("  ".to_owned(), Style::default().fg(ACCENT)),
+                    Span::styled("  ".to_owned(), Style::default().fg(accent)),
                     Span::styled(
                         truncate_display_width(&body, inner_width.saturating_sub(2)),
                         Style::default(),
@@ -314,6 +326,7 @@ pub(in crate::tui::ui) fn user_profile_popup_text(
         push_section_header(
             &mut lines,
             &format!("MUTUAL FRIENDS ({})", profile.mutual_friends_count),
+            accent,
         );
     }
 
@@ -323,26 +336,24 @@ pub(in crate::tui::ui) fn user_profile_popup_text(
     }
 }
 
-pub(in crate::tui::ui) fn user_profile_display_name_style(status: PresenceStatus) -> Style {
-    Style::default()
-        .fg(presence_color(status))
-        .add_modifier(Modifier::BOLD)
+pub(in crate::tui::ui) fn user_profile_display_name_style(color: Color) -> Style {
+    Style::default().fg(color).add_modifier(Modifier::BOLD)
 }
 
-fn friend_status_badge(status: FriendStatus) -> (String, Color) {
+fn friend_status_badge(status: FriendStatus, dim: Color) -> (String, Color) {
     match status {
         FriendStatus::Friend => ("● Friend".to_owned(), Color::Green),
         FriendStatus::IncomingRequest => ("● Incoming friend request".to_owned(), Color::Yellow),
         FriendStatus::OutgoingRequest => ("● Outgoing friend request".to_owned(), Color::Yellow),
         FriendStatus::Blocked => ("● Blocked".to_owned(), Color::Red),
-        FriendStatus::None => ("● Not friends".to_owned(), DIM),
+        FriendStatus::None => ("● Not friends".to_owned(), dim),
     }
 }
 
-fn push_section_header(lines: &mut Vec<Line<'static>>, label: &str) {
+fn push_section_header(lines: &mut Vec<Line<'static>>, label: &str, accent: Color) {
     lines.push(Line::from(Span::styled(
         label.to_owned(),
-        Style::default().fg(ACCENT).add_modifier(Modifier::BOLD),
+        Style::default().fg(accent).add_modifier(Modifier::BOLD),
     )));
 }
 
@@ -352,6 +363,7 @@ fn push_activity_lines(
     activity: &ActivityInfo,
     width: usize,
     emoji_images: &[EmojiImage<'_>],
+    dim: Color,
 ) {
     let render = build_activity_render(activity, emoji_images, false);
     if !render.is_empty() {
@@ -365,7 +377,7 @@ fn push_activity_lines(
                     Span::raw("  "),
                     Span::styled(
                         truncate_display_width(&render.body, width.saturating_sub(2)),
-                        Style::default().fg(DIM),
+                        Style::default().fg(dim),
                     ),
                 ])
             }
@@ -374,12 +386,12 @@ fn push_activity_lines(
                 Span::raw(" "),
                 Span::styled(
                     truncate_display_width(&render.body, width.saturating_sub(2)),
-                    Style::default().fg(DIM),
+                    Style::default().fg(dim),
                 ),
             ]),
             ActivityLeading::None => Line::from(Span::styled(
                 truncate_display_width(&render.body, width),
-                Style::default().fg(DIM),
+                Style::default().fg(dim),
             )),
         };
         lines.push(line);
@@ -387,13 +399,13 @@ fn push_activity_lines(
     if let Some(secondary) = activity_secondary_line(activity) {
         lines.push(Line::from(Span::styled(
             truncate_display_width(&secondary, width),
-            Style::default().fg(DIM),
+            Style::default().fg(dim),
         )));
     }
     if let Some(tertiary) = activity_tertiary_line(activity) {
         lines.push(Line::from(Span::styled(
             truncate_display_width(&tertiary, width),
-            Style::default().fg(DIM),
+            Style::default().fg(dim),
         )));
     }
 }

--- a/src/tui/ui/popups/reactions.rs
+++ b/src/tui/ui/popups/reactions.rs
@@ -35,13 +35,13 @@ pub(in crate::tui::ui) fn render_emoji_reaction_picker(
         .iter()
         .map(|image| image.url.clone())
         .collect::<Vec<_>>();
-    let block = panel_block("Choose reaction", true);
+    let block = panel_block("Choose reaction", true, state.theme().accent);
     let content = block.inner(popup);
     let filter_lines = u16::from(filter.is_some());
     let visible_items =
         usize::from(content.height.saturating_sub(filter_lines)).min(desired_visible_items);
     let visible_range = selection::visible_item_range(reactions.len(), selected, visible_items);
-    frame.render_widget(Clear, popup);
+    frame.render_widget(bg_clear(state.theme().background), popup);
     frame.render_widget(
         Paragraph::new(emoji_reaction_picker_lines_with_custom_emoji_images(
             reactions,
@@ -51,6 +51,7 @@ pub(in crate::tui::ui) fn render_emoji_reaction_picker(
             state.show_custom_emoji(),
             filter,
             usize::from(content.width),
+            &RenderCtx::new(state.theme()),
         ))
         .block(block)
         .wrap(Wrap { trim: false }),
@@ -66,6 +67,7 @@ pub(in crate::tui::ui) fn render_emoji_reaction_picker(
             emoji_images,
         );
     }
+    let ctx = RenderCtx::new(state.theme());
     render_vertical_scrollbar(
         frame,
         Rect {
@@ -75,6 +77,7 @@ pub(in crate::tui::ui) fn render_emoji_reaction_picker(
         visible_range.start,
         visible_items,
         reactions.len(),
+        &ctx,
     );
 }
 
@@ -95,6 +98,7 @@ pub(in crate::tui::ui) fn render_reaction_users_popup(
     let popup_width = POPUP_TARGET_WIDTH.min(area.width.saturating_sub(2)).max(1);
     let inner_width = usize::from(popup_width.saturating_sub(2));
 
+    let ctx = RenderCtx::new(state.theme());
     let max_visible_lines = reaction_users_visible_line_count(area);
     let lines = reaction_users_popup_lines_with_custom_emoji_images(
         popup_state.reactions(),
@@ -102,15 +106,16 @@ pub(in crate::tui::ui) fn render_reaction_users_popup(
         max_visible_lines,
         inner_width,
         state.show_custom_emoji(),
+        &ctx,
     );
     let popup = centered_rect(
         area,
         POPUP_TARGET_WIDTH,
         (lines.len() as u16).saturating_add(2),
     );
-    frame.render_widget(Clear, popup);
+    frame.render_widget(bg_clear(state.theme().background), popup);
     frame.render_widget(
-        Paragraph::new(lines).block(panel_block("Reacted users", true)),
+        Paragraph::new(lines).block(panel_block("Reacted users", true, state.theme().accent)),
         popup,
     );
     render_vertical_scrollbar(
@@ -122,6 +127,7 @@ pub(in crate::tui::ui) fn render_reaction_users_popup(
         popup_state.scroll(),
         max_visible_lines,
         popup_state.data_line_count(),
+        &ctx,
     );
 }
 
@@ -132,12 +138,15 @@ pub(in crate::tui::ui) fn reaction_users_popup_lines(
     max_visible_lines: usize,
     inner_width: usize,
 ) -> Vec<Line<'static>> {
+    let scheme = crate::tui::theme::ColorScheme::default();
+    let ctx = RenderCtx::new(&scheme);
     reaction_users_popup_lines_with_custom_emoji_images(
         reactions,
         scroll,
         max_visible_lines,
         inner_width,
         true,
+        &ctx,
     )
 }
 
@@ -147,8 +156,9 @@ fn reaction_users_popup_lines_with_custom_emoji_images(
     max_visible_lines: usize,
     inner_width: usize,
     show_custom_emoji: bool,
+    ctx: &RenderCtx<'_>,
 ) -> Vec<Line<'static>> {
-    let data_lines = reaction_users_popup_data_lines(reactions, show_custom_emoji);
+    let data_lines = reaction_users_popup_data_lines(reactions, show_custom_emoji, ctx);
     let visible_lines = max_visible_lines.min(data_lines.len());
     let scroll = scroll.min(data_lines.len().saturating_sub(visible_lines));
     data_lines
@@ -162,12 +172,13 @@ fn reaction_users_popup_lines_with_custom_emoji_images(
 fn reaction_users_popup_data_lines(
     reactions: &[ReactionUsersInfo],
     show_custom_emoji: bool,
+    ctx: &RenderCtx<'_>,
 ) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
     if reactions.is_empty() {
         lines.push(Line::from(Span::styled(
             "No reactions found",
-            Style::default().fg(DIM),
+            Style::default().fg(ctx.theme.dim),
         )));
     }
 
@@ -179,12 +190,14 @@ fn reaction_users_popup_data_lines(
                 "{} · {count} {user_label}",
                 reaction_emoji_label(&reaction.emoji, show_custom_emoji)
             ),
-            Style::default().fg(ACCENT).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(ctx.theme.accent)
+                .add_modifier(Modifier::BOLD),
         )));
         if reaction.users.is_empty() {
             lines.push(Line::from(Span::styled(
                 "  no users found",
-                Style::default().fg(DIM),
+                Style::default().fg(ctx.theme.dim),
             )));
         } else {
             lines.extend(
@@ -214,6 +227,8 @@ pub(in crate::tui::ui) fn emoji_reaction_picker_lines(
     max_visible_items: usize,
     thumbnail_urls: &[String],
 ) -> Vec<Line<'static>> {
+    let scheme = crate::tui::theme::ColorScheme::default();
+    let ctx = RenderCtx::new(&scheme);
     emoji_reaction_picker_lines_with_custom_emoji_images(
         reactions,
         selected,
@@ -222,6 +237,7 @@ pub(in crate::tui::ui) fn emoji_reaction_picker_lines(
         true,
         None,
         usize::MAX,
+        &ctx,
     )
 }
 
@@ -233,6 +249,8 @@ pub(in crate::tui::ui) fn emoji_reaction_picker_lines_for_width(
     thumbnail_urls: &[String],
     width: usize,
 ) -> Vec<Line<'static>> {
+    let scheme = crate::tui::theme::ColorScheme::default();
+    let ctx = RenderCtx::new(&scheme);
     emoji_reaction_picker_lines_with_custom_emoji_images(
         reactions,
         selected,
@@ -241,6 +259,7 @@ pub(in crate::tui::ui) fn emoji_reaction_picker_lines_for_width(
         true,
         None,
         width,
+        &ctx,
     )
 }
 
@@ -252,6 +271,8 @@ pub(in crate::tui::ui) fn filtered_emoji_reaction_picker_lines(
     thumbnail_urls: &[String],
     filter: &str,
 ) -> Vec<Line<'static>> {
+    let scheme = crate::tui::theme::ColorScheme::default();
+    let ctx = RenderCtx::new(&scheme);
     emoji_reaction_picker_lines_with_custom_emoji_images(
         reactions,
         selected,
@@ -260,9 +281,11 @@ pub(in crate::tui::ui) fn filtered_emoji_reaction_picker_lines(
         true,
         Some(filter),
         usize::MAX,
+        &ctx,
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn emoji_reaction_picker_lines_with_custom_emoji_images(
     reactions: &[EmojiReactionItem],
     selected: usize,
@@ -271,6 +294,7 @@ fn emoji_reaction_picker_lines_with_custom_emoji_images(
     show_custom_emoji: bool,
     filter: Option<&str>,
     max_width: usize,
+    ctx: &RenderCtx<'_>,
 ) -> Vec<Line<'static>> {
     let selected = selected.min(reactions.len().saturating_sub(1));
     let visible_items = max_visible_items.max(1).min(reactions.len().max(1));
@@ -294,8 +318,8 @@ fn emoji_reaction_picker_lines_with_custom_emoji_images(
                     .custom_image_url()
                     .is_some_and(|url| thumbnail_urls.iter().any(|ready| ready == &url));
             Line::from(vec![
-                Span::styled(marker, Style::default().fg(ACCENT)),
-                Span::styled(shortcut, Style::default().fg(DIM)),
+                Span::styled(marker, Style::default().fg(ctx.theme.accent)),
+                Span::styled(shortcut, Style::default().fg(ctx.theme.dim)),
                 Span::styled(
                     format_emoji_reaction_item(reaction, thumbnail_ready, show_custom_emoji),
                     style,
@@ -307,16 +331,18 @@ fn emoji_reaction_picker_lines_with_custom_emoji_images(
     if reactions.is_empty() {
         lines.push(Line::from(Span::styled(
             "  no matching reactions",
-            Style::default().fg(DIM),
+            Style::default().fg(ctx.theme.dim),
         )));
     }
 
     if let Some(filter) = filter {
         lines.push(Line::from(vec![
-            Span::styled("Filter ", Style::default().fg(DIM)),
+            Span::styled("Filter ", Style::default().fg(ctx.theme.dim)),
             Span::styled(
                 format!("/{filter}"),
-                Style::default().fg(ACCENT).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(ctx.theme.accent)
+                    .add_modifier(Modifier::BOLD),
             ),
         ]));
     }

--- a/src/tui/ui/tests.rs
+++ b/src/tui/ui/tests.rs
@@ -11,12 +11,11 @@ use unicode_width::UnicodeWidthStr;
 
 use super::{
     ACCENT, DIM, ImagePreview, ImagePreviewState, MENTION_ORANGE, MemberEntry, READ_DIM,
-    SELECTED_FORUM_POST_BORDER, SELECTED_MESSAGE_BORDER, UNREAD_BRIGHT,
-    channel_switcher_cursor_position, channel_switcher_lines, channel_unread_decoration,
-    composer_content_line_count, composer_cursor_position, composer_lines,
-    composer_lines_with_loaded_custom_emoji_urls, composer_prompt_line_count, composer_text,
-    date_separator_line, debug_log_popup_lines, dm_presence_dot_span, emoji_picker_lines,
-    emoji_reaction_picker_lines, emoji_reaction_picker_lines_for_width,
+    UNREAD_BRIGHT, channel_switcher_cursor_position, channel_switcher_lines,
+    channel_unread_decoration, composer_content_line_count, composer_cursor_position,
+    composer_lines, composer_lines_with_loaded_custom_emoji_urls, composer_prompt_line_count,
+    composer_text, date_separator_line, debug_log_popup_lines, dm_presence_dot_span,
+    emoji_picker_lines, emoji_reaction_picker_lines, emoji_reaction_picker_lines_for_width,
     filtered_emoji_reaction_picker_lines, focus_pane_at, format_message_sent_time,
     forum_post_reaction_summary, forum_post_scrollbar_visible_count, forum_post_viewport_lines,
     inline_image_preview_area, inline_image_preview_row, member_display_label, member_name_style,
@@ -32,6 +31,8 @@ use crate::tui::message_time::{
     discord_epoch_unix_millis, format_unix_millis_with_offset, message_starts_new_day,
     test_message_id_for_unix_millis,
 };
+use crate::tui::theme::ColorScheme;
+use crate::tui::ui::types::RenderCtx;
 use crate::{
     config::DisplayOptions,
     discord::{
@@ -86,7 +87,13 @@ fn options_popup_lines_show_selected_toggle_state() {
         },
     ];
 
-    let lines = options_popup_lines(&items, 1, items.len(), 120);
+    let lines = options_popup_lines(
+        &items,
+        1,
+        items.len(),
+        120,
+        &RenderCtx::new(&ColorScheme::default()),
+    );
 
     assert_eq!(lines[0].spans[1].content, "[ ] ");
     assert_eq!(lines[1].spans[0].content, "› ");
@@ -128,7 +135,7 @@ fn options_popup_lines_keep_selected_item_visible_when_clipped() {
         },
     ];
 
-    let lines = options_popup_lines(&items, 3, 2, 120);
+    let lines = options_popup_lines(&items, 3, 2, 120, &RenderCtx::new(&ColorScheme::default()));
     let rendered = line_texts_from_ratatui(&lines).join("\n");
 
     assert!(!rendered.contains("Option 1"), "{rendered}");
@@ -258,7 +265,15 @@ fn channel_switcher_lines_show_search_and_grouped_selection() {
         },
     ];
 
-    let lines = channel_switcher_lines(&items, 1, "gen", "gen".len(), 10, 40);
+    let lines = channel_switcher_lines(
+        &items,
+        1,
+        "gen",
+        "gen".len(),
+        10,
+        40,
+        &RenderCtx::new(&ColorScheme::default()),
+    );
 
     assert_eq!(lines[0].spans[0].content, "🔎 ");
     assert_eq!(lines[0].spans[1].content, "gen");
@@ -298,7 +313,15 @@ fn channel_switcher_lines_show_unread_badges_like_channel_pane() {
         original_index: 0,
     }];
 
-    let lines = channel_switcher_lines(&items, 0, "", 0, 10, 40);
+    let lines = channel_switcher_lines(
+        &items,
+        0,
+        "",
+        0,
+        10,
+        40,
+        &RenderCtx::new(&ColorScheme::default()),
+    );
 
     assert!(
         lines
@@ -324,7 +347,15 @@ fn selected_channel_switcher_unread_row_keeps_highlight() {
         original_index: 0,
     }];
 
-    let lines = channel_switcher_lines(&items, 0, "", 0, 10, 40);
+    let lines = channel_switcher_lines(
+        &items,
+        0,
+        "",
+        0,
+        10,
+        40,
+        &RenderCtx::new(&ColorScheme::default()),
+    );
     let item_line = lines
         .iter()
         .find(|line| line.to_string().contains("#alerts"))
@@ -357,7 +388,15 @@ fn channel_switcher_cursor_position_tracks_query_cursor() {
 fn channel_switcher_search_line_windows_long_query_around_cursor() {
     let query = "abcdefghijklmnopqrstuvwxyz";
 
-    let lines = channel_switcher_lines(&[], 0, query, query.len(), 10, 12);
+    let lines = channel_switcher_lines(
+        &[],
+        0,
+        query,
+        query.len(),
+        10,
+        12,
+        &RenderCtx::new(&ColorScheme::default()),
+    );
     let rendered = lines[0].to_string();
 
     assert!(rendered.contains("uvwxyz"));
@@ -756,6 +795,7 @@ fn emoji_picker_lines_cross_out_unavailable_custom_emoji() {
             "https://cdn.discordapp.com/emojis/50.png".to_owned(),
         ],
         true,
+        &RenderCtx::new(&ColorScheme::default()),
     );
 
     assert!(
@@ -860,7 +900,8 @@ fn dashboard_renders_scrollbar_for_overflowing_composer_pickers() {
 fn one_to_one_dm_carries_presence_in_dot() {
     let channel = channel_with_recipients("dm", &[PresenceStatus::DoNotDisturb]);
 
-    let dot = dm_presence_dot_span(&channel).expect("1-on-1 DM should produce a presence dot");
+    let dot = dm_presence_dot_span(&channel, &RenderCtx::new(&ColorScheme::default()))
+        .expect("1-on-1 DM should produce a presence dot");
     assert_eq!(dot.content.as_ref(), "● ");
     assert_eq!(dot.style.fg, Some(Color::Red));
 }
@@ -886,7 +927,12 @@ fn channel_unread_decoration_matches_unread_state() {
     ];
 
     for (unread, expected_badge, expected_fg, expect_bold) in cases {
-        let (badge, style) = channel_unread_decoration(unread, base, false);
+        let (badge, style) = channel_unread_decoration(
+            unread,
+            base,
+            false,
+            &RenderCtx::new(&ColorScheme::default()),
+        );
         match expected_badge {
             Some((content, color)) => {
                 let badge = badge.expect("unread state should include a count badge");
@@ -906,8 +952,12 @@ fn channel_unread_decoration_matches_unread_state() {
     let active_base = Style::default()
         .fg(Color::Green)
         .add_modifier(Modifier::BOLD);
-    let (badge, style) =
-        channel_unread_decoration(ChannelUnreadState::Mentioned(2), active_base, true);
+    let (badge, style) = channel_unread_decoration(
+        ChannelUnreadState::Mentioned(2),
+        active_base,
+        true,
+        &RenderCtx::new(&ColorScheme::default()),
+    );
     assert!(badge.is_none());
     assert_eq!(style, active_base);
 }
@@ -1488,8 +1538,14 @@ fn forum_post_lines_render_title_author_and_preview() {
     assert_eq!(lines[4].spans[2].style.fg, Some(Color::White));
     assert_eq!(lines[4].spans[4].style.fg, Some(Color::Yellow));
     assert_eq!(lines[4].spans[6].style.fg, Some(Color::White));
-    assert_eq!(lines[1].spans[1].style.fg, Some(SELECTED_FORUM_POST_BORDER));
-    assert_eq!(lines[2].spans[1].style.fg, Some(SELECTED_FORUM_POST_BORDER));
+    assert_eq!(
+        lines[1].spans[1].style.fg,
+        Some(ColorScheme::default().selection_border)
+    );
+    assert_eq!(
+        lines[2].spans[1].style.fg,
+        Some(ColorScheme::default().selection_border)
+    );
     assert!(
         lines
             .iter()
@@ -1850,7 +1906,8 @@ fn offline_like_dm_status_uses_empty_dim_presence_marker() {
     for status in [PresenceStatus::Offline, PresenceStatus::Unknown] {
         let channel = channel_with_recipients("dm", &[status]);
 
-        let dot = dm_presence_dot_span(&channel).expect("DM should still produce a dot");
+        let dot = dm_presence_dot_span(&channel, &RenderCtx::new(&ColorScheme::default()))
+            .expect("DM should still produce a dot");
         assert_eq!(dot.content.as_ref(), "○ ");
         assert_eq!(dot.style.fg, Some(Color::DarkGray));
     }
@@ -1863,7 +1920,7 @@ fn group_dm_has_no_presence_dot() {
         &[PresenceStatus::Online, PresenceStatus::DoNotDisturb],
     );
 
-    assert!(dm_presence_dot_span(&channel).is_none());
+    assert!(dm_presence_dot_span(&channel, &RenderCtx::new(&ColorScheme::default())).is_none());
 }
 
 #[test]
@@ -2641,6 +2698,7 @@ fn thread_starter_message_uses_referenced_message_card() {
     let mut message = message_with_content(Some(String::new()));
     message.message_kind = MessageKind::new(21);
     message.reply = Some(ReplyInfo {
+        author_id: None,
         author: "alice".to_owned(),
         content: Some("original topic".to_owned()),
         sticker_names: Vec::new(),
@@ -2690,6 +2748,7 @@ fn reply_message_uses_preview_instead_of_type_label() {
     let mut message = message_with_attachment(Some("message body".to_owned()), image_attachment());
     message.message_kind = MessageKind::new(19);
     message.reply = Some(ReplyInfo {
+        author_id: None,
         author: "casey".to_owned(),
         content: Some("looks good".to_owned()),
         sticker_names: Vec::new(),
@@ -2714,6 +2773,7 @@ fn reply_preview_renders_known_user_mentions() {
     let mut message = message_with_content(Some("asdf".to_owned()));
     message.message_kind = MessageKind::new(19);
     message.reply = Some(ReplyInfo {
+        author_id: None,
         author: "neo".to_owned(),
         content: Some("hello <@10>".to_owned()),
         sticker_names: Vec::new(),
@@ -2731,6 +2791,7 @@ fn reply_preview_renders_mentions_from_reply_metadata() {
     let mut message = message_with_content(Some("asdf".to_owned()));
     message.message_kind = MessageKind::new(19);
     message.reply = Some(ReplyInfo {
+        author_id: None,
         author: "neo".to_owned(),
         content: Some("hello <@10>".to_owned()),
         sticker_names: Vec::new(),
@@ -2942,7 +3003,7 @@ fn message_action_menu_marks_selected_and_disabled_actions() {
         },
     ];
 
-    let lines = message_action_menu_lines(&actions, 1);
+    let lines = message_action_menu_lines(&actions, 1, &RenderCtx::new(&ColorScheme::default()));
 
     assert_eq!(
         line_texts_from_ratatui(&lines),
@@ -2965,7 +3026,7 @@ fn message_action_menu_uses_numbered_shortcuts_for_duplicate_preferred_keys() {
         },
     ];
 
-    let lines = message_action_menu_lines(&actions, 0);
+    let lines = message_action_menu_lines(&actions, 0, &RenderCtx::new(&ColorScheme::default()));
 
     assert_eq!(
         line_texts_from_ratatui(&lines),
@@ -3013,7 +3074,7 @@ fn poll_vote_picker_marks_selected_and_checked_answers() {
         },
     ];
 
-    let lines = poll_vote_picker_lines(&answers, 1);
+    let lines = poll_vote_picker_lines(&answers, 1, &RenderCtx::new(&ColorScheme::default()));
 
     assert_eq!(
         line_texts_from_ratatui(&lines),
@@ -3447,6 +3508,7 @@ fn debug_log_popup_shows_recent_errors() {
         },
         1,
         80,
+        &RenderCtx::new(&ColorScheme::default()),
     );
 
     assert_eq!(
@@ -3461,7 +3523,13 @@ fn debug_log_popup_shows_recent_errors() {
 
 #[test]
 fn debug_log_popup_has_empty_state() {
-    let lines = debug_log_popup_lines(Vec::new(), ChannelVisibilityStats::default(), 5, 80);
+    let lines = debug_log_popup_lines(
+        Vec::new(),
+        ChannelVisibilityStats::default(),
+        5,
+        80,
+        &RenderCtx::new(&ColorScheme::default()),
+    );
 
     assert_eq!(
         line_texts_from_ratatui(&lines),
@@ -3480,6 +3548,7 @@ fn debug_log_popup_wraps_long_detail_lines() {
             ChannelVisibilityStats::default(),
             4,
             44,
+            &RenderCtx::new(&ColorScheme::default()),
         );
     let texts = line_texts_from_ratatui(&lines);
     let joined = texts.join("");
@@ -3982,7 +4051,7 @@ fn member_label_truncates_by_display_width() {
         status: PresenceStatus::Online,
     };
 
-    let label = member_display_label(MemberEntry::Guild(&member), 0, 12);
+    let label = member_display_label(MemberEntry::Guild(&member), &member.display_name, 0, 12);
 
     assert_eq!(label, "漢字仮名...");
     assert!(label.width() <= 12);
@@ -4023,7 +4092,7 @@ fn member_label_uses_horizontal_scroll_offset() {
         status: PresenceStatus::Online,
     };
 
-    let label = member_display_label(MemberEntry::Guild(&member), 5, 8);
+    let label = member_display_label(MemberEntry::Guild(&member), &member.display_name, 5, 8);
 
     assert_eq!(label, "membe...");
 }
@@ -4156,7 +4225,7 @@ fn date_separator_appears_when_local_date_changes() {
 #[test]
 fn date_separator_line_centers_label_within_full_width() {
     let id = test_message_id_for_unix_millis(1_743_508_800_000); // arbitrary timestamp
-    let line = date_separator_line(id, 30);
+    let line = date_separator_line(id, 30, ColorScheme::default().dim);
     let text = line
         .spans
         .iter()
@@ -4173,7 +4242,7 @@ fn date_separator_line_centers_label_within_full_width() {
 
 #[test]
 fn new_messages_notice_line_centers_count_within_full_width() {
-    let line = new_messages_notice_line(3, 30);
+    let line = new_messages_notice_line(3, 30, ColorScheme::default().accent);
     let text = line
         .spans
         .iter()
@@ -4324,8 +4393,14 @@ fn selected_author_group_keeps_avatar_body_inside_border() {
     assert!(texts[1].ends_with(" │"));
     assert!(texts[2].starts_with("╰"));
     assert!(texts[2].ends_with("╯"));
-    assert_eq!(lines[0].spans[0].style.fg, Some(SELECTED_MESSAGE_BORDER));
-    assert_eq!(lines[1].spans[0].style.fg, Some(SELECTED_MESSAGE_BORDER));
+    assert_eq!(
+        lines[0].spans[0].style.fg,
+        Some(ColorScheme::default().selection_border)
+    );
+    assert_eq!(
+        lines[1].spans[0].style.fg,
+        Some(ColorScheme::default().selection_border)
+    );
     assert!(
         lines[1].spans[0]
             .style

--- a/src/tui/ui/types.rs
+++ b/src/tui/ui/types.rs
@@ -2,10 +2,21 @@ use ratatui::{layout::Rect, style::Color, text::Line};
 use ratatui_image::protocol::{Protocol, StatefulProtocol};
 
 use super::super::state::FocusPane;
+use super::super::theme::ColorScheme;
+
+pub(super) struct RenderCtx<'a> {
+    pub(super) theme: &'a ColorScheme,
+}
+
+impl<'a> RenderCtx<'a> {
+    pub(super) fn new(theme: &'a ColorScheme) -> Self {
+        Self { theme }
+    }
+}
 
 pub(super) const ACCENT: Color = Color::Cyan;
+#[allow(dead_code)]
 pub(super) const DIM: Color = Color::DarkGray;
-pub(super) const SCROLLBAR_THUMB: Color = Color::Rgb(170, 170, 170);
 pub(super) const MIN_MESSAGE_INPUT_HEIGHT: u16 = 3;
 pub(super) const IMAGE_PREVIEW_HEIGHT: u16 = 10;
 pub(super) const IMAGE_PREVIEW_WIDTH: u16 = 72;
@@ -17,8 +28,6 @@ pub(super) const EMBED_PREVIEW_GUTTER_PREFIX: &str = "  ▎ ";
 pub(super) const MAX_REACTION_USERS_VISIBLE_LINES: usize = 14;
 pub(super) const IMAGE_VIEWER_POPUP_WIDTH: u16 = 78;
 pub(super) const IMAGE_VIEWER_POPUP_HEIGHT: u16 = 16;
-pub(super) const SELECTED_FORUM_POST_BORDER: Color = Color::Green;
-pub(super) const SELECTED_MESSAGE_BORDER: Color = Color::Green;
 
 pub struct ImagePreview<'a> {
     pub viewer: bool,


### PR DESCRIPTION
Introduces a ColorScheme struct derived from config.toml's [theme] section, replacing all hardcoded ACCENT/DIM/selection-border constants throughout the TUI. All 18 theme fields (accent, dim, selection_border, presence colors, mention colors, self_reaction, folder_default, etc.) are now threaded through every render path so user-configured colors apply everywhere.

Also, somehow (fix: usernames (#60) is here ( I think I did something wrong). This was a large and tedious commit.


This was a terrible thing to do. It took so long.  Example:

```toml
  [theme]
  background      = "#000000"  # terminal default (Color::Reset if unset)
  accent          = "#00ffff"  # cyan
  dim             = "#555555"  # dark gray
  scrollbar_thumb = "#aaaaaa"
  selection_border = "#00ff00"  # green
  mention_badge   = "#ffa500"  # orange
  channel_read    = "#828282"
  channel_unread  = "#ffffff"
  self_reaction   = "#ffff00"  # yellow
  self_mention_bg = "#5c4c23"
  self_mention_fg = "#ffff00"  # yellow
  other_mention_bg = "#28325c"
  other_mention_fg = "#c1cef7"
  presence_online  = "#00ff00"  # green
  presence_idle    = "#b48c00"
  presence_dnd     = "#ff0000"  # red
  presence_offline = "#555555"  # dark gray
  folder_default   = "#00ffff"  # cyan
 
 ```