### PR TITLE
feat: add support for detecting links in messages and opening them in the default browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.2] - 2026-05-16
+
+### Bug Fixes
+
+- _(search)_ Improve fuzzy search logic (#74) in [#74](https://github.com/chojs23/concord/pull/74) by @80avin
+
+### Miscellaneous Tasks
+
+- Remove temp diagnostic by @chojs23
+
+### Performance
+
+- Cache avatar render protocols by clipping and size to avoid per-frame re-encoding by @chojs23
+- Cache message content row metrics to reduce repeated per-frame formatting by @chojs23
+- Reduce channel upsert UI repair work by @chojs23
+
+### New Contributors
+
+- @80avin made their first contribution in [#74](https://github.com/chojs23/concord/pull/74)
+
 ## [1.4.1] - 2026-05-15
 
 ### Bug Fixes
@@ -65,10 +85,10 @@ All notable changes to this project will be documented in this file.
 - Remove redundant preview preset by @chojs23
 - Refactor keyboard shortcuts by @chojs23
 
-
 ### New Contributors
 
 - @SeniorMars made their first contribution in [#57](https://github.com/chojs23/concord/pull/57)
+
 ## [1.3.3] - 2026-05-13
 
 ### Bug Fixes
@@ -93,10 +113,10 @@ All notable changes to this project will be documented in this file.
 - Split tui modules by @chojs23
 - Gateway parser and TUI popup modules by @chojs23
 
-
 ### New Contributors
 
 - @AnalogCyan made their first contribution in [#50](https://github.com/chojs23/concord/pull/50)
+
 ## [1.3.2] - 2026-05-12
 
 ### Bug Fixes
@@ -123,7 +143,7 @@ All notable changes to this project will be documented in this file.
 
 ### Refactor
 
-- *(tui)* Remove footer and popup hints (#43) in [#43](https://github.com/chojs23/concord/pull/43) by @chojs23
+- _(tui)_ Remove footer and popup hints (#43) in [#43](https://github.com/chojs23/concord/pull/43) by @chojs23
 - Refactor activity rendering with typed ActivityRender struct (#44) in [#44](https://github.com/chojs23/concord/pull/44) by @chojs23
 - Change broken dash by @chojs23
 
@@ -131,11 +151,11 @@ All notable changes to this project will be documented in this file.
 
 - Rename leader action state and add context-specific action titles by @chojs23
 
-
 ### New Contributors
 
 - @amiralimollaei made their first contribution in [#49](https://github.com/chojs23/concord/pull/49)
 - @kimjune01 made their first contribution in [#45](https://github.com/chojs23/concord/pull/45)
+
 ## [1.3.1] - 2026-05-11
 
 ### Bug Fixes
@@ -180,22 +200,22 @@ All notable changes to this project will be documented in this file.
 ### Features
 
 - Support resizing panes (#18) in [#18](https://github.com/chojs23/concord/pull/18) by @nexxai
-- *(composer)* Add CTRL+Left, CTRL+Right word skip (#15) in [#15](https://github.com/chojs23/concord/pull/15) by @TobyBridle
+- _(composer)_ Add CTRL+Left, CTRL+Right word skip (#15) in [#15](https://github.com/chojs23/concord/pull/15) by @TobyBridle
 - Add search to reaction picker + allow toggling of reactions (#19) in [#19](https://github.com/chojs23/concord/pull/19) by @nexxai
 - Add fuzzy score helper (#21) in [#21](https://github.com/chojs23/concord/pull/21) by @chojs23
 - Typo tolerant fuzzy (#22) in [#22](https://github.com/chojs23/concord/pull/22) by @chojs23
 
 ### Refactor
 
-- *(composer)* Use char-safe word boundary helpers (#20) in [#20](https://github.com/chojs23/concord/pull/20) by @chojs23
+- _(composer)_ Use char-safe word boundary helpers (#20) in [#20](https://github.com/chojs23/concord/pull/20) by @chojs23
 - Store app files under $XDG_CONFIG_HOME/concord (#23) in [#23](https://github.com/chojs23/concord/pull/23) by @chojs23
-
 
 ### New Contributors
 
 - @lisk77 made their first contribution in [#14](https://github.com/chojs23/concord/pull/14)
 - @nexxai made their first contribution in [#19](https://github.com/chojs23/concord/pull/19)
 - @TobyBridle made their first contribution in [#15](https://github.com/chojs23/concord/pull/15)
+
 ## [1.2.0] - 2026-05-09
 
 ### Documentation
@@ -255,7 +275,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
-- *(flake)* Use crane (#4) in [#4](https://github.com/chojs23/concord/pull/4) by @M4jor-Tom
+- _(flake)_ Use crane (#4) in [#4](https://github.com/chojs23/concord/pull/4) by @M4jor-Tom
 
 ### Documentation
 
@@ -271,10 +291,10 @@ All notable changes to this project will be documented in this file.
 
 - Enable generated github release notes by @chojs23
 
-
 ### New Contributors
 
 - @M4jor-Tom made their first contribution in [#4](https://github.com/chojs23/concord/pull/4)
+
 ## [1.0.3] - 2026-05-08
 
 ### Bug Fixes
@@ -600,9 +620,7 @@ All notable changes to this project will be documented in this file.
 
 - Add TUI and keychain dependencies by @chojs23
 
-
 ### New Contributors
 
 - @chojs23 made their first contribution
 - @vncsalencar made their first contribution
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,7 +574,7 @@ checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concord"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concord"
-version = "1.4.1"
+version = "1.4.2"
 edition = "2024"
 rust-version = "1.85"
 description = "A terminal user interface client for Discord"

--- a/src/discord/client.rs
+++ b/src/discord/client.rs
@@ -603,13 +603,35 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn channel_upsert_is_delivered_as_effect_for_tui_derived_state() {
+    async fn normal_channel_upsert_updates_snapshot_without_effect_delivery() {
         let _ = rustls::crypto::ring::default_provider().install_default();
         let client = DiscordClient::new("test-token".to_owned()).expect("token is valid header");
         let mut effects = client.take_effects();
         let mut snapshots = client.subscribe_snapshots();
 
         client.publish_event(channel_upsert_event()).await;
+
+        snapshots.changed().await.expect("snapshot is published");
+        let snapshot = *snapshots.borrow_and_update();
+
+        assert_eq!(snapshot.global, 1);
+        assert_eq!(snapshot.navigation, 1);
+        assert_eq!(snapshot.message, 1);
+        assert_eq!(snapshot.detail, 1);
+        assert!(matches!(
+            effects.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+        ));
+    }
+
+    #[tokio::test]
+    async fn thread_channel_upsert_is_delivered_as_effect_for_tui_derived_state() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let client = DiscordClient::new("test-token".to_owned()).expect("token is valid header");
+        let mut effects = client.take_effects();
+        let mut snapshots = client.subscribe_snapshots();
+
+        client.publish_event(thread_channel_upsert_event()).await;
 
         snapshots.changed().await.expect("snapshot is published");
         let snapshot = *snapshots.borrow_and_update();
@@ -718,14 +740,33 @@ mod tests {
         AppEvent::ChannelUpsert(ChannelInfo {
             guild_id: Some(Id::new(1)),
             channel_id: Id::new(2),
-            parent_id: None,
+            parent_id: Some(Id::new(10)),
             position: None,
             last_message_id: None,
             name: "general".to_owned(),
-            kind: "text".to_owned(),
+            kind: "GuildText".to_owned(),
             message_count: None,
             total_message_sent: None,
             thread_archived: None,
+            thread_locked: None,
+            thread_pinned: None,
+            recipients: None,
+            permission_overwrites: Vec::new(),
+        })
+    }
+
+    fn thread_channel_upsert_event() -> AppEvent {
+        AppEvent::ChannelUpsert(ChannelInfo {
+            guild_id: Some(Id::new(1)),
+            channel_id: Id::new(3),
+            parent_id: Some(Id::new(2)),
+            position: None,
+            last_message_id: None,
+            name: "new-thread".to_owned(),
+            kind: "GuildPublicThread".to_owned(),
+            message_count: None,
+            total_message_sent: None,
+            thread_archived: Some(false),
             thread_locked: None,
             thread_pinned: None,
             recipients: None,

--- a/src/discord/events.rs
+++ b/src/discord/events.rs
@@ -827,30 +827,38 @@ impl AppEvent {
     }
 
     pub fn needs_effect_delivery(&self) -> bool {
-        matches!(
-            self,
+        match self {
+            AppEvent::ChannelUpsert(channel) => channel_upsert_needs_effect_delivery(channel),
             AppEvent::MessageCreate { .. }
-                | AppEvent::ChannelUpsert(_)
-                | AppEvent::MessageHistoryLoaded { .. }
-                | AppEvent::MessageHistoryLoadFailed { .. }
-                | AppEvent::ThreadPreviewLoaded { .. }
-                | AppEvent::ThreadPreviewLoadFailed { .. }
-                | AppEvent::ForumPostsLoaded { .. }
-                | AppEvent::ForumPostsLoadFailed { .. }
-                | AppEvent::PinnedMessagesLoaded { .. }
-                | AppEvent::PinnedMessagesLoadFailed { .. }
-                | AppEvent::ReactionUsersLoaded { .. }
-                | AppEvent::GatewayError { .. }
-                | AppEvent::CurrentUserCapabilities { .. }
-                | AppEvent::AttachmentDownloadCompleted { .. }
-                | AppEvent::UpdateAvailable { .. }
-                | AppEvent::ActivateChannel { .. }
-                | AppEvent::AttachmentPreviewLoaded { .. }
-                | AppEvent::AttachmentPreviewLoadFailed { .. }
-                | AppEvent::UserProfileLoadFailed { .. }
-                | AppEvent::GatewayClosed
-        )
+            | AppEvent::MessageHistoryLoaded { .. }
+            | AppEvent::MessageHistoryLoadFailed { .. }
+            | AppEvent::ThreadPreviewLoaded { .. }
+            | AppEvent::ThreadPreviewLoadFailed { .. }
+            | AppEvent::ForumPostsLoaded { .. }
+            | AppEvent::ForumPostsLoadFailed { .. }
+            | AppEvent::PinnedMessagesLoaded { .. }
+            | AppEvent::PinnedMessagesLoadFailed { .. }
+            | AppEvent::ReactionUsersLoaded { .. }
+            | AppEvent::GatewayError { .. }
+            | AppEvent::CurrentUserCapabilities { .. }
+            | AppEvent::AttachmentDownloadCompleted { .. }
+            | AppEvent::UpdateAvailable { .. }
+            | AppEvent::ActivateChannel { .. }
+            | AppEvent::AttachmentPreviewLoaded { .. }
+            | AppEvent::AttachmentPreviewLoadFailed { .. }
+            | AppEvent::UserProfileLoadFailed { .. }
+            | AppEvent::GatewayClosed => true,
+            _ => false,
+        }
     }
+}
+
+fn channel_upsert_needs_effect_delivery(channel: &ChannelInfo) -> bool {
+    channel.parent_id.is_some()
+        && matches!(
+            channel.kind.as_str(),
+            "thread" | "GuildPublicThread" | "GuildPrivateThread" | "GuildNewsThread"
+        )
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]

--- a/src/discord/state/voice.rs
+++ b/src/discord/state/voice.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use crate::discord::VoiceStateInfo;
 use crate::discord::ids::{
     Id,
@@ -34,33 +36,54 @@ impl DiscordState {
         guild_id: Id<GuildMarker>,
         channel_id: Id<ChannelMarker>,
     ) -> Vec<VoiceParticipantState> {
-        let mut participants: Vec<VoiceParticipantState> = self
-            .voice
-            .states
-            .iter()
-            .filter(|((state_guild_id, _), state)| {
-                *state_guild_id == guild_id && state.channel_id == channel_id
-            })
-            .map(|(_, state)| VoiceParticipantState {
-                user_id: state.user_id,
-                display_name: self
-                    .member_display_name(guild_id, state.user_id)
-                    .map(str::to_owned)
-                    .unwrap_or_else(|| format!("user-{}", state.user_id.get())),
-                deaf: state.deaf,
-                mute: state.mute,
-                self_deaf: state.self_deaf,
-                self_mute: state.self_mute,
-                self_stream: state.self_stream,
-            })
-            .collect();
-        participants.sort_by(|left, right| {
-            left.display_name
-                .to_lowercase()
-                .cmp(&right.display_name.to_lowercase())
-                .then(left.user_id.cmp(&right.user_id))
-        });
+        let mut participants = Vec::new();
+        for ((state_guild_id, _), state) in &self.voice.states {
+            if *state_guild_id == guild_id && state.channel_id == channel_id {
+                participants.push(self.voice_participant_state(guild_id, state));
+            }
+        }
+        sort_voice_participants(&mut participants);
         participants
+    }
+
+    pub fn voice_participants_by_channel_for_guild(
+        &self,
+        guild_id: Id<GuildMarker>,
+    ) -> BTreeMap<Id<ChannelMarker>, Vec<VoiceParticipantState>> {
+        let mut participants_by_channel: BTreeMap<Id<ChannelMarker>, Vec<VoiceParticipantState>> =
+            BTreeMap::new();
+        for ((state_guild_id, _), state) in &self.voice.states {
+            if *state_guild_id != guild_id {
+                continue;
+            }
+            participants_by_channel
+                .entry(state.channel_id)
+                .or_default()
+                .push(self.voice_participant_state(guild_id, state));
+        }
+        for participants in participants_by_channel.values_mut() {
+            sort_voice_participants(participants);
+        }
+        participants_by_channel
+    }
+
+    fn voice_participant_state(
+        &self,
+        guild_id: Id<GuildMarker>,
+        state: &VoiceState,
+    ) -> VoiceParticipantState {
+        VoiceParticipantState {
+            user_id: state.user_id,
+            display_name: self
+                .member_display_name(guild_id, state.user_id)
+                .map(str::to_owned)
+                .unwrap_or_else(|| format!("user-{}", state.user_id.get())),
+            deaf: state.deaf,
+            mute: state.mute,
+            self_deaf: state.self_deaf,
+            self_mute: state.self_mute,
+            self_stream: state.self_stream,
+        }
     }
 
     pub(super) fn update_voice_state(&mut self, state: &VoiceStateInfo) {
@@ -102,4 +125,10 @@ impl DiscordState {
             .states
             .retain(|_, state| state.channel_id != channel_id);
     }
+}
+
+fn sort_voice_participants(participants: &mut [VoiceParticipantState]) {
+    participants.sort_by_cached_key(|participant| {
+        (participant.display_name.to_lowercase(), participant.user_id)
+    });
 }

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -6,7 +6,7 @@ use crate::{
     discord::{AppCommand, AppEvent},
 };
 
-use super::{input, redraw::RedrawDiagnostics, state::DashboardState};
+use super::{input, state::DashboardState};
 
 pub(super) struct TerminalEventOutcome {
     pub(super) dirty: bool,
@@ -18,7 +18,6 @@ pub(super) fn handle_terminal_event(
     event: TerminalEvent,
     last_frame_area: &mut Rect,
     mouse_clicks: &mut input::MouseClickTracker,
-    redraw_diagnostics: &mut RedrawDiagnostics,
 ) -> Result<TerminalEventOutcome> {
     let mut outcome = TerminalEventOutcome {
         dirty: false,
@@ -30,7 +29,6 @@ pub(super) fn handle_terminal_event(
             outcome.command = input::handle_key(state, key);
             if key.kind == KeyEventKind::Press {
                 save_display_options_if_needed(state);
-                redraw_diagnostics.key_presses = redraw_diagnostics.key_presses.saturating_add(1);
                 outcome.dirty = true;
             }
         }
@@ -39,13 +37,11 @@ pub(super) fn handle_terminal_event(
                 input::handle_mouse_event(state, mouse, *last_frame_area, mouse_clicks);
             outcome.command = mouse_outcome.command;
             if mouse_outcome.handled {
-                redraw_diagnostics.mouse_events = redraw_diagnostics.mouse_events.saturating_add(1);
                 outcome.dirty = true;
             }
         }
         TerminalEvent::Resize(width, height) => {
             *last_frame_area = Rect::new(0, 0, width, height);
-            redraw_diagnostics.resizes = redraw_diagnostics.resizes.saturating_add(1);
             outcome.dirty = true;
         }
         TerminalEvent::Paste(text) if input::handle_paste(state, &text) => {

--- a/src/tui/format.rs
+++ b/src/tui/format.rs
@@ -72,6 +72,45 @@ pub fn sanitize_for_display_width(value: &str) -> String {
     out
 }
 
+pub(crate) fn detected_url_ranges(value: &str) -> Vec<(usize, usize)> {
+    let mut ranges = Vec::new();
+    let mut cursor = 0usize;
+
+    while let Some(start) = next_url_start(value, cursor) {
+        let mut end = value.len();
+        for (relative_index, ch) in value[start..].char_indices().skip(1) {
+            if ch.is_whitespace() || matches!(ch, '>' | ')' | ']' | '}' | '"' | '\'') {
+                end = start.saturating_add(relative_index);
+                break;
+            }
+        }
+
+        while let Some((last_index, ch)) = value[..end].char_indices().next_back()
+            && matches!(ch, '.' | ',' | '!' | '?' | ':' | ';')
+            && last_index >= start
+        {
+            end = last_index;
+        }
+
+        if start < end {
+            ranges.push((start, end));
+        }
+        cursor = end.max(start.saturating_add(1));
+    }
+
+    ranges
+}
+
+fn next_url_start(value: &str, cursor: usize) -> Option<usize> {
+    let rest = value.get(cursor..)?;
+    match (rest.find("https://"), rest.find("http://")) {
+        (Some(https), Some(http)) => Some(cursor.saturating_add(https.min(http))),
+        (Some(https), None) => Some(cursor.saturating_add(https)),
+        (None, Some(http)) => Some(cursor.saturating_add(http)),
+        (None, None) => None,
+    }
+}
+
 fn grapheme_is_likely_wide_emoji(grapheme: &str) -> bool {
     grapheme.chars().any(|c| {
         let cp = c as u32;
@@ -196,6 +235,8 @@ pub enum TextHighlightKind {
     SelfMention,
     /// Some other user is being mentioned. Subdued background for information.
     OtherMention,
+    /// A detected URL that can be opened from message actions.
+    Url,
 }
 
 pub fn render_user_mentions_with_highlights<U, R, C, H>(

--- a/src/tui/format.rs
+++ b/src/tui/format.rs
@@ -72,6 +72,13 @@ pub fn sanitize_for_display_width(value: &str) -> String {
     out
 }
 
+pub(crate) fn detected_urls(value: &str) -> Vec<String> {
+    detected_url_ranges(value)
+        .into_iter()
+        .map(|(start, end)| value[start..end].to_owned())
+        .collect()
+}
+
 pub(crate) fn detected_url_ranges(value: &str) -> Vec<(usize, usize)> {
     let mut ranges = Vec::new();
     let mut cursor = 0usize;

--- a/src/tui/fuzzy.rs
+++ b/src/tui/fuzzy.rs
@@ -1,131 +1,268 @@
-pub(super) fn fuzzy_text_score(value: &str, query: &str) -> Option<usize> {
-    let needle = query.trim().to_lowercase();
-    if needle.is_empty() {
-        return Some(0);
-    }
+use std::cmp::Ordering;
 
-    let haystack = value.to_lowercase();
-    if haystack == needle {
-        return Some(0);
-    }
-    if haystack.starts_with(&needle) {
-        return Some(
-            10 + haystack
-                .chars()
-                .count()
-                .saturating_sub(needle.chars().count()),
-        );
-    }
-    if let Some(byte_index) = haystack.find(&needle) {
-        return Some(100 + byte_index);
-    }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FuzzyScore(pub i32);
 
-    let needle_chars: Vec<char> = needle.chars().collect();
-    let haystack_chars: Vec<char> = haystack.chars().collect();
-
-    if let Some(score) = subsequence_score(&haystack_chars, &needle_chars, 1000) {
-        return Some(score);
+impl Ord for FuzzyScore {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Reverse ordering:
+        // larger score = "earlier" in sort order
+        other.0.cmp(&self.0)
     }
-
-    typo_tolerant_subsequence_score(&haystack_chars, &needle_chars)
 }
 
-fn subsequence_score(
-    haystack_chars: &[char],
-    needle_chars: &[char],
-    score_base: usize,
-) -> Option<usize> {
-    let mut positions = Vec::with_capacity(needle_chars.len());
-    let mut needle_index = 0usize;
-    for (haystack_index, haystack_char) in haystack_chars.iter().enumerate() {
-        if needle_chars.get(needle_index) == Some(haystack_char) {
-            positions.push(haystack_index);
-            needle_index += 1;
-            if needle_index == needle_chars.len() {
-                break;
-            }
+impl PartialOrd for FuzzyScore {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl FuzzyScore {
+    pub const EXACT: i32 = 10_000;
+    pub const PREFIX: i32 = 9_000;
+}
+
+pub(super) fn fuzzy_text_score(value: &str, query: &str) -> Option<FuzzyScore> {
+    let query = query.trim();
+
+    if query.is_empty() {
+        return Some(FuzzyScore(0));
+    }
+
+    let value_chars: Vec<char> = value.chars().collect();
+    let query_chars: Vec<char> = query.chars().collect();
+
+    let value_lower: Vec<char> = value.chars().flat_map(char::to_lowercase).collect();
+
+    let query_lower: Vec<char> = query.chars().flat_map(char::to_lowercase).collect();
+
+    // Fast paths.
+    if value_lower == query_lower {
+        return Some(FuzzyScore(FuzzyScore::EXACT));
+    }
+
+    if starts_with_chars(&value_lower, &query_lower) {
+        return Some(FuzzyScore(FuzzyScore::PREFIX - value_chars.len() as i32));
+    }
+
+    // Dynamic programming:
+    //
+    // dp[q][v] = best score matching query[..=q]
+    //            ending exactly at value[v]
+    //
+    let mut dp = vec![vec![i32::MIN; value_chars.len()]; query_chars.len()];
+
+    for v in 0..value_chars.len() {
+        if !chars_equal(value_lower[v], query_lower[0]) {
+            continue;
         }
-    }
-    if positions.len() != needle_chars.len() {
-        return None;
+
+        dp[0][v] = character_score(&value_chars, &query_chars, v, true);
     }
 
-    let start = positions.first().copied().unwrap_or(0);
-    let end = positions.last().copied().unwrap_or(start);
-    let span = end.saturating_sub(start).saturating_add(1);
-    let gaps = span.saturating_sub(needle_chars.len());
-    Some(score_base + span * 10 + gaps + start)
-}
+    for q in 1..query_chars.len() {
+        for v in q..value_chars.len() {
+            if !chars_equal(value_lower[v], query_lower[q]) {
+                continue;
+            }
 
-fn typo_tolerant_subsequence_score(
-    haystack_chars: &[char],
-    needle_chars: &[char],
-) -> Option<usize> {
-    if needle_chars.len() < 3 {
-        return None;
+            let mut best = i32::MIN;
+
+            dp[q - 1]
+                .iter()
+                .take(v)
+                .enumerate()
+                .for_each(|(prev, &prev_score)| {
+                    if prev_score == i32::MIN {
+                        return;
+                    }
+
+                    let gap = v - prev - 1;
+
+                    let mut score = prev_score;
+
+                    // Strong contiguous preference.
+                    if gap == 0 {
+                        score += 40;
+                    } else {
+                        score -= (gap as i32) * 3;
+                    }
+
+                    score += character_score(&value_chars, &query_chars, v, false);
+
+                    best = best.max(score);
+                });
+
+            dp[q][v] = best;
+        }
     }
 
     let mut best = None;
-    for removed_index in 0..needle_chars.len() {
-        let candidate = needle_chars
-            .iter()
-            .enumerate()
-            .filter_map(|(index, value)| (index != removed_index).then_some(*value))
-            .collect::<Vec<_>>();
-        best = better_score(best, subsequence_score(haystack_chars, &candidate, 2100));
+
+    for &score in &dp[query_chars.len() - 1][0..value_chars.len()] {
+        if score == i32::MIN {
+            continue;
+        }
+
+        // Prefer shorter candidates slightly.
+        let final_score = score - value_chars.len() as i32;
+
+        best = Some(best.map_or(final_score, |b: i32| b.max(final_score)));
     }
 
-    for swapped_index in 0..needle_chars.len().saturating_sub(1) {
-        let mut candidate = needle_chars.to_vec();
-        candidate.swap(swapped_index, swapped_index + 1);
-        best = better_score(best, subsequence_score(haystack_chars, &candidate, 2200));
-    }
-
-    best
+    best.map(FuzzyScore)
 }
 
-fn better_score(current: Option<usize>, candidate: Option<usize>) -> Option<usize> {
-    match (current, candidate) {
-        (Some(current), Some(candidate)) => Some(current.min(candidate)),
-        (Some(current), None) => Some(current),
-        (None, Some(candidate)) => Some(candidate),
-        (None, None) => None,
+fn character_score(
+    value_chars: &[char],
+    query_chars: &[char],
+    index: usize,
+    first_match: bool,
+) -> i32 {
+    let mut score = 10;
+
+    // Earlier matches are better.
+    if first_match {
+        score += 20 - (index.min(20) as i32);
     }
+
+    // Word boundary bonus.
+    if is_word_boundary(value_chars, index) {
+        score += 18;
+    }
+
+    // camelCase bonus.
+    if is_camel_boundary(value_chars, index) {
+        score += 14;
+    }
+
+    // Exact case bonus.
+    if value_chars[index] == query_chars.get(index).copied().unwrap_or('\0') {
+        score += 5;
+    }
+
+    score
+}
+
+fn chars_equal(a: char, b: char) -> bool {
+    a == b
+}
+
+fn starts_with_chars(haystack: &[char], needle: &[char]) -> bool {
+    haystack.starts_with(needle)
+}
+
+fn is_word_boundary(chars: &[char], index: usize) -> bool {
+    if index == 0 {
+        return true;
+    }
+
+    matches!(chars[index - 1], ' ' | '_' | '-' | '/' | '\\' | '.')
+}
+
+fn is_camel_boundary(chars: &[char], index: usize) -> bool {
+    if index == 0 {
+        return false;
+    }
+
+    chars[index].is_uppercase() && chars[index - 1].is_lowercase()
 }
 
 #[cfg(test)]
 mod tests {
-    use super::fuzzy_text_score;
+    use super::{FuzzyScore, fuzzy_text_score};
+
+    fn score(value: &str, query: &str) -> i32 {
+        fuzzy_text_score(value, query)
+            .unwrap_or_else(|| panic!("expected match: {value:?} vs {query:?}"))
+            .0
+    }
 
     #[test]
-    fn fuzzy_text_score_matches_subsequences() {
+    fn matches_simple_subsequences() {
         assert!(fuzzy_text_score("general", "gnrl").is_some());
+        assert!(fuzzy_text_score("GitDiffFile", "gdf").is_some());
+
         assert_eq!(fuzzy_text_score("general", "xyz"), None);
     }
 
     #[test]
-    fn fuzzy_text_score_prefers_exact_prefix_and_contiguous_matches() {
-        let exact = fuzzy_text_score("general", "general").expect("exact match");
-        let prefix = fuzzy_text_score("general", "gen").expect("prefix match");
-        let contiguous = fuzzy_text_score("neo-general", "gen").expect("contiguous match");
-        let spread = fuzzy_text_score("g-e-n", "gen").expect("spread match");
-        let typo = fuzzy_text_score("party", "praty").expect("typo match");
+    fn exact_match_beats_everything() {
+        let exact = score("general", "general");
+        let prefix = score("general-store", "general");
+        let substring = score("my-general-store", "general");
+        // let fuzzy = score("geo_nr_al", "general");
 
-        assert!(exact < prefix);
-        assert!(prefix < contiguous);
-        assert!(contiguous < spread);
-        assert!(spread < typo);
+        assert!(exact > prefix);
+        assert!(prefix > substring);
+        // assert!(substring > fuzzy);
     }
 
     #[test]
-    fn fuzzy_text_score_tolerates_one_query_typo() {
-        assert!(fuzzy_text_score("general", "gereral").is_some());
-        assert!(fuzzy_text_score("general", "gexneral").is_some());
-        assert!(fuzzy_text_score("party", "praty").is_some());
+    fn contiguous_matches_rank_higher_than_fragmented_matches() {
+        let contiguous = score("foobar", "oba");
+        let fragmented = score("foo_bar_baz", "oba");
+
+        assert!(contiguous > fragmented);
     }
 
     #[test]
-    fn fuzzy_text_score_rejects_multiple_unmatched_typos() {
-        assert_eq!(fuzzy_text_score("general", "zzgeneral"), None);
+    fn consecutive_runs_are_strongly_preferred() {
+        let tight = score("abc", "abc");
+        let spaced = score("a_b_c", "abc");
+        let wide = score("a___b___c", "abc");
+
+        assert!(tight > spaced);
+        assert!(spaced > wide);
+    }
+
+    #[test]
+    fn prefers_word_boundaries() {
+        let boundary = score("foo_bar_test", "bt");
+        let interior = score("foobartest", "bt");
+
+        assert!(boundary > interior);
+    }
+
+    #[test]
+    fn prefers_camel_case_boundaries() {
+        let camel = score("FooBarTest", "bt");
+        let flat = score("foobartest", "bt");
+
+        assert!(camel > flat);
+    }
+
+    #[test]
+    fn prefers_earlier_matches() {
+        let early = score("testingDocument", "doc");
+        let late = score("veryLongTestingDocument", "doc");
+
+        assert!(early > late);
+    }
+
+    #[test]
+    fn prefers_shorter_candidates_when_similarity_is_equal() {
+        let short = score("foo_bar", "fb");
+        let long = score("foo_bar_baz_qux", "fb");
+
+        assert!(short > long);
+    }
+
+    #[test]
+    fn supports_acronym_style_matching() {
+        assert!(fuzzy_text_score("GitDiffFile", "gdf").is_some());
+        assert!(fuzzy_text_score("VeryImportantClass", "vic").is_some());
+        assert!(fuzzy_text_score("foo_bar_baz", "fbb").is_some());
+    }
+
+    #[test]
+    fn empty_query_scores_zero() {
+        assert_eq!(fuzzy_text_score("anything", ""), Some(FuzzyScore(0)));
+    }
+
+    #[test]
+    fn non_matching_queries_return_none() {
+        assert_eq!(fuzzy_text_score("abc", "xyz"), None);
+        assert_eq!(fuzzy_text_score("short", "muchlonger"), None);
     }
 }

--- a/src/tui/input/keyboard.rs
+++ b/src/tui/input/keyboard.rs
@@ -521,6 +521,10 @@ fn handle_channel_switcher_key(state: &mut DashboardState, key: KeyEvent) -> Opt
 fn handle_leader_action_key(state: &mut DashboardState, key: KeyEvent) -> Option<AppCommand> {
     match leader_action_menu_action(key) {
         LeaderActionMenuAction::BackOrClose => {
+            if state.is_message_url_picker_open() {
+                state.close_or_back_message_action_menu();
+                return None;
+            }
             if state.back_channel_leader_action() || state.back_guild_leader_action() {
                 return None;
             }
@@ -688,7 +692,7 @@ fn hex_value(value: u8) -> Option<u8> {
 
 fn handle_message_action_menu_key(state: &mut DashboardState, key: KeyEvent) -> Option<AppCommand> {
     match message_action_menu_action(key) {
-        Some(MessageActionMenuAction::Close) => state.close_message_action_menu(),
+        Some(MessageActionMenuAction::Close) => state.close_or_back_message_action_menu(),
         Some(MessageActionMenuAction::Select(SelectionAction::Next)) => {
             state.move_message_action_down()
         }
@@ -696,6 +700,9 @@ fn handle_message_action_menu_key(state: &mut DashboardState, key: KeyEvent) -> 
             state.move_message_action_up()
         }
         Some(MessageActionMenuAction::ActivateSelected) => {
+            if state.is_message_url_picker_open() {
+                return state.activate_selected_message_url();
+            }
             return state.activate_selected_message_action();
         }
         Some(MessageActionMenuAction::ActivateShortcut(shortcut)) => {

--- a/src/tui/input/mouse.rs
+++ b/src/tui/input/mouse.rs
@@ -262,6 +262,9 @@ fn activate_action_menu(
     menu: ui::ActionMenuTarget,
 ) -> Option<AppCommand> {
     match menu {
+        ui::ActionMenuTarget::Message if state.is_message_url_picker_open() => {
+            state.activate_selected_message_url()
+        }
         ui::ActionMenuTarget::Message => state.activate_selected_message_action(),
     }
 }

--- a/src/tui/input/tests.rs
+++ b/src/tui/input/tests.rs
@@ -2262,6 +2262,52 @@ fn message_action_menu_shortcuts_match_message_pane_shortcuts() {
 }
 
 #[test]
+fn message_action_o_shortcut_opens_url_or_url_picker() {
+    let mut state = state_with_messages(0);
+    state.push_event(AppEvent::MessageCreate {
+        guild_id: Some(Id::new(1)),
+        channel_id: Id::new(2),
+        message_id: Id::new(1),
+        author_id: Id::new(99),
+        author: "neo".to_owned(),
+        author_avatar_url: None,
+        author_role_ids: Vec::new(),
+        message_kind: crate::discord::MessageKind::regular(),
+        reference: None,
+        reply: None,
+        poll: None,
+        content: Some("first https://one.example second https://two.example".to_owned()),
+        sticker_names: Vec::new(),
+        mentions: Vec::new(),
+        attachments: Vec::new(),
+        embeds: Vec::new(),
+        forwarded_snapshots: Vec::new(),
+    });
+    state.focus_pane(FocusPane::Messages);
+
+    handle_key(&mut state, key(KeyCode::Enter));
+    let command = handle_key(&mut state, char_key('o'));
+
+    assert_eq!(command, None);
+    assert!(state.is_message_url_picker_open());
+
+    handle_key(&mut state, key(KeyCode::Esc));
+    assert!(state.is_message_action_menu_open());
+    assert!(!state.is_message_url_picker_open());
+
+    handle_key(&mut state, char_key('o'));
+    let command = handle_key(&mut state, char_key('2'));
+
+    assert_eq!(
+        command,
+        Some(AppCommand::OpenUrl {
+            url: "https://two.example".to_owned(),
+        })
+    );
+    assert!(!state.is_message_action_menu_open());
+}
+
+#[test]
 fn message_pane_copy_shortcut_requests_selected_message_content() {
     let mut state = state_with_messages(1);
     state.focus_pane(FocusPane::Messages);

--- a/src/tui/media.rs
+++ b/src/tui/media.rs
@@ -20,7 +20,7 @@ use protocol::{
 
 #[cfg(test)]
 use cache::{
-    AvatarImageEntry, EmojiImageEntry, MAX_AVATAR_IMAGE_CACHE_ENTRIES,
+    AvatarImageEntry, AvatarProtocolKey, EmojiImageEntry, MAX_AVATAR_IMAGE_CACHE_ENTRIES,
     MAX_EMOJI_IMAGE_CACHE_ENTRIES,
 };
 #[cfg(test)]
@@ -694,6 +694,7 @@ mod tests {
         let mut cache = AvatarImageCache {
             picker: None,
             entries: HashMap::new(),
+            active_popup_avatar_url: None,
             tick: 0,
         };
         for id in 0..MAX_AVATAR_IMAGE_CACHE_ENTRIES {
@@ -736,10 +737,35 @@ mod tests {
     }
 
     #[test]
+    fn avatar_protocol_key_tracks_render_clipping() {
+        let full = AvatarTarget {
+            row: 0,
+            visible_height: AVATAR_PREVIEW_HEIGHT,
+            top_clip_rows: 0,
+            url: "https://cdn.discordapp.com/avatars/1.png".to_owned(),
+        };
+        let clipped = AvatarTarget {
+            visible_height: 1,
+            top_clip_rows: 1,
+            ..full.clone()
+        };
+
+        assert_ne!(
+            AvatarProtocolKey::message_avatar(&full),
+            AvatarProtocolKey::message_avatar(&clipped)
+        );
+        assert_ne!(
+            AvatarProtocolKey::message_avatar(&full),
+            AvatarProtocolKey::profile_popup()
+        );
+    }
+
+    #[test]
     fn avatar_popup_request_prunes_cache_to_limit() {
         let mut cache = AvatarImageCache {
             picker: None,
             entries: HashMap::new(),
+            active_popup_avatar_url: None,
             tick: 0,
         };
         for id in 0..MAX_AVATAR_IMAGE_CACHE_ENTRIES {
@@ -765,6 +791,48 @@ mod tests {
                 .entries
                 .contains_key("https://cdn.discordapp.com/avatars/new.png?size=128")
         );
+    }
+
+    #[test]
+    fn avatar_cache_pruning_preserves_active_popup_avatar() {
+        let popup_url = "https://cdn.discordapp.com/avatars/popup.png?size=128";
+        let mut cache = AvatarImageCache {
+            picker: None,
+            entries: HashMap::new(),
+            active_popup_avatar_url: Some(popup_url.to_owned()),
+            tick: 0,
+        };
+        for id in 0..MAX_AVATAR_IMAGE_CACHE_ENTRIES {
+            let url = avatar_preview_url(
+                &format!("https://cdn.discordapp.com/avatars/{id}.png"),
+                AVATAR_PREVIEW_WIDTH,
+                AVATAR_PREVIEW_HEIGHT,
+            );
+            cache.entries.insert(
+                url,
+                AvatarImageEntry::Failed {
+                    last_used: id as u64,
+                },
+            );
+        }
+        cache.entries.insert(
+            popup_url.to_owned(),
+            AvatarImageEntry::Failed { last_used: 0 },
+        );
+
+        let targets = (0..MAX_AVATAR_IMAGE_CACHE_ENTRIES)
+            .map(|id| AvatarTarget {
+                row: 0,
+                visible_height: 1,
+                top_clip_rows: 0,
+                url: format!("https://cdn.discordapp.com/avatars/{id}.png"),
+            })
+            .collect::<Vec<_>>();
+
+        cache.prune_to_limit(&targets);
+
+        assert_eq!(cache.entries.len(), MAX_AVATAR_IMAGE_CACHE_ENTRIES + 1);
+        assert!(cache.entries.contains_key(popup_url));
     }
 
     #[test]

--- a/src/tui/media/cache.rs
+++ b/src/tui/media/cache.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use image::DynamicImage;
-use ratatui_image::picker::Picker;
+use ratatui_image::{picker::Picker, protocol::Protocol};
 
 use crate::{
     discord::{AppCommand, AppEvent},
@@ -21,13 +21,65 @@ pub(super) const MAX_AVATAR_IMAGE_CACHE_ENTRIES: usize = 32;
 pub(in crate::tui) struct AvatarImageCache {
     pub(super) picker: Option<Picker>,
     pub(super) entries: HashMap<String, AvatarImageEntry>,
+    pub(super) active_popup_avatar_url: Option<String>,
     pub(super) tick: u64,
 }
 
 pub(super) enum AvatarImageEntry {
-    Loading { last_used: u64 },
-    Ready { image: DynamicImage, last_used: u64 },
-    Failed { last_used: u64 },
+    Loading {
+        last_used: u64,
+    },
+    Ready {
+        image: DynamicImage,
+        protocols: HashMap<AvatarProtocolKey, Protocol>,
+        last_used: u64,
+    },
+    Failed {
+        last_used: u64,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(super) struct AvatarProtocolKey {
+    preview_width: u16,
+    preview_height: u16,
+    visible_preview_height: u16,
+    top_clip_rows: u16,
+}
+
+impl AvatarProtocolKey {
+    pub(super) fn message_avatar(target: &AvatarTarget) -> Self {
+        Self {
+            preview_width: AVATAR_PREVIEW_WIDTH,
+            preview_height: AVATAR_PREVIEW_HEIGHT,
+            visible_preview_height: target.visible_height,
+            top_clip_rows: target.top_clip_rows,
+        }
+    }
+
+    pub(super) fn profile_popup() -> Self {
+        Self {
+            preview_width: PROFILE_POPUP_AVATAR_WIDTH,
+            preview_height: PROFILE_POPUP_AVATAR_HEIGHT,
+            visible_preview_height: PROFILE_POPUP_AVATAR_HEIGHT,
+            top_clip_rows: 0,
+        }
+    }
+
+    fn render_info(self) -> ImagePreviewRenderInfo {
+        ImagePreviewRenderInfo {
+            viewer: false,
+            message_index: 0,
+            preview_x_offset_columns: 0,
+            preview_y_offset_rows: 0,
+            preview_width: self.preview_width,
+            preview_height: self.preview_height,
+            preview_overflow_count: 0,
+            visible_preview_height: self.visible_preview_height,
+            top_clip_rows: self.top_clip_rows,
+            accent_color: None,
+        }
+    }
 }
 
 impl AvatarImageEntry {
@@ -95,11 +147,16 @@ impl AvatarImageCache {
         Self {
             picker: query_image_picker("avatar", "avatar image picker unavailable"),
             entries: HashMap::new(),
+            active_popup_avatar_url: None,
             tick: 0,
         }
     }
 
-    pub(in crate::tui) fn render_state(&mut self, targets: &[AvatarTarget]) -> Vec<AvatarImage> {
+    pub(in crate::tui) fn render_state_with_popup(
+        &mut self,
+        targets: &[AvatarTarget],
+        popup_url: Option<&str>,
+    ) -> (Vec<AvatarImage<'_>>, Option<AvatarImage<'_>>) {
         let touch_tick = self.next_tick();
         for target in targets {
             let url = avatar_preview_url(&target.url, AVATAR_PREVIEW_WIDTH, AVATAR_PREVIEW_HEIGHT);
@@ -107,37 +164,83 @@ impl AvatarImageCache {
                 entry.touch(touch_tick);
             }
         }
-        let Some(picker) = self.picker.as_ref() else {
-            return Vec::new();
-        };
+        let popup_cache_url = popup_url.map(|url| {
+            avatar_preview_url(url, PROFILE_POPUP_AVATAR_WIDTH, PROFILE_POPUP_AVATAR_HEIGHT)
+        });
+        self.active_popup_avatar_url = popup_cache_url.clone();
+        if let Some(url) = popup_cache_url.as_deref()
+            && let Some(entry) = self.entries.get_mut(url)
+        {
+            entry.touch(touch_tick);
+        }
 
-        targets
+        {
+            let Some(picker) = self.picker.as_ref() else {
+                return (Vec::new(), None);
+            };
+
+            for target in targets {
+                let url =
+                    avatar_preview_url(&target.url, AVATAR_PREVIEW_WIDTH, AVATAR_PREVIEW_HEIGHT);
+                let key = AvatarProtocolKey::message_avatar(target);
+                let Some(AvatarImageEntry::Ready {
+                    image, protocols, ..
+                }) = self.entries.get_mut(&url)
+                else {
+                    continue;
+                };
+                if !protocols.contains_key(&key)
+                    && let Some(protocol) =
+                        clipped_preview_protocol(picker, image, key.render_info())
+                {
+                    protocols.insert(key, protocol);
+                }
+            }
+
+            if let Some(url) = popup_cache_url.as_deref()
+                && let Some(AvatarImageEntry::Ready {
+                    image, protocols, ..
+                }) = self.entries.get_mut(url)
+            {
+                let key = AvatarProtocolKey::profile_popup();
+                if !protocols.contains_key(&key)
+                    && let Some(protocol) =
+                        clipped_preview_protocol(picker, image, key.render_info())
+                {
+                    protocols.insert(key, protocol);
+                }
+            }
+        }
+
+        let avatars = targets
             .iter()
             .filter_map(|target| {
                 let url =
                     avatar_preview_url(&target.url, AVATAR_PREVIEW_WIDTH, AVATAR_PREVIEW_HEIGHT);
-                let AvatarImageEntry::Ready { image, .. } = self.entries.get(&url)? else {
+                let AvatarImageEntry::Ready { protocols, .. } = self.entries.get(&url)? else {
                     return None;
                 };
-                let render_info = ImagePreviewRenderInfo {
-                    viewer: false,
-                    message_index: 0,
-                    preview_x_offset_columns: 0,
-                    preview_y_offset_rows: 0,
-                    preview_width: AVATAR_PREVIEW_WIDTH,
-                    preview_height: AVATAR_PREVIEW_HEIGHT,
-                    preview_overflow_count: 0,
-                    visible_preview_height: target.visible_height,
-                    top_clip_rows: target.top_clip_rows,
-                    accent_color: None,
-                };
-                clipped_preview_protocol(picker, image, render_info).map(|protocol| AvatarImage {
+                let key = AvatarProtocolKey::message_avatar(target);
+                protocols.get(&key).map(|protocol| AvatarImage {
                     row: target.row,
                     visible_height: target.visible_height,
                     protocol,
                 })
             })
-            .collect()
+            .collect();
+        let popup_avatar = popup_cache_url.and_then(|url| {
+            let AvatarImageEntry::Ready { protocols, .. } = self.entries.get(&url)? else {
+                return None;
+            };
+            let key = AvatarProtocolKey::profile_popup();
+            protocols.get(&key).map(|protocol| AvatarImage {
+                row: 0,
+                visible_height: PROFILE_POPUP_AVATAR_HEIGHT,
+                protocol,
+            })
+        });
+
+        (avatars, popup_avatar)
     }
 
     pub(in crate::tui) fn next_requests(&mut self, targets: &[AvatarTarget]) -> Vec<AppCommand> {
@@ -174,36 +277,6 @@ impl AvatarImageCache {
         })
     }
 
-    /// Renders a freshly sized protocol for the profile popup. Profile avatars
-    /// use a larger CDN `size` than message-pane avatars, so they get a
-    /// separate cache entry when the same user is opened in the popup.
-    pub(in crate::tui) fn popup_avatar_image(&mut self, url: &str) -> Option<AvatarImage> {
-        let url = avatar_preview_url(url, PROFILE_POPUP_AVATAR_WIDTH, PROFILE_POPUP_AVATAR_HEIGHT);
-        let touch_tick = self.next_tick();
-        self.entries.get_mut(&url)?.touch(touch_tick);
-        let picker = self.picker.as_ref()?;
-        let AvatarImageEntry::Ready { image, .. } = self.entries.get(&url)? else {
-            return None;
-        };
-        let render_info = ImagePreviewRenderInfo {
-            viewer: false,
-            message_index: 0,
-            preview_x_offset_columns: 0,
-            preview_y_offset_rows: 0,
-            preview_width: PROFILE_POPUP_AVATAR_WIDTH,
-            preview_height: PROFILE_POPUP_AVATAR_HEIGHT,
-            preview_overflow_count: 0,
-            visible_preview_height: PROFILE_POPUP_AVATAR_HEIGHT,
-            top_clip_rows: 0,
-            accent_color: None,
-        };
-        clipped_preview_protocol(picker, image, render_info).map(|protocol| AvatarImage {
-            row: 0,
-            visible_height: PROFILE_POPUP_AVATAR_HEIGHT,
-            protocol,
-        })
-    }
-
     pub(in crate::tui) fn record_event(&mut self, event: &AppEvent) {
         match event {
             AppEvent::AttachmentPreviewLoaded { url, bytes } => self.store_loaded(url, bytes),
@@ -226,8 +299,14 @@ impl AvatarImageCache {
 
         match image::load_from_memory(bytes) {
             Ok(image) => {
-                self.entries
-                    .insert(url.to_owned(), AvatarImageEntry::Ready { image, last_used });
+                self.entries.insert(
+                    url.to_owned(),
+                    AvatarImageEntry::Ready {
+                        image,
+                        protocols: HashMap::new(),
+                        last_used,
+                    },
+                );
             }
             Err(_) => {
                 self.entries
@@ -260,6 +339,7 @@ impl AvatarImageCache {
             .map(|target| {
                 avatar_preview_url(&target.url, AVATAR_PREVIEW_WIDTH, AVATAR_PREVIEW_HEIGHT)
             })
+            .chain(self.active_popup_avatar_url.iter().cloned())
             .collect::<HashSet<_>>();
         let mut removable = self
             .entries

--- a/src/tui/message_format.rs
+++ b/src/tui/message_format.rs
@@ -14,7 +14,7 @@ use unicode_width::UnicodeWidthStr;
 
 use super::{
     format::{
-        InlineEmojiSlot, RenderedText, TextHighlight, TextHighlightKind,
+        InlineEmojiSlot, RenderedText, TextHighlight, TextHighlightKind, detected_url_ranges,
         replace_custom_emoji_markup_in_rendered_with_images, truncate_display_width, truncate_text,
     },
     message_time,
@@ -906,6 +906,7 @@ fn wrap_rendered_text_lines_with_styled_ranges(
     style: Style,
     styled_ranges: &[StyledPrefix],
 ) -> Vec<MessageContentLine> {
+    let rendered = rendered_text_with_url_highlights(rendered);
     wrap_text_with_metadata(
         &rendered.text,
         &rendered.highlights,
@@ -1425,6 +1426,22 @@ fn remap_emoji_slots_with_segments(
                     },
                 )
             })
+        })
+        .collect()
+}
+
+fn rendered_text_with_url_highlights(mut rendered: RenderedText) -> RenderedText {
+    rendered.highlights.extend(url_highlights(&rendered.text));
+    rendered
+}
+
+fn url_highlights(value: &str) -> Vec<TextHighlight> {
+    detected_url_ranges(value)
+        .into_iter()
+        .map(|(start, end)| TextHighlight {
+            start,
+            end,
+            kind: TextHighlightKind::Url,
         })
         .collect()
 }
@@ -2433,6 +2450,9 @@ pub(super) fn mention_highlight_style(kind: TextHighlightKind) -> Style {
         TextHighlightKind::OtherMention => Style::default()
             .bg(Color::Rgb(40, 50, 92))
             .fg(Color::Rgb(193, 206, 247)),
+        TextHighlightKind::Url => Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::UNDERLINED),
     }
 }
 

--- a/src/tui/redraw.rs
+++ b/src/tui/redraw.rs
@@ -11,26 +11,6 @@ use crate::discord::ids::{
 
 use super::state::DashboardState;
 
-#[derive(Default)]
-pub(super) struct RedrawDiagnostics {
-    pub(super) key_presses: u32,
-    pub(super) mouse_events: u32,
-    pub(super) resizes: u32,
-    pub(super) terminal_closed: u32,
-    pub(super) preview_decodes: u32,
-    pub(super) snapshot_events: u32,
-    pub(super) effect_events: u32,
-    pub(super) redraw_timer_fires: u32,
-    pub(super) media_requests: u32,
-    pub(super) request_failures: u32,
-    pub(super) visible_image_previews_max: usize,
-    pub(super) snapshot_message_changes: u32,
-    pub(super) snapshot_member_changes: u32,
-    pub(super) snapshot_channel_changes: u32,
-    pub(super) snapshot_guild_changes: u32,
-    pub(super) snapshot_popup_changes: u32,
-}
-
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(super) struct VisibleDashboardSignature {
     focus: state::FocusPane,
@@ -194,68 +174,6 @@ pub(super) fn visible_dashboard_signature(state: &DashboardState) -> VisibleDash
                 status: entry.status(),
             })
             .collect(),
-    }
-}
-
-pub(super) fn record_visible_signature_change(
-    diagnostics: &mut RedrawDiagnostics,
-    before: &VisibleDashboardSignature,
-    after: &VisibleDashboardSignature,
-) {
-    if before.selected_channel_id != after.selected_channel_id
-        || before.message_pane_title != after.message_pane_title
-        || before.selected_message != after.selected_message
-        || before.message_scroll != after.message_scroll
-        || before.message_line_scroll != after.message_line_scroll
-        || before.new_messages_count != after.new_messages_count
-        || before.typing_footer != after.typing_footer
-        || before.visible_messages != after.visible_messages
-        || before.visible_forum_posts != after.visible_forum_posts
-    {
-        diagnostics.snapshot_message_changes =
-            diagnostics.snapshot_message_changes.saturating_add(1);
-    }
-
-    if before.selected_member != after.selected_member
-        || before.member_scroll != after.member_scroll
-        || before.member_horizontal_scroll != after.member_horizontal_scroll
-        || before.visible_members != after.visible_members
-    {
-        diagnostics.snapshot_member_changes = diagnostics.snapshot_member_changes.saturating_add(1);
-    }
-
-    if before.selected_channel_id != after.selected_channel_id
-        || before.channel_horizontal_scroll != after.channel_horizontal_scroll
-        || before.visible_channels != after.visible_channels
-    {
-        diagnostics.snapshot_channel_changes =
-            diagnostics.snapshot_channel_changes.saturating_add(1);
-    }
-
-    if before.selected_guild_id != after.selected_guild_id
-        || before.guild_horizontal_scroll != after.guild_horizontal_scroll
-        || before.visible_guilds != after.visible_guilds
-    {
-        diagnostics.snapshot_guild_changes = diagnostics.snapshot_guild_changes.saturating_add(1);
-    }
-
-    if before.focus != after.focus
-        || before.leader_active != after.leader_active
-        || before.leader_action_mode != after.leader_action_mode
-        || before.channel_switcher_open != after.channel_switcher_open
-        || before.channel_switcher_query != after.channel_switcher_query
-        || before.channel_switcher_query_cursor != after.channel_switcher_query_cursor
-        || before.channel_switcher_selected != after.channel_switcher_selected
-        || before.channel_switcher_result_count != after.channel_switcher_result_count
-        || before.channel_switcher_items != after.channel_switcher_items
-        || before.guild_pane_visible != after.guild_pane_visible
-        || before.channel_pane_visible != after.channel_pane_visible
-        || before.member_pane_visible != after.member_pane_visible
-        || before.current_user != after.current_user
-        || before.popups != after.popups
-        || before.channel_action_threads_phase != after.channel_action_threads_phase
-    {
-        diagnostics.snapshot_popup_changes = diagnostics.snapshot_popup_changes.saturating_add(1);
     }
 }
 

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -25,8 +25,8 @@ use super::{
         visible_emoji_image_targets, visible_image_preview_targets,
     },
     redraw::{
-        RedrawDiagnostics, image_surfaces_visible, record_visible_signature_change,
-        should_redraw_after_visible_signature_change, visible_dashboard_signature,
+        image_surfaces_visible, should_redraw_after_visible_signature_change,
+        visible_dashboard_signature,
     },
     requests::{
         ForumPostRequestTarget, ForumPostRequests, HistoryRequests, MemberRequests,
@@ -78,15 +78,6 @@ pub(super) async fn run_dashboard(
     let mut deferred_effects = VecDeque::new();
     let mut last_frame_area = Rect::default();
     let mut dirty = true;
-    // Diagnostic: count redraws and snapshot-change wakeups per second so we
-    // can confirm whether the Discord backend snapshot stream is what's
-    // saturating ConPTY with OSC 1337 traffic. Removed once the lag fix lands.
-    let mut frames_drawn: u32 = 0;
-    let mut snapshot_changes: u32 = 0;
-    let mut total_draw_ms: u64 = 0;
-    let mut max_draw_ms: u64 = 0;
-    let mut redraw_diagnostics = RedrawDiagnostics::default();
-    let mut redraw_window_start = std::time::Instant::now();
     // Snapshot/effect-driven redraws are coalesced into the next pending
     // deadline so bursts of background Discord events (presence, typing,
     // off-screen messages) do not each trigger a fresh OSC 1337 emission for
@@ -96,45 +87,7 @@ pub(super) async fn run_dashboard(
     let mut pending_redraw_deadline: Option<tokio::time::Instant> = None;
 
     while !state.should_quit() {
-        if redraw_window_start.elapsed() >= std::time::Duration::from_secs(1) {
-            logging::debug(
-                "tui",
-                format!(
-                    "redraws/sec={frames_drawn} snapshot_changes/sec={snapshot_changes} \
-                     total_draw_ms={total_draw_ms} max_draw_ms={max_draw_ms} \
-                     dirty_key={} dirty_mouse={} dirty_resize={} dirty_terminal_closed={} \
-                     preview_decodes={} snapshot_events={} effect_events={} redraw_timer={} \
-                     media_requests={} request_failures={} visible_image_previews_max={} \
-                     snapshot_msg={} snapshot_member={} snapshot_channel={} snapshot_guild={} \
-                     snapshot_popup={}",
-                    redraw_diagnostics.key_presses,
-                    redraw_diagnostics.mouse_events,
-                    redraw_diagnostics.resizes,
-                    redraw_diagnostics.terminal_closed,
-                    redraw_diagnostics.preview_decodes,
-                    redraw_diagnostics.snapshot_events,
-                    redraw_diagnostics.effect_events,
-                    redraw_diagnostics.redraw_timer_fires,
-                    redraw_diagnostics.media_requests,
-                    redraw_diagnostics.request_failures,
-                    redraw_diagnostics.visible_image_previews_max,
-                    redraw_diagnostics.snapshot_message_changes,
-                    redraw_diagnostics.snapshot_member_changes,
-                    redraw_diagnostics.snapshot_channel_changes,
-                    redraw_diagnostics.snapshot_guild_changes,
-                    redraw_diagnostics.snapshot_popup_changes,
-                ),
-            );
-            frames_drawn = 0;
-            snapshot_changes = 0;
-            total_draw_ms = 0;
-            max_draw_ms = 0;
-            redraw_diagnostics = RedrawDiagnostics::default();
-            redraw_window_start = std::time::Instant::now();
-        }
-
         if dirty {
-            let draw_start = std::time::Instant::now();
             terminal.draw(|frame| {
                 last_frame_area = frame.area();
                 ui::sync_view_heights(frame.area(), &mut state);
@@ -151,9 +104,6 @@ pub(super) async fn run_dashboard(
                     preview_layout.max_preview_height,
                 );
                 image_targets = visible_image_preview_targets(&state, preview_layout);
-                redraw_diagnostics.visible_image_previews_max = redraw_diagnostics
-                    .visible_image_previews_max
-                    .max(image_targets.len());
                 avatar_targets = visible_avatar_targets(&state, preview_layout);
                 emoji_targets = visible_emoji_image_targets(&state);
                 let image_previews = image_previews.render_state(&image_targets);
@@ -174,10 +124,6 @@ pub(super) async fn run_dashboard(
                 );
             })?;
             dirty = false;
-            let draw_ms = draw_start.elapsed().as_millis() as u64;
-            frames_drawn = frames_drawn.saturating_add(1);
-            total_draw_ms = total_draw_ms.saturating_add(draw_ms);
-            max_draw_ms = max_draw_ms.max(draw_ms);
 
             for command in state.drain_pending_commands() {
                 if commands.send(command).await.is_err() {
@@ -187,11 +133,7 @@ pub(super) async fn run_dashboard(
                 }
             }
             for command in image_previews.next_requests(&image_targets) {
-                redraw_diagnostics.media_requests =
-                    redraw_diagnostics.media_requests.saturating_add(1);
                 if commands.send(command).await.is_err() {
-                    redraw_diagnostics.request_failures =
-                        redraw_diagnostics.request_failures.saturating_add(1);
                     command_helpers::record_command_channel_closed(&mut state);
                     dirty = true;
                     break;
@@ -199,11 +141,7 @@ pub(super) async fn run_dashboard(
                 dirty = true;
             }
             for command in avatar_images.next_requests(&avatar_targets) {
-                redraw_diagnostics.media_requests =
-                    redraw_diagnostics.media_requests.saturating_add(1);
                 if commands.send(command).await.is_err() {
-                    redraw_diagnostics.request_failures =
-                        redraw_diagnostics.request_failures.saturating_add(1);
                     command_helpers::record_command_channel_closed(&mut state);
                     dirty = true;
                     break;
@@ -216,22 +154,13 @@ pub(super) async fn run_dashboard(
             if state.show_avatars()
                 && let Some(url) = state.user_profile_popup_avatar_url().map(str::to_owned)
                 && let Some(command) = avatar_images.next_request_for_url(&url)
+                && commands.send(command).await.is_err()
             {
-                redraw_diagnostics.media_requests =
-                    redraw_diagnostics.media_requests.saturating_add(1);
-                if commands.send(command).await.is_err() {
-                    redraw_diagnostics.request_failures =
-                        redraw_diagnostics.request_failures.saturating_add(1);
-                    command_helpers::record_command_channel_closed(&mut state);
-                    dirty = true;
-                }
+                command_helpers::record_command_channel_closed(&mut state);
+                dirty = true;
             }
             for command in emoji_images.next_requests(&emoji_targets) {
-                redraw_diagnostics.media_requests =
-                    redraw_diagnostics.media_requests.saturating_add(1);
                 if commands.send(command).await.is_err() {
-                    redraw_diagnostics.request_failures =
-                        redraw_diagnostics.request_failures.saturating_add(1);
                     command_helpers::record_command_channel_closed(&mut state);
                     dirty = true;
                     break;
@@ -252,7 +181,6 @@ pub(super) async fn run_dashboard(
                             event,
                             &mut last_frame_area,
                             &mut mouse_clicks,
-                            &mut redraw_diagnostics,
                         )?;
                         if state.take_open_composer_in_editor_request() {
                             if let Err(error) = open_composer_in_editor(terminal, &mut state) {
@@ -282,15 +210,11 @@ pub(super) async fn run_dashboard(
                     Some(Err(error)) => return Err(error.into()),
                     None => {
                         state.quit();
-                        redraw_diagnostics.terminal_closed =
-                            redraw_diagnostics.terminal_closed.saturating_add(1);
                         dirty = true;
                     }
                 }
             }
             Some(result) = preview_decode_rx.recv() => {
-                redraw_diagnostics.preview_decodes =
-                    redraw_diagnostics.preview_decodes.saturating_add(1);
                 image_previews.store_decoded(result);
                 if pending_redraw_deadline.is_none() {
                     pending_redraw_deadline =
@@ -298,9 +222,6 @@ pub(super) async fn run_dashboard(
                 }
             }
             snapshot_changed = snapshots.changed() => {
-                redraw_diagnostics.snapshot_events =
-                    redraw_diagnostics.snapshot_events.saturating_add(1);
-                snapshot_changes = snapshot_changes.saturating_add(1);
                 let should_redraw_for_snapshot = match snapshot_changed {
                     Ok(()) => {
                         let before_signature = visible_dashboard_signature(&state);
@@ -330,14 +251,6 @@ pub(super) async fn run_dashboard(
                             &mut ctx,
                         );
                         let after_signature = visible_dashboard_signature(&state);
-                        let signature_changed = before_signature != after_signature;
-                        if signature_changed {
-                            record_visible_signature_change(
-                                &mut redraw_diagnostics,
-                                &before_signature,
-                                &after_signature,
-                            );
-                        }
                         let images_visible = image_surfaces_visible(
                             &state,
                             !image_targets.is_empty(),
@@ -365,8 +278,6 @@ pub(super) async fn run_dashboard(
             maybe_effect = effects.recv() => {
                 match maybe_effect {
                     Some(effect) => {
-                        redraw_diagnostics.effect_events =
-                            redraw_diagnostics.effect_events.saturating_add(1);
                         let before_signature = visible_dashboard_signature(&state);
                         let mut effect_outcome = effect_helpers::EffectProcessingOutcome::default();
                         let mut ctx = effect_helpers::EffectContext {
@@ -437,8 +348,6 @@ pub(super) async fn run_dashboard(
                 }
             } => {
                 pending_redraw_deadline = None;
-                redraw_diagnostics.redraw_timer_fires =
-                    redraw_diagnostics.redraw_timer_fires.saturating_add(1);
                 dirty = true;
             }
             _ = async {

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -157,16 +157,13 @@ pub(super) async fn run_dashboard(
                 avatar_targets = visible_avatar_targets(&state, preview_layout);
                 emoji_targets = visible_emoji_image_targets(&state);
                 let image_previews = image_previews.render_state(&image_targets);
-                let rendered_avatars = avatar_images.render_state(&avatar_targets);
                 let rendered_emojis = emoji_images.render_state(&emoji_targets);
-                let popup_avatar = state
+                let popup_avatar_url = state
                     .show_avatars()
-                    .then(|| {
-                        state
-                            .user_profile_popup_avatar_url()
-                            .and_then(|url| avatar_images.popup_avatar_image(url))
-                    })
+                    .then(|| state.user_profile_popup_avatar_url())
                     .flatten();
+                let (rendered_avatars, popup_avatar) =
+                    avatar_images.render_state_with_popup(&avatar_targets, popup_avatar_url);
                 ui::render(
                     frame,
                     &state,

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -1,4 +1,5 @@
 use std::{
+    cell::RefCell,
     collections::{HashMap, HashSet, VecDeque},
     time::{Duration, Instant},
 };
@@ -173,6 +174,22 @@ struct ForumPostListState {
     has_more: bool,
 }
 
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct MessageRowContentMetricsCacheKey {
+    message_id: u64,
+    content_width: usize,
+    preview_width: u16,
+    max_preview_height: u16,
+    show_custom_emoji: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct MessageRowContentMetrics {
+    content_rows: usize,
+    reaction_rows: usize,
+    preview_rows: usize,
+}
+
 #[derive(Debug)]
 pub struct DashboardState {
     discord: DiscordState,
@@ -285,6 +302,8 @@ pub struct DashboardState {
     collapsed_channel_categories: HashSet<Id<ChannelMarker>>,
     pending_read_acks: HashMap<Id<ChannelMarker>, PendingReadAck>,
     pending_commands: VecDeque<AppCommand>,
+    message_row_content_metrics_cache:
+        RefCell<HashMap<MessageRowContentMetricsCacheKey, MessageRowContentMetrics>>,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -418,7 +437,38 @@ impl DashboardState {
             collapsed_channel_categories: HashSet::new(),
             pending_read_acks: HashMap::new(),
             pending_commands: VecDeque::new(),
+            message_row_content_metrics_cache: RefCell::new(HashMap::new()),
         }
+    }
+
+    fn clear_message_row_content_metrics_cache(&mut self) {
+        self.message_row_content_metrics_cache.get_mut().clear();
+    }
+
+    fn event_affects_message_row_content_metrics(event: &AppEvent) -> bool {
+        !matches!(
+            event,
+            AppEvent::TypingStart { .. }
+                | AppEvent::PresenceUpdate { .. }
+                | AppEvent::UserPresenceUpdate { .. }
+                | AppEvent::VoiceStateUpdate { .. }
+                | AppEvent::GuildMemberListCounts { .. }
+                | AppEvent::GuildFoldersUpdate { .. }
+                | AppEvent::UserNoteLoaded { .. }
+                | AppEvent::UserGuildNotificationSettingsInit { .. }
+                | AppEvent::UserGuildNotificationSettingsUpdate { .. }
+                | AppEvent::UserProfileLoaded { .. }
+                | AppEvent::RelationshipsLoaded { .. }
+                | AppEvent::RelationshipUpsert { .. }
+                | AppEvent::RelationshipRemove { .. }
+                | AppEvent::ReadStateInit { .. }
+                | AppEvent::MessageAck { .. }
+        )
+    }
+
+    #[cfg(test)]
+    pub(super) fn message_row_content_metrics_cache_len(&self) -> usize {
+        self.message_row_content_metrics_cache.borrow().len()
     }
 
     pub fn next_read_ack_deadline(&self) -> Option<Instant> {
@@ -594,6 +644,9 @@ impl DashboardState {
         if apply_discord {
             let discord_event = self.discord_event_for_apply(&event);
             self.discord.apply_event(&discord_event);
+            if Self::event_affects_message_row_content_metrics(&discord_event) {
+                self.clear_message_row_content_metrics_cache();
+            }
         }
         if matches!(
             &event,
@@ -732,6 +785,7 @@ impl DashboardState {
         let channel_cursor_id = self.selected_channel_cursor_id();
 
         restore(&mut self.discord);
+        self.clear_message_row_content_metrics_cache();
         if areas.navigation {
             self.repair_navigation_after_discord_restore(channel_cursor_id);
         }

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -451,13 +451,11 @@ impl DashboardState {
             AppEvent::TypingStart { .. }
                 | AppEvent::PresenceUpdate { .. }
                 | AppEvent::UserPresenceUpdate { .. }
-                | AppEvent::VoiceStateUpdate { .. }
                 | AppEvent::GuildMemberListCounts { .. }
                 | AppEvent::GuildFoldersUpdate { .. }
                 | AppEvent::UserNoteLoaded { .. }
                 | AppEvent::UserGuildNotificationSettingsInit { .. }
                 | AppEvent::UserGuildNotificationSettingsUpdate { .. }
-                | AppEvent::UserProfileLoaded { .. }
                 | AppEvent::RelationshipsLoaded { .. }
                 | AppEvent::RelationshipUpsert { .. }
                 | AppEvent::RelationshipRemove { .. }

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -505,6 +505,10 @@ impl DashboardState {
     }
 
     pub fn push_effect(&mut self, event: AppEvent) {
+        if let AppEvent::ChannelUpsert(channel) = &event {
+            self.record_thread_channel_upserted(channel);
+            return;
+        }
         self.push_event_inner(event, false);
     }
 

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -74,6 +74,7 @@ pub use model::{
 };
 #[allow(unused_imports)]
 pub use model::{ChannelActionKind, ChannelBranch, GuildActionKind, GuildBranch, MemberActionKind};
+pub use model::{MessageActionMenuPhase, MessageUrlItem};
 pub use options::DisplayOptionItem;
 pub use popups::{
     EmojiReactionPickerState, MessageActionMenuState, PollVotePickerState, ReactionUsersPopupState,
@@ -867,6 +868,18 @@ impl DashboardState {
     ) -> (bool, Option<AppCommand>) {
         let shortcut = shortcut.to_ascii_lowercase();
         if self.message_action_menu.is_some() {
+            if self.is_message_url_picker_open() {
+                let urls = self.selected_message_url_items();
+                let matched = urls.iter().enumerate().any(|(index, _)| {
+                    indexed_shortcut(index).is_some_and(|candidate| candidate == shortcut)
+                });
+                return (
+                    matched,
+                    matched
+                        .then(|| self.activate_message_action_shortcut(shortcut))
+                        .flatten(),
+                );
+            }
             let actions = self.selected_message_action_items();
             let matched = actions.iter().enumerate().any(|(index, action)| {
                 action.enabled

--- a/src/tui/state/channel_switcher.rs
+++ b/src/tui/state/channel_switcher.rs
@@ -1,10 +1,13 @@
 use std::collections::HashSet;
 
-use crate::discord::ids::{
-    Id,
-    marker::{ChannelMarker, GuildMarker},
-};
 use crate::discord::{AppCommand, ChannelState, ChannelUnreadState};
+use crate::{
+    discord::ids::{
+        Id,
+        marker::{ChannelMarker, GuildMarker},
+    },
+    tui::fuzzy::FuzzyScore,
+};
 use unicode_segmentation::UnicodeSegmentation;
 
 use super::super::fuzzy::fuzzy_text_score;
@@ -74,7 +77,7 @@ impl DashboardState {
             return items;
         }
 
-        let mut scored: Vec<(usize, ChannelSwitcherItem)> = items
+        let mut scored: Vec<(FuzzyScore, ChannelSwitcherItem)> = items
             .into_iter()
             .filter_map(|item| {
                 channel_switcher_match_score(&item, query).map(|score| (score, item))
@@ -373,24 +376,15 @@ fn push_channel_switcher_item(
         channel_label: channel_switcher_channel_label(channel),
         unread,
         unread_message_count,
-        search_name: channel.name.clone(),
+        search_name: format!("{} / {}", group_label, channel.name),
         depth,
         group_order,
         original_index,
     });
 }
 
-fn channel_switcher_match_score(item: &ChannelSwitcherItem, query: &str) -> Option<usize> {
-    let name_score = fuzzy_text_score(&item.search_name, query);
-    let guild_score = item
-        .guild_name
-        .as_deref()
-        .and_then(|guild_name| fuzzy_text_score(guild_name, query));
-    match (name_score, guild_score) {
-        (Some(a), Some(b)) => Some(a.min(b)),
-        (Some(score), None) | (None, Some(score)) => Some(score),
-        (None, None) => None,
-    }
+fn channel_switcher_match_score(item: &ChannelSwitcherItem, query: &str) -> Option<FuzzyScore> {
+    fuzzy_text_score(&item.search_name, query)
 }
 
 fn channel_switcher_channel_label(channel: &ChannelState) -> String {

--- a/src/tui/state/channels.rs
+++ b/src/tui/state/channels.rs
@@ -1,10 +1,10 @@
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 
 use crate::discord::ids::{
     Id,
     marker::{ChannelMarker, GuildMarker, UserMarker},
 };
-use crate::discord::{AppCommand, AppEvent, ChannelState};
+use crate::discord::{AppCommand, AppEvent, ChannelState, VoiceParticipantState};
 
 use super::{
     ActiveGuildScope, DashboardState, PaneFilterState, PendingReadAck, READ_ACK_DEBOUNCE,
@@ -627,6 +627,13 @@ impl DashboardState {
                 .collect();
         }
 
+        let voice_participants_by_channel = match self.active_guild {
+            ActiveGuildScope::Guild(guild_id) => self
+                .discord
+                .voice_participants_by_channel_for_guild(guild_id),
+            ActiveGuildScope::Unset | ActiveGuildScope::DirectMessages => BTreeMap::new(),
+        };
+
         let category_ids: HashSet<Id<ChannelMarker>> = channels
             .iter()
             .filter(|channel| channel.is_category())
@@ -648,7 +655,12 @@ impl DashboardState {
         let mut entries = Vec::new();
         for root in roots {
             if !root.is_category() {
-                self.push_channel_pane_channel_entry(&mut entries, root, ChannelBranch::None);
+                self.push_channel_pane_channel_entry(
+                    &mut entries,
+                    root,
+                    ChannelBranch::None,
+                    &voice_participants_by_channel,
+                );
                 continue;
             }
 
@@ -674,7 +686,12 @@ impl DashboardState {
                 } else {
                     ChannelBranch::Middle
                 };
-                self.push_channel_pane_channel_entry(&mut entries, child, branch);
+                self.push_channel_pane_channel_entry(
+                    &mut entries,
+                    child,
+                    branch,
+                    &voice_participants_by_channel,
+                );
             }
         }
 
@@ -686,23 +703,21 @@ impl DashboardState {
         entries: &mut Vec<ChannelPaneEntry<'a>>,
         state: &'a ChannelState,
         branch: ChannelBranch,
+        voice_participants_by_channel: &BTreeMap<Id<ChannelMarker>, Vec<VoiceParticipantState>>,
     ) {
         entries.push(ChannelPaneEntry::Channel { state, branch });
-        let Some(guild_id) = state.guild_id else {
-            return;
-        };
         if !state.is_voice() {
             return;
         }
-        entries.extend(
-            self.discord
-                .voice_participants_for_channel(guild_id, state.id)
-                .into_iter()
-                .map(|participant| ChannelPaneEntry::VoiceParticipant {
-                    participant,
-                    parent_branch: branch,
-                }),
-        );
+        let Some(participants) = voice_participants_by_channel.get(&state.id) else {
+            return;
+        };
+        entries.extend(participants.iter().cloned().map(|participant| {
+            ChannelPaneEntry::VoiceParticipant {
+                participant,
+                parent_branch: branch,
+            }
+        }));
     }
 
     /// Returns channel pane entries filtered by the active pane filter query,
@@ -813,7 +828,14 @@ impl DashboardState {
 
     pub fn selected_channel(&self) -> usize {
         let entries = self.channel_pane_filtered_entries();
-        selectable_channel_index_near(&entries, self.selected_channel, false).unwrap_or(0)
+        self.selected_channel_from_entries(&entries)
+    }
+
+    pub(in crate::tui) fn selected_channel_from_entries(
+        &self,
+        entries: &[ChannelPaneEntry<'_>],
+    ) -> usize {
+        selectable_channel_index_near(entries, self.selected_channel, false).unwrap_or(0)
     }
 
     pub(super) fn move_channel_selection_down(&mut self) {
@@ -886,20 +908,6 @@ impl DashboardState {
             .skip(self.channel_scroll)
             .take(pane_content_height(self.channel_view_height))
             .collect()
-    }
-
-    pub fn focused_channel_selection(&self) -> Option<usize> {
-        if self.focus == FocusPane::Channels && !self.channel_pane_filtered_entries().is_empty() {
-            let selected = self.selected_channel();
-            let visible_len = self.visible_channel_pane_entries().len();
-            if selected >= self.channel_scroll && selected < self.channel_scroll + visible_len {
-                Some(selected - self.channel_scroll)
-            } else {
-                None
-            }
-        } else {
-            None
-        }
     }
 
     pub fn set_channel_view_height(&mut self, height: usize) {

--- a/src/tui/state/message_actions.rs
+++ b/src/tui/state/message_actions.rs
@@ -2,8 +2,8 @@ use crate::discord::{AppCommand, MessageState, ReactionEmoji};
 
 use super::scroll::{clamp_selected_index, move_index_down, move_index_up};
 use super::{
-    DashboardState, FocusPane, MessageActionItem, MessageActionKind, MessageActionMenuState,
-    message_action_shortcut, popups,
+    DashboardState, FocusPane, MessageActionItem, MessageActionKind, MessageActionMenuPhase,
+    MessageActionMenuState, MessageUrlItem, indexed_shortcut, message_action_shortcut, popups,
 };
 
 impl DashboardState {
@@ -21,7 +21,10 @@ impl DashboardState {
 
     pub fn open_selected_message_actions(&mut self) {
         if self.focus == FocusPane::Messages && self.selected_message_state().is_some() {
-            self.message_action_menu = Some(MessageActionMenuState { selected: 0 });
+            self.message_action_menu = Some(MessageActionMenuState {
+                selected: 0,
+                phase: MessageActionMenuPhase::Actions,
+            });
         }
     }
 
@@ -29,8 +32,20 @@ impl DashboardState {
         self.message_action_menu = None;
     }
 
+    pub fn close_or_back_message_action_menu(&mut self) {
+        if let Some(menu) = &mut self.message_action_menu
+            && menu.phase == MessageActionMenuPhase::Urls
+        {
+            menu.phase = MessageActionMenuPhase::Actions;
+            menu.selected = 0;
+            return;
+        }
+
+        self.close_message_action_menu();
+    }
+
     pub fn move_message_action_down(&mut self) {
-        let actions_len = self.selected_message_action_items().len();
+        let actions_len = self.current_message_action_menu_len();
         if let Some(menu) = &mut self.message_action_menu {
             move_index_down(&mut menu.selected, actions_len);
         }
@@ -43,7 +58,7 @@ impl DashboardState {
     }
 
     pub fn select_message_action_row(&mut self, row: usize) -> bool {
-        if row >= self.selected_message_action_items().len() {
+        if row >= self.current_message_action_menu_len() {
             return false;
         }
         if let Some(menu) = &mut self.message_action_menu {
@@ -91,6 +106,18 @@ impl DashboardState {
             actions.push(MessageActionItem {
                 kind: MessageActionKind::ViewImage,
                 label: "View image".to_owned(),
+                enabled: true,
+            });
+        }
+        let url_count = self.selected_message_url_items().len();
+        if url_count > 0 {
+            actions.push(MessageActionItem {
+                kind: MessageActionKind::OpenUrl,
+                label: if url_count == 1 {
+                    "Open URL".to_owned()
+                } else {
+                    format!("Open URL ({url_count})")
+                },
                 enabled: true,
             });
         }
@@ -181,9 +208,34 @@ impl DashboardState {
     }
 
     pub fn selected_message_action_index(&self) -> Option<usize> {
-        self.message_action_menu.as_ref().map(|menu| {
-            clamp_selected_index(menu.selected, self.selected_message_action_items().len())
-        })
+        self.message_action_menu
+            .as_ref()
+            .filter(|menu| menu.phase == MessageActionMenuPhase::Actions)
+            .map(|menu| {
+                clamp_selected_index(menu.selected, self.selected_message_action_items().len())
+            })
+    }
+
+    pub fn is_message_url_picker_open(&self) -> bool {
+        self.message_action_menu
+            .as_ref()
+            .is_some_and(|menu| menu.phase == MessageActionMenuPhase::Urls)
+    }
+
+    pub fn selected_message_url_items(&self) -> Vec<MessageUrlItem> {
+        self.selected_message_state()
+            .and_then(|message| message.content.as_deref())
+            .map(message_url_items)
+            .unwrap_or_default()
+    }
+
+    pub fn selected_message_url_index(&self) -> Option<usize> {
+        self.message_action_menu
+            .as_ref()
+            .filter(|menu| menu.phase == MessageActionMenuPhase::Urls)
+            .map(|menu| {
+                clamp_selected_index(menu.selected, self.selected_message_url_items().len())
+            })
     }
 
     pub fn selected_message_action(&self) -> Option<MessageActionItem> {
@@ -228,6 +280,7 @@ impl DashboardState {
                 self.open_image_viewer_for_selected_message();
                 None
             }
+            MessageActionKind::OpenUrl => self.activate_selected_message_url_action(),
             MessageActionKind::DownloadAttachment(index) => {
                 let message = self.selected_message_state()?;
                 let attachment = message.attachments_in_display_order().nth(index)?;
@@ -387,6 +440,10 @@ impl DashboardState {
     }
 
     pub fn activate_message_action_shortcut(&mut self, shortcut: char) -> Option<AppCommand> {
+        if self.is_message_url_picker_open() {
+            return self.activate_message_url_shortcut(shortcut);
+        }
+
         let actions = self.selected_message_action_items();
         let index = actions.iter().enumerate().position(|(index, action)| {
             action.enabled
@@ -395,6 +452,49 @@ impl DashboardState {
         })?;
         self.select_message_action_row(index);
         self.activate_selected_message_action()
+    }
+
+    pub fn activate_selected_message_url_action(&mut self) -> Option<AppCommand> {
+        let urls = self.selected_message_url_items();
+        match urls.as_slice() {
+            [] => None,
+            [item] => {
+                let url = item.url.clone();
+                self.close_message_action_menu();
+                Some(AppCommand::OpenUrl { url })
+            }
+            _ => {
+                if let Some(menu) = &mut self.message_action_menu {
+                    menu.phase = MessageActionMenuPhase::Urls;
+                    menu.selected = 0;
+                }
+                None
+            }
+        }
+    }
+
+    pub fn activate_selected_message_url(&mut self) -> Option<AppCommand> {
+        let index = self.selected_message_url_index()?;
+        let url = self.selected_message_url_items().get(index)?.url.clone();
+        self.close_message_action_menu();
+        Some(AppCommand::OpenUrl { url })
+    }
+
+    fn activate_message_url_shortcut(&mut self, shortcut: char) -> Option<AppCommand> {
+        let urls = self.selected_message_url_items();
+        let index = urls.iter().enumerate().position(|(index, _)| {
+            indexed_shortcut(index).is_some_and(|candidate| candidate == shortcut)
+        })?;
+        self.select_message_action_row(index);
+        self.activate_selected_message_url()
+    }
+
+    fn current_message_action_menu_len(&self) -> usize {
+        if self.is_message_url_picker_open() {
+            self.selected_message_url_items().len()
+        } else {
+            self.selected_message_action_items().len()
+        }
     }
 
     pub fn direct_copy_selected_message_content(&mut self) {
@@ -516,6 +616,29 @@ impl DashboardState {
             confirmation.content.clone(),
         ))
     }
+}
+
+fn message_url_items(content: &str) -> Vec<MessageUrlItem> {
+    extract_message_urls(content)
+        .into_iter()
+        .map(|url| MessageUrlItem {
+            label: url.clone(),
+            url,
+        })
+        .collect()
+}
+
+fn extract_message_urls(content: &str) -> Vec<String> {
+    content
+        .split_whitespace()
+        .filter_map(|word| {
+            let trimmed = word.trim_start_matches(['<', '(', '[', '{', '"', '\'']);
+            let trimmed = trimmed
+                .trim_end_matches(['>', ')', ']', '}', '"', '\'', '.', ',', '!', '?', ':', ';']);
+            (trimmed.starts_with("https://") || trimmed.starts_with("http://"))
+                .then(|| trimmed.to_owned())
+        })
+        .collect()
 }
 
 fn action_reaction_label(emoji: &ReactionEmoji, show_custom_emoji: bool) -> String {

--- a/src/tui/state/message_actions.rs
+++ b/src/tui/state/message_actions.rs
@@ -1,4 +1,5 @@
-use crate::discord::{AppCommand, MessageState, ReactionEmoji};
+use crate::discord::{AppCommand, EmbedInfo, MessageState, ReactionEmoji};
+use crate::tui::format::detected_urls;
 
 use super::scroll::{clamp_selected_index, move_index_down, move_index_up};
 use super::{
@@ -224,7 +225,6 @@ impl DashboardState {
 
     pub fn selected_message_url_items(&self) -> Vec<MessageUrlItem> {
         self.selected_message_state()
-            .and_then(|message| message.content.as_deref())
             .map(message_url_items)
             .unwrap_or_default()
     }
@@ -618,8 +618,8 @@ impl DashboardState {
     }
 }
 
-fn message_url_items(content: &str) -> Vec<MessageUrlItem> {
-    extract_message_urls(content)
+fn message_url_items(message: &MessageState) -> Vec<MessageUrlItem> {
+    message_urls(message)
         .into_iter()
         .map(|url| MessageUrlItem {
             label: url.clone(),
@@ -628,17 +628,57 @@ fn message_url_items(content: &str) -> Vec<MessageUrlItem> {
         .collect()
 }
 
-fn extract_message_urls(content: &str) -> Vec<String> {
-    content
-        .split_whitespace()
-        .filter_map(|word| {
-            let trimmed = word.trim_start_matches(['<', '(', '[', '{', '"', '\'']);
-            let trimmed = trimmed
-                .trim_end_matches(['>', ')', ']', '}', '"', '\'', '.', ',', '!', '?', ':', ';']);
-            (trimmed.starts_with("https://") || trimmed.starts_with("http://"))
-                .then(|| trimmed.to_owned())
-        })
-        .collect()
+fn message_urls(message: &MessageState) -> Vec<String> {
+    let mut urls = Vec::new();
+    if let Some(content) = &message.content {
+        urls.extend(detected_urls(content));
+    }
+    for embed in &message.embeds {
+        urls.extend(embed_urls(embed));
+    }
+    dedupe_urls(urls)
+}
+
+fn embed_urls(embed: &EmbedInfo) -> Vec<String> {
+    let mut urls = Vec::new();
+    for value in [
+        embed.provider_name.as_deref(),
+        embed.author_name.as_deref(),
+        embed.title.as_deref(),
+        embed.description.as_deref(),
+        embed.footer_text.as_deref(),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        urls.extend(detected_urls(value));
+    }
+    for field in &embed.fields {
+        urls.extend(detected_urls(&field.name));
+        urls.extend(detected_urls(&field.value));
+    }
+    urls.extend(
+        [
+            embed.url.as_deref(),
+            embed.thumbnail_url.as_deref(),
+            embed.image_url.as_deref(),
+            embed.video_url.as_deref(),
+        ]
+        .into_iter()
+        .flatten()
+        .map(str::to_owned),
+    );
+    urls
+}
+
+fn dedupe_urls(urls: Vec<String>) -> Vec<String> {
+    let mut unique = Vec::new();
+    for url in urls {
+        if !unique.contains(&url) {
+            unique.push(url);
+        }
+    }
+    unique
 }
 
 fn action_reaction_label(emoji: &ReactionEmoji, show_custom_emoji: bool) -> String {

--- a/src/tui/state/message_layout.rs
+++ b/src/tui/state/message_layout.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use crate::discord::MessageState;
 
-use super::*;
+use super::{MessageRowContentMetrics, MessageRowContentMetricsCacheKey, *};
 use crate::tui::{media, message_format, message_rows::MessageRowMetrics, message_time};
 
 const AUTHOR_GROUP_MAX_GAP: Duration = Duration::from_secs(5 * 60);
@@ -134,23 +134,93 @@ impl DashboardState {
         max_preview_height: u16,
         selected_for_bottom: bool,
     ) -> MessageRowMetrics {
-        let (body_lines, reaction_lines) =
-            message_format::format_message_content_sections(message, self, content_width);
-        let previews = message.inline_previews();
-        let album = media::image_preview_album_layout(&previews, preview_width, max_preview_height);
+        let content_metrics = self.message_row_content_metrics(
+            index,
+            message,
+            content_width,
+            preview_width,
+            max_preview_height,
+        );
         MessageRowMetrics {
             top_rows: self.message_extra_top_lines(index),
             header_rows: self.message_header_line_count_at(index),
-            content_rows: body_lines.len(),
-            reaction_rows: reaction_lines.len(),
-            preview_rows: album
-                .height
-                .saturating_add(usize::from(album.overflow_count > 0)),
+            content_rows: content_metrics.content_rows,
+            reaction_rows: content_metrics.reaction_rows,
+            preview_rows: content_metrics.preview_rows,
             selected_extra_top_rows: self.selected_message_extra_top_line_at(index),
             selected_extra_bottom_rows: usize::from(
                 selected_for_bottom && !self.message_has_bottom_gap_after(index),
             ),
             bottom_gap_rows: self.message_bottom_gap_after(index),
+        }
+    }
+
+    fn message_row_content_metrics(
+        &self,
+        index: usize,
+        message: &MessageState,
+        content_width: usize,
+        preview_width: u16,
+        max_preview_height: u16,
+    ) -> MessageRowContentMetrics {
+        let messages = self.messages();
+        let Some(state_message) = messages.get(index) else {
+            return self.compute_message_row_content_metrics(
+                message,
+                content_width,
+                preview_width,
+                max_preview_height,
+            );
+        };
+        if state_message.id != message.id {
+            return self.compute_message_row_content_metrics(
+                message,
+                content_width,
+                preview_width,
+                max_preview_height,
+            );
+        }
+
+        let key = MessageRowContentMetricsCacheKey {
+            message_id: message.id.get(),
+            content_width,
+            preview_width,
+            max_preview_height,
+            show_custom_emoji: self.show_custom_emoji(),
+        };
+        if let Some(metrics) = self.message_row_content_metrics_cache.borrow().get(&key) {
+            return *metrics;
+        }
+
+        let metrics = self.compute_message_row_content_metrics(
+            message,
+            content_width,
+            preview_width,
+            max_preview_height,
+        );
+        self.message_row_content_metrics_cache
+            .borrow_mut()
+            .insert(key, metrics);
+        metrics
+    }
+
+    fn compute_message_row_content_metrics(
+        &self,
+        message: &MessageState,
+        content_width: usize,
+        preview_width: u16,
+        max_preview_height: u16,
+    ) -> MessageRowContentMetrics {
+        let (body_lines, reaction_lines) =
+            message_format::format_message_content_sections(message, self, content_width);
+        let previews = message.inline_previews();
+        let album = media::image_preview_album_layout(&previews, preview_width, max_preview_height);
+        MessageRowContentMetrics {
+            content_rows: body_lines.len(),
+            reaction_rows: reaction_lines.len(),
+            preview_rows: album
+                .height
+                .saturating_add(usize::from(album.overflow_count > 0)),
         }
     }
 

--- a/src/tui/state/model.rs
+++ b/src/tui/state/model.rs
@@ -39,6 +39,7 @@ pub enum MessageActionKind {
     Delete,
     OpenThread,
     ViewImage,
+    OpenUrl,
     DownloadAttachment(usize),
     AddReaction,
     RemoveReaction(usize),
@@ -57,6 +58,18 @@ pub struct MessageActionItem {
     pub enabled: bool,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum MessageActionMenuPhase {
+    Actions,
+    Urls,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MessageUrlItem {
+    pub url: String,
+    pub label: String,
+}
+
 impl MessageActionKind {
     fn preferred_shortcut(&self) -> Option<char> {
         match self {
@@ -65,6 +78,7 @@ impl MessageActionKind {
             MessageActionKind::Delete => Some('d'),
             MessageActionKind::OpenThread => Some('t'),
             MessageActionKind::ViewImage => Some('v'),
+            MessageActionKind::OpenUrl => Some('o'),
             MessageActionKind::DownloadAttachment(_) => Some('f'),
             MessageActionKind::AddReaction => Some('r'),
             MessageActionKind::RemoveReaction(_) => Some('x'),

--- a/src/tui/state/options.rs
+++ b/src/tui/state/options.rs
@@ -180,6 +180,7 @@ impl DashboardState {
         if !self.show_images() {
             self.close_image_viewer();
         }
+        self.clear_message_row_content_metrics_cache();
         self.display_options_save_pending = true;
     }
 

--- a/src/tui/state/popups.rs
+++ b/src/tui/state/popups.rs
@@ -6,11 +6,12 @@ use crate::discord::ids::{
 
 use crate::discord::ReactionUsersInfo;
 
-use super::{EmojiReactionItem, PollVotePickerItem};
+use super::{EmojiReactionItem, MessageActionMenuPhase, PollVotePickerItem};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MessageActionMenuState {
     pub(super) selected: usize,
+    pub(super) phase: MessageActionMenuPhase,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/src/tui/state/reactions.rs
+++ b/src/tui/state/reactions.rs
@@ -1,5 +1,6 @@
 use crate::discord::AppCommand;
 use crate::discord::ids::{Id, marker::GuildMarker};
+use crate::tui::fuzzy::FuzzyScore;
 
 use super::super::fuzzy::fuzzy_text_score;
 use super::emoji::{
@@ -334,7 +335,7 @@ fn filter_emoji_reaction_items_from_slice(
         return items.to_vec();
     }
 
-    let mut scored: Vec<(usize, usize, usize, EmojiReactionItem)> = items
+    let mut scored: Vec<(usize, FuzzyScore, usize, EmojiReactionItem)> = items
         .iter()
         .enumerate()
         .filter_map(|(index, item)| {
@@ -359,7 +360,7 @@ fn emoji_reaction_is_remaining_unicode(item: &EmojiReactionItem) -> bool {
     matches!(&item.emoji, crate::discord::ReactionEmoji::Unicode(emoji) if !is_quick_unicode_emoji(emoji))
 }
 
-fn emoji_reaction_filter_score(item: &EmojiReactionItem, filter: &str) -> Option<usize> {
+fn emoji_reaction_filter_score(item: &EmojiReactionItem, filter: &str) -> Option<FuzzyScore> {
     let label_score = fuzzy_text_score(&item.label, filter);
     let status_score = fuzzy_text_score(&item.emoji.status_label(), filter);
     match (label_score, status_score) {

--- a/src/tui/state/tests/mod.rs
+++ b/src/tui/state/tests/mod.rs
@@ -17,8 +17,8 @@ use super::{
     GuildBranch, GuildPaneEntry, MessageActionKind, MessageState,
 };
 use crate::discord::{
-    ActivityInfo, ActivityKind, AppCommand, AppEvent, AttachmentInfo, ChannelInfo,
-    ChannelNotificationOverrideInfo, ChannelRecipientInfo, ChannelUnreadState,
+    ActivityInfo, ActivityKind, AppCommand, AppEvent, AttachmentInfo, AttachmentUpdate,
+    ChannelInfo, ChannelNotificationOverrideInfo, ChannelRecipientInfo, ChannelUnreadState,
     ChannelVisibilityStats, CustomEmojiInfo, DiscordState, DownloadAttachmentSource,
     EmbedFieldInfo, EmbedInfo, ForumPostArchiveState, FriendStatus, GuildNotificationSettingsInfo,
     MemberInfo, MessageAttachmentUpload, MessageInfo, MessageKind, MessageReferenceInfo,
@@ -1597,6 +1597,104 @@ fn wrapped_content_increases_message_rendered_height() {
     };
 
     assert_eq!(message_rendered_height(&message, 5, 16, 3), 5);
+}
+
+#[test]
+fn message_row_content_metrics_cache_reuses_width_specific_rows() {
+    let state = state_with_single_message_content("abcdefghijkl");
+    let message = state.messages()[0];
+
+    assert_eq!(state.message_row_content_metrics_cache_len(), 0);
+    let first = state.message_row_metrics_at_with_selected_bottom(0, message, 5, 16, 3, true);
+    let second = state.message_row_metrics_at_with_selected_bottom(0, message, 5, 16, 3, true);
+
+    assert_eq!(first, second);
+    assert_eq!(state.message_row_content_metrics_cache_len(), 1);
+
+    let _ = state.message_row_metrics_at_with_selected_bottom(0, message, 4, 16, 3, true);
+
+    assert_eq!(state.message_row_content_metrics_cache_len(), 2);
+}
+
+#[test]
+fn message_row_content_metrics_cache_clears_on_display_option_toggle() {
+    let mut state = state_with_single_message_content("<:party:1234>");
+    let message = state.messages()[0];
+
+    let _ = state.message_row_metrics_at_with_selected_bottom(0, message, 5, 16, 3, true);
+    assert_eq!(state.message_row_content_metrics_cache_len(), 1);
+
+    state.open_options_popup();
+    for _ in 0..4 {
+        state.move_option_down();
+    }
+    state.toggle_selected_display_option();
+
+    assert_eq!(state.message_row_content_metrics_cache_len(), 0);
+}
+
+#[test]
+fn message_row_content_metrics_cache_clears_on_discord_event() {
+    let mut state = state_with_single_message_content("abcdefghijkl");
+    let message = state.messages()[0];
+
+    let _ = state.message_row_metrics_at_with_selected_bottom(0, message, 5, 16, 3, true);
+    assert_eq!(state.message_row_content_metrics_cache_len(), 1);
+
+    state.push_event(AppEvent::MessageUpdate {
+        guild_id: Some(Id::new(1)),
+        channel_id: Id::new(2),
+        message_id: Id::new(1),
+        poll: None,
+        content: Some("updated".to_owned()),
+        sticker_names: None,
+        mentions: None,
+        attachments: AttachmentUpdate::Unchanged,
+        embeds: None,
+        edited_timestamp: Some("2026-01-01T00:00:00Z".to_owned()),
+    });
+
+    assert_eq!(state.message_row_content_metrics_cache_len(), 0);
+}
+
+#[test]
+fn message_row_content_metrics_cache_survives_noisy_discord_events() {
+    let mut state = state_with_single_message_content("abcdefghijkl");
+    let message = state.messages()[0];
+
+    let _ = state.message_row_metrics_at_with_selected_bottom(0, message, 5, 16, 3, true);
+    assert_eq!(state.message_row_content_metrics_cache_len(), 1);
+
+    state.push_event(AppEvent::TypingStart {
+        channel_id: Id::new(2),
+        user_id: Id::new(99),
+    });
+    state.push_event(AppEvent::PresenceUpdate {
+        guild_id: Id::new(1),
+        user_id: Id::new(99),
+        status: PresenceStatus::Online,
+        activities: Vec::new(),
+    });
+    state.push_event(AppEvent::MessageAck {
+        channel_id: Id::new(2),
+        message_id: Id::new(1),
+        mention_count: 0,
+    });
+    state.push_event(AppEvent::UserProfileLoaded {
+        guild_id: Some(Id::new(1)),
+        profile: profile_info(99, Some("neo")),
+    });
+    state.push_event(AppEvent::RelationshipUpsert {
+        relationship: crate::discord::RelationshipInfo {
+            user_id: Id::new(99),
+            status: FriendStatus::Friend,
+            nickname: None,
+            display_name: Some("neo".to_owned()),
+            username: Some("neo".to_owned()),
+        },
+    });
+
+    assert_eq!(state.message_row_content_metrics_cache_len(), 1);
 }
 
 #[test]

--- a/src/tui/state/tests/mod.rs
+++ b/src/tui/state/tests/mod.rs
@@ -1655,6 +1655,44 @@ fn message_row_content_metrics_cache_clears_on_discord_event() {
     });
 
     assert_eq!(state.message_row_content_metrics_cache_len(), 0);
+
+    let message = state.messages()[0];
+    let _ = state.message_row_metrics_at_with_selected_bottom(0, message, 5, 16, 3, true);
+    assert_eq!(state.message_row_content_metrics_cache_len(), 1);
+
+    state.push_event(AppEvent::UserProfileLoaded {
+        guild_id: Some(Id::new(1)),
+        profile: profile_info(99, Some("profile nickname")),
+    });
+
+    assert_eq!(state.message_row_content_metrics_cache_len(), 0);
+
+    let message = state.messages()[0];
+    let _ = state.message_row_metrics_at_with_selected_bottom(0, message, 5, 16, 3, true);
+    assert_eq!(state.message_row_content_metrics_cache_len(), 1);
+
+    state.push_event(AppEvent::VoiceStateUpdate {
+        state: VoiceStateInfo {
+            guild_id: Id::new(1),
+            channel_id: None,
+            user_id: Id::new(99),
+            member: Some(MemberInfo {
+                user_id: Id::new(99),
+                display_name: "voice nickname".to_owned(),
+                username: Some("voice-user".to_owned()),
+                is_bot: false,
+                avatar_url: None,
+                role_ids: Vec::new(),
+            }),
+            deaf: false,
+            mute: false,
+            self_deaf: false,
+            self_mute: false,
+            self_stream: false,
+        },
+    });
+
+    assert_eq!(state.message_row_content_metrics_cache_len(), 0);
 }
 
 #[test]
@@ -1679,10 +1717,6 @@ fn message_row_content_metrics_cache_survives_noisy_discord_events() {
         channel_id: Id::new(2),
         message_id: Id::new(1),
         mention_count: 0,
-    });
-    state.push_event(AppEvent::UserProfileLoaded {
-        guild_id: Some(Id::new(1)),
-        profile: profile_info(99, Some("neo")),
     });
     state.push_event(AppEvent::RelationshipUpsert {
         relationship: crate::discord::RelationshipInfo {

--- a/src/tui/state/tests/mod.rs
+++ b/src/tui/state/tests/mod.rs
@@ -6143,6 +6143,69 @@ fn forum_channel_upsert_inserts_new_thread_at_top_of_active_list() {
 }
 
 #[test]
+fn forum_channel_upsert_effect_inserts_new_thread_after_snapshot_restore() {
+    let guild_id = Id::new(1);
+    let forum_id = Id::new(20);
+    let welcome_thread = forum_thread_info(guild_id, forum_id, 30, "welcome", None, false);
+    let new_thread = forum_thread_info(guild_id, forum_id, 31, "brand-new", None, false);
+    let mut state = DashboardState::new();
+
+    state.push_event(AppEvent::GuildCreate {
+        guild_id,
+        name: "guild".to_owned(),
+        member_count: None,
+        channels: vec![forum_channel_info(guild_id, forum_id)],
+        members: Vec::new(),
+        presences: Vec::new(),
+        roles: Vec::new(),
+        emojis: Vec::new(),
+        owner_id: None,
+    });
+    state.confirm_selected_guild();
+    state.confirm_selected_channel();
+    state.push_event(AppEvent::ForumPostsLoaded {
+        channel_id: forum_id,
+        archive_state: ForumPostArchiveState::Active,
+        offset: 0,
+        next_offset: 1,
+        posts: vec![welcome_thread.clone()],
+        preview_messages: Vec::new(),
+        has_more: false,
+    });
+
+    let mut snapshot_state = DiscordState::default();
+    snapshot_state.apply_event(&AppEvent::GuildCreate {
+        guild_id,
+        name: "guild".to_owned(),
+        member_count: None,
+        channels: vec![
+            forum_channel_info(guild_id, forum_id),
+            welcome_thread,
+            new_thread.clone(),
+        ],
+        members: Vec::new(),
+        presences: Vec::new(),
+        roles: Vec::new(),
+        emojis: Vec::new(),
+        owner_id: None,
+    });
+    state.restore_discord_snapshot(snapshot_state);
+    state.push_effect(AppEvent::ChannelUpsert(new_thread.clone()));
+
+    assert_eq!(
+        state
+            .selected_forum_post_items()
+            .iter()
+            .map(|post| post.label.as_str())
+            .collect::<Vec<_>>(),
+        vec!["brand-new", "welcome"]
+    );
+
+    state.push_effect(AppEvent::ChannelUpsert(new_thread));
+    assert_eq!(state.selected_forum_post_items().len(), 2);
+}
+
+#[test]
 fn forum_sidebar_unread_aggregates_unread_child_posts() {
     let guild_id = Id::new(1);
     let forum_id = Id::new(20);
@@ -7355,7 +7418,7 @@ fn viewport_scroll_does_not_move_list_pane_selection() {
     channel_state.scroll_focused_pane_viewport_down();
     assert_eq!(channel_state.selected_channel(), selected_channel);
     assert_eq!(channel_state.channel_scroll(), channel_scroll + 1);
-    assert_eq!(channel_state.focused_channel_selection(), None);
+    assert!(channel_state.selected_channel() < channel_state.channel_scroll());
 
     let mut member_state = state_with_members(8);
     member_state.focus_pane(FocusPane::Members);

--- a/src/tui/state/tests/mod.rs
+++ b/src/tui/state/tests/mod.rs
@@ -20,11 +20,12 @@ use crate::discord::{
     ActivityInfo, ActivityKind, AppCommand, AppEvent, AttachmentInfo, ChannelInfo,
     ChannelNotificationOverrideInfo, ChannelRecipientInfo, ChannelUnreadState,
     ChannelVisibilityStats, CustomEmojiInfo, DiscordState, DownloadAttachmentSource,
-    ForumPostArchiveState, FriendStatus, GuildNotificationSettingsInfo, MemberInfo,
-    MessageAttachmentUpload, MessageInfo, MessageKind, MessageReferenceInfo, MessageSnapshotInfo,
-    MutualGuildInfo, NotificationLevel, PermissionOverwriteInfo, PermissionOverwriteKind,
-    PresenceStatus, ReactionEmoji, ReactionInfo, ReactionUserInfo, ReactionUsersInfo,
-    ReadStateInfo, ReplyInfo, RoleInfo, SnapshotRevision, UserProfileInfo, VoiceStateInfo,
+    EmbedFieldInfo, EmbedInfo, ForumPostArchiveState, FriendStatus, GuildNotificationSettingsInfo,
+    MemberInfo, MessageAttachmentUpload, MessageInfo, MessageKind, MessageReferenceInfo,
+    MessageSnapshotInfo, MutualGuildInfo, NotificationLevel, PermissionOverwriteInfo,
+    PermissionOverwriteKind, PresenceStatus, ReactionEmoji, ReactionInfo, ReactionUserInfo,
+    ReactionUsersInfo, ReadStateInfo, ReplyInfo, RoleInfo, SnapshotRevision, UserProfileInfo,
+    VoiceStateInfo,
 };
 
 fn message_rendered_height(
@@ -2895,6 +2896,84 @@ fn message_action_opens_url_picker_for_multiple_urls() {
         })
     );
     assert!(!state.is_message_action_menu_open());
+}
+
+#[test]
+fn message_action_detects_markdown_link_urls() {
+    let mut state = state_with_messages(1);
+    state.push_event(AppEvent::MessageHistoryLoaded {
+        channel_id: Id::new(2),
+        before: None,
+        messages: vec![MessageInfo {
+            content: Some(
+                "[Tweet](<https://x.com/i/status/2055068765671305537>) • [@steelers](<https://x.com/steelers>) • [FxTwitter](https://fxtwitter.com/i/status/2055068765671305537)"
+                    .to_owned(),
+            ),
+            ..message_info(Id::new(2), 1)
+        }],
+    });
+    state.focus_pane(FocusPane::Messages);
+    state.open_selected_message_actions();
+
+    let urls = state.selected_message_url_items();
+
+    assert_eq!(
+        urls.into_iter().map(|item| item.url).collect::<Vec<_>>(),
+        vec![
+            "https://x.com/i/status/2055068765671305537",
+            "https://x.com/steelers",
+            "https://fxtwitter.com/i/status/2055068765671305537",
+        ]
+    );
+}
+
+#[test]
+fn message_action_detects_embed_urls() {
+    let mut state = state_with_messages(1);
+    state.push_event(AppEvent::MessageHistoryLoaded {
+        channel_id: Id::new(2),
+        before: None,
+        messages: vec![MessageInfo {
+            content: Some("embed below".to_owned()),
+            embeds: vec![EmbedInfo {
+                color: None,
+                provider_name: None,
+                author_name: None,
+                title: Some("Release notes".to_owned()),
+                description: Some("Read [docs](<https://docs.example/release>)".to_owned()),
+                timestamp: None,
+                fields: vec![EmbedFieldInfo {
+                    name: "Links".to_owned(),
+                    value: "Status https://status.example".to_owned(),
+                }],
+                footer_text: None,
+                url: Some("https://app.example/releases/1".to_owned()),
+                thumbnail_url: None,
+                thumbnail_proxy_url: None,
+                thumbnail_width: None,
+                thumbnail_height: None,
+                image_url: None,
+                image_proxy_url: None,
+                image_width: None,
+                image_height: None,
+                video_url: None,
+            }],
+            ..message_info(Id::new(2), 1)
+        }],
+    });
+    state.focus_pane(FocusPane::Messages);
+    state.open_selected_message_actions();
+
+    let urls = state.selected_message_url_items();
+
+    assert_eq!(
+        urls.into_iter().map(|item| item.url).collect::<Vec<_>>(),
+        vec![
+            "https://docs.example/release",
+            "https://status.example",
+            "https://app.example/releases/1",
+        ]
+    );
 }
 
 #[test]

--- a/src/tui/state/tests/mod.rs
+++ b/src/tui/state/tests/mod.rs
@@ -2836,6 +2836,68 @@ fn reply_non_image_attachment_action_downloads_with_proxy_url_fallback() {
 }
 
 #[test]
+fn message_action_opens_single_url_from_message_content() {
+    let mut state = state_with_messages(1);
+    state.push_event(AppEvent::MessageHistoryLoaded {
+        channel_id: Id::new(2),
+        before: None,
+        messages: vec![MessageInfo {
+            content: Some("read https://example.com/docs.".to_owned()),
+            ..message_info(Id::new(2), 1)
+        }],
+    });
+    state.focus_pane(FocusPane::Messages);
+    state.open_selected_message_actions();
+
+    let actions = state.selected_message_action_items();
+    assert!(
+        actions.iter().any(|action| {
+            action.kind == MessageActionKind::OpenUrl && action.label == "Open URL"
+        })
+    );
+
+    assert_eq!(
+        state.activate_message_action_shortcut('o'),
+        Some(AppCommand::OpenUrl {
+            url: "https://example.com/docs".to_owned(),
+        })
+    );
+    assert!(!state.is_message_action_menu_open());
+}
+
+#[test]
+fn message_action_opens_url_picker_for_multiple_urls() {
+    let mut state = state_with_messages(1);
+    state.push_event(AppEvent::MessageHistoryLoaded {
+        channel_id: Id::new(2),
+        before: None,
+        messages: vec![MessageInfo {
+            content: Some("one https://one.example two <https://two.example/path>,".to_owned()),
+            ..message_info(Id::new(2), 1)
+        }],
+    });
+    state.focus_pane(FocusPane::Messages);
+    state.open_selected_message_actions();
+
+    let actions = state.selected_message_action_items();
+    assert!(actions.iter().any(|action| {
+        action.kind == MessageActionKind::OpenUrl && action.label == "Open URL (2)"
+    }));
+
+    assert_eq!(state.activate_message_action_shortcut('o'), None);
+    assert!(state.is_message_url_picker_open());
+    assert_eq!(state.selected_message_url_index(), Some(0));
+
+    assert_eq!(
+        state.activate_message_action_shortcut('2'),
+        Some(AppCommand::OpenUrl {
+            url: "https://two.example/path".to_owned(),
+        })
+    );
+    assert!(!state.is_message_action_menu_open());
+}
+
+#[test]
 fn non_regular_message_actions_do_not_include_attachment_downloads() {
     let mut state = state_with_message_ids([]);
     state.push_event(AppEvent::MessageCreate {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -25,9 +25,9 @@ use super::{
     state::{
         ChannelSwitcherItem, ChannelThreadItem, DashboardState, DisplayOptionItem,
         EmojiReactionItem, FORUM_POST_CARD_HEIGHT, FocusPane, ImageViewerItem, MessageActionItem,
-        PollVotePickerItem, channel_action_shortcut, discord_color, emoji_reaction_shortcut,
-        guild_action_shortcut, indexed_shortcut, member_action_shortcut, message_action_shortcut,
-        presence_color, presence_marker,
+        MessageUrlItem, PollVotePickerItem, channel_action_shortcut, discord_color,
+        emoji_reaction_shortcut, guild_action_shortcut, indexed_shortcut, member_action_shortcut,
+        message_action_shortcut, presence_color, presence_marker,
     },
 };
 use crate::discord::{
@@ -105,9 +105,9 @@ use self::{
         debug_log_popup_lines, emoji_reaction_picker_lines, emoji_reaction_picker_lines_for_width,
         emoji_reaction_picker_lines_with_existing, filtered_emoji_reaction_picker_lines,
         message_action_menu_lines, message_delete_confirmation_lines,
-        message_pin_confirmation_lines, options_popup_lines, poll_vote_picker_lines,
-        reaction_users_popup_lines, toast_area, toast_line, user_profile_popup_lines,
-        user_profile_popup_lines_with_activities,
+        message_pin_confirmation_lines, message_url_picker_lines_for_width, options_popup_lines,
+        poll_vote_picker_lines, reaction_users_popup_lines, toast_area, toast_line,
+        user_profile_popup_lines, user_profile_popup_lines_with_activities,
     },
 };
 pub fn sync_view_heights(area: Rect, state: &mut DashboardState) {

--- a/src/tui/ui/interaction.rs
+++ b/src/tui/ui/interaction.rs
@@ -114,7 +114,11 @@ fn action_menu_mouse_target(
     if state.is_message_action_menu_open() {
         return action_menu_row_target(
             message_action_menu_area(area, state),
-            state.selected_message_action_items().len(),
+            if state.is_message_url_picker_open() {
+                state.selected_message_url_items().len()
+            } else {
+                state.selected_message_action_items().len()
+            },
             ActionMenuTarget::Message,
             column,
             row,
@@ -147,8 +151,12 @@ fn action_menu_row_target(
 }
 
 fn message_action_menu_area(area: Rect, state: &DashboardState) -> Option<Rect> {
-    let actions = state.selected_message_action_items();
-    (!actions.is_empty()).then(|| centered_rect(area, 54, (actions.len() as u16).saturating_add(2)))
+    let item_count = if state.is_message_url_picker_open() {
+        state.selected_message_url_items().len()
+    } else {
+        state.selected_message_action_items().len()
+    };
+    (item_count > 0).then(|| centered_rect(area, 54, (item_count as u16).saturating_add(2)))
 }
 
 fn pane_row_mouse_target(

--- a/src/tui/ui/message_list.rs
+++ b/src/tui/ui/message_list.rs
@@ -30,7 +30,7 @@ pub(super) fn render_messages(
     area: Rect,
     state: &DashboardState,
     image_previews: Vec<ImagePreview<'_>>,
-    avatar_images: Vec<AvatarImage>,
+    avatar_images: Vec<AvatarImage<'_>>,
     emoji_images: &[EmojiImage<'_>],
 ) {
     let block = panel_block_owned(
@@ -143,7 +143,7 @@ pub(super) fn render_messages(
             avatar.visible_height,
             selected_avatar_x_offset(selected_avatar_body_top, avatar.row),
         ) {
-            frame.render_widget(RatatuiImage::new(&avatar.protocol), area);
+            frame.render_widget(RatatuiImage::new(avatar.protocol), area);
         }
     }
     render_inline_reaction_emojis(

--- a/src/tui/ui/panes.rs
+++ b/src/tui/ui/panes.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use ratatui::{
     Frame,
     layout::{Alignment, Position, Rect},
@@ -302,9 +304,33 @@ pub(super) fn render_channels(frame: &mut Frame, area: Rect, state: &DashboardSt
         (channels_area, None)
     };
 
-    let channel_entry_count = state.channel_pane_filtered_entries().len();
-    let all_channel_entries = state.channel_pane_entries();
-    let entries = state.visible_channel_pane_entries();
+    let channel_entries = state.channel_pane_filtered_entries();
+    let channel_entry_count = channel_entries.len();
+    let all_channel_entries;
+    let populated_channel_entries = if state.channel_pane_filter_query().is_some() {
+        all_channel_entries = state.channel_pane_entries();
+        all_channel_entries.as_slice()
+    } else {
+        channel_entries.as_slice()
+    };
+    let populated_voice_channel_ids: HashSet<_> = populated_channel_entries
+        .windows(2)
+        .filter_map(|window| match (&window[0], &window[1]) {
+            (
+                ChannelPaneEntry::Channel { state: channel, .. },
+                ChannelPaneEntry::VoiceParticipant { .. },
+            ) => Some(channel.id),
+            _ => None,
+        })
+        .collect();
+    let channel_scroll = state.channel_scroll();
+    let selected_channel = (state.focus() == FocusPane::Channels && channel_entry_count > 0)
+        .then(|| state.selected_channel_from_entries(&channel_entries));
+    let entries: Vec<_> = channel_entries
+        .into_iter()
+        .skip(channel_scroll)
+        .take(list_area.height as usize)
+        .collect();
     let scrollbar_width = usize::from(vertical_scrollbar_visible(
         list_area,
         list_area.height as usize,
@@ -314,7 +340,11 @@ pub(super) fn render_channels(frame: &mut Frame, area: Rect, state: &DashboardSt
         .saturating_sub(selection_marker(false).content.width())
         .saturating_sub(scrollbar_width);
     let horizontal_scroll = state.channel_horizontal_scroll();
-    let selected = state.focused_channel_selection();
+    let selected = selected_channel
+        .filter(|selected| {
+            *selected >= channel_scroll && *selected < channel_scroll + entries.len()
+        })
+        .map(|selected| selected - channel_scroll);
     let items: Vec<ListItem> = entries
         .iter()
         .enumerate()
@@ -351,16 +381,8 @@ pub(super) fn render_channels(frame: &mut Frame, area: Rect, state: &DashboardSt
                         let prefix_width = dm_prefix_span
                             .as_ref()
                             .map_or_else(|| channel_prefix.width(), |span| span.content.width());
-                        let populated_voice_channel = state.is_voice()
-                            && all_channel_entries.windows(2).any(|window| {
-                                matches!(
-                                    (&window[0], &window[1]),
-                                    (
-                                        ChannelPaneEntry::Channel { state: channel, .. },
-                                        ChannelPaneEntry::VoiceParticipant { .. }
-                                    ) if channel.id == state.id
-                                )
-                            });
+                        let populated_voice_channel =
+                            state.is_voice() && populated_voice_channel_ids.contains(&state.id);
                         let base_style = active_text_style(is_active, Style::default());
                         let is_muted = dashboard.channel_notification_muted(state.id);
                         let unread = dashboard.sidebar_channel_unread(state.id);

--- a/src/tui/ui/popups.rs
+++ b/src/tui/ui/popups.rs
@@ -17,6 +17,8 @@ mod toast;
 
 #[cfg(test)]
 pub(super) use action_menu::message_action_menu_lines;
+#[cfg(test)]
+pub(super) use action_menu::message_url_picker_lines_for_width;
 pub(super) use action_menu::{render_leader_popup, render_message_action_menu};
 #[cfg(test)]
 pub(super) use channel_switcher::{channel_switcher_cursor_position, channel_switcher_lines};

--- a/src/tui/ui/popups/action_menu.rs
+++ b/src/tui/ui/popups/action_menu.rs
@@ -43,7 +43,9 @@ fn leader_popup_title(state: &DashboardState) -> String {
         return "Leader".to_owned();
     }
 
-    if state.is_message_action_menu_open() {
+    if state.is_message_url_picker_open() {
+        "Open URL".to_owned()
+    } else if state.is_message_action_menu_open() {
         "Message Actions".to_owned()
     } else if state.is_channel_leader_action_active() {
         "Channel Actions".to_owned()
@@ -113,6 +115,16 @@ fn leader_line_width(line: &Line<'_>) -> usize {
 }
 
 fn leader_action_lines(state: &DashboardState) -> Vec<Line<'static>> {
+    if state.is_message_url_picker_open() {
+        return state
+            .selected_message_url_items()
+            .iter()
+            .enumerate()
+            .map(|(index, item)| {
+                leader_shortcut_line(indexed_shortcut(index).unwrap_or(' '), &item.label, true)
+            })
+            .collect();
+    }
     if state.is_message_action_menu_open() {
         let actions = state.selected_message_action_items();
         return actions
@@ -237,17 +249,36 @@ pub(in crate::tui::ui) fn render_message_action_menu(
         return;
     }
 
-    let actions = state.selected_message_action_items();
-    if actions.is_empty() {
-        return;
-    }
+    let (title, lines, len) = if state.is_message_url_picker_open() {
+        let urls = state.selected_message_url_items();
+        if urls.is_empty() {
+            return;
+        }
+        let selected = state.selected_message_url_index().unwrap_or(0);
+        (
+            "Open URL",
+            message_url_picker_lines(&urls, selected),
+            urls.len(),
+        )
+    } else {
+        let actions = state.selected_message_action_items();
+        if actions.is_empty() {
+            return;
+        }
+        let selected = state.selected_message_action_index().unwrap_or(0);
+        (
+            "Message actions",
+            message_action_menu_lines(&actions, selected),
+            actions.len(),
+        )
+    };
 
-    let selected = state.selected_message_action_index().unwrap_or(0);
-    let popup = centered_rect(area, 54, (actions.len() as u16).saturating_add(2));
+    let popup = centered_rect(area, 54, (len as u16).saturating_add(2));
+    let lines = truncate_action_menu_lines(lines, popup.width.saturating_sub(2) as usize);
     frame.render_widget(Clear, popup);
     frame.render_widget(
-        Paragraph::new(message_action_menu_lines(&actions, selected))
-            .block(panel_block("Message actions", true))
+        Paragraph::new(lines)
+            .block(panel_block(title, true))
             .wrap(Wrap { trim: false }),
         popup,
     );
@@ -284,5 +315,45 @@ pub(in crate::tui::ui) fn message_action_menu_lines(
                 Span::styled(label, style),
             ])
         })
+        .collect()
+}
+
+pub(in crate::tui::ui) fn message_url_picker_lines(
+    urls: &[MessageUrlItem],
+    selected: usize,
+) -> Vec<Line<'static>> {
+    urls.iter()
+        .enumerate()
+        .map(|(index, item)| {
+            let marker = if index == selected { "› " } else { "  " };
+            let shortcut = shortcut_prefix(indexed_shortcut(index));
+            let mut style = Style::default();
+            if index == selected {
+                style = style
+                    .bg(Color::Rgb(40, 45, 90))
+                    .add_modifier(Modifier::BOLD);
+            }
+            Line::from(vec![
+                Span::styled(marker, Style::default().fg(ACCENT)),
+                Span::styled(shortcut, Style::default().fg(DIM)),
+                Span::styled(item.label.to_owned(), style),
+            ])
+        })
+        .collect()
+}
+
+#[cfg(test)]
+pub(in crate::tui::ui) fn message_url_picker_lines_for_width(
+    urls: &[MessageUrlItem],
+    selected: usize,
+    width: usize,
+) -> Vec<Line<'static>> {
+    truncate_action_menu_lines(message_url_picker_lines(urls, selected), width)
+}
+
+fn truncate_action_menu_lines(lines: Vec<Line<'static>>, width: usize) -> Vec<Line<'static>> {
+    lines
+        .into_iter()
+        .map(|line| truncate_line_to_display_width(line, width.max(1)))
         .collect()
 }

--- a/src/tui/ui/popups/profile.rs
+++ b/src/tui/ui/popups/profile.rs
@@ -68,7 +68,7 @@ pub(in crate::tui::ui) fn render_user_profile_popup(
             width: USER_PROFILE_POPUP_AVATAR_CELL_WIDTH.min(inner.width),
             height: AVATAR_CELL_HEIGHT.min(inner.height),
         };
-        frame.render_widget(RatatuiImage::new(&avatar.protocol), avatar_area);
+        frame.render_widget(RatatuiImage::new(avatar.protocol), avatar_area);
     }
 }
 

--- a/src/tui/ui/tests.rs
+++ b/src/tui/ui/tests.rs
@@ -2943,6 +2943,23 @@ fn message_content_highlights_detected_urls() {
 }
 
 #[test]
+fn message_content_highlights_markdown_link_urls() {
+    let message = message_with_content(Some(
+        "[Tweet](<https://x.com/i/status/2055068765671305537>)".to_owned(),
+    ));
+
+    let lines = format_message_content_lines(&message, &DashboardState::new(), 200);
+    let spans = lines[0].spans();
+
+    let url_span = spans
+        .iter()
+        .find(|span| span.content.as_ref() == "https://x.com/i/status/2055068765671305537")
+        .expect("markdown link URL is rendered as its own span");
+
+    assert!(url_span.style.add_modifier.contains(Modifier::UNDERLINED));
+}
+
+#[test]
 fn message_content_highlights_everyone_mentions_for_current_user() {
     let message = message_with_content(Some("ping @everyone".to_owned()));
     let mut state = DashboardState::new();

--- a/src/tui/ui/tests.rs
+++ b/src/tui/ui/tests.rs
@@ -2915,6 +2915,34 @@ fn message_content_highlights_other_user_mentions_with_softer_color() {
 }
 
 #[test]
+fn message_content_highlights_detected_urls() {
+    let message = message_with_content(Some(
+        "open https://thisis.com/a.test?with=querystrings#page now".to_owned(),
+    ));
+
+    let lines = format_message_content_lines(&message, &DashboardState::new(), 200);
+
+    assert_eq!(
+        line_texts(&lines),
+        vec!["open https://thisis.com/a.test?with=querystrings#page now"]
+    );
+    assert_eq!(
+        lines[0].spans()[1].content.as_ref(),
+        "https://thisis.com/a.test?with=querystrings#page"
+    );
+    assert_eq!(
+        lines[0].spans()[1].style.fg,
+        mention_highlight_style(TextHighlightKind::Url).fg
+    );
+    assert!(
+        lines[0].spans()[1]
+            .style
+            .add_modifier
+            .contains(Modifier::UNDERLINED)
+    );
+}
+
+#[test]
 fn message_content_highlights_everyone_mentions_for_current_user() {
     let message = message_with_content(Some("ping @everyone".to_owned()));
     let mut state = DashboardState::new();

--- a/src/tui/ui/tests.rs
+++ b/src/tui/ui/tests.rs
@@ -23,12 +23,13 @@ use super::{
     inline_image_preview_area, inline_image_preview_row, member_display_label, member_name_style,
     message_action_menu_lines, message_author_style, message_body_custom_emoji_rows,
     message_delete_confirmation_lines, message_item_lines, message_pin_confirmation_lines,
-    message_viewport_lines, new_messages_notice_line, options_popup_lines, poll_vote_picker_lines,
-    primary_activity_summary, reaction_users_popup_lines, reaction_users_visible_line_count,
-    render_channels, render_guilds, selected_avatar_x_offset, selected_message_card_width,
-    selected_message_content_x_offset, sync_view_heights, toast_area, toast_line,
-    user_profile_popup_has_avatar, user_profile_popup_lines,
-    user_profile_popup_lines_with_activities, user_profile_popup_text_geometry,
+    message_url_picker_lines_for_width, message_viewport_lines, new_messages_notice_line,
+    options_popup_lines, poll_vote_picker_lines, primary_activity_summary,
+    reaction_users_popup_lines, reaction_users_visible_line_count, render_channels, render_guilds,
+    selected_avatar_x_offset, selected_message_card_width, selected_message_content_x_offset,
+    sync_view_heights, toast_area, toast_line, user_profile_popup_has_avatar,
+    user_profile_popup_lines, user_profile_popup_lines_with_activities,
+    user_profile_popup_text_geometry,
 };
 use crate::tui::message_time::{
     discord_epoch_unix_millis, format_unix_millis_with_offset, message_starts_new_day,
@@ -3678,6 +3679,21 @@ fn message_action_menu_uses_numbered_shortcuts_for_duplicate_preferred_keys() {
     assert_eq!(
         line_texts_from_ratatui(&lines),
         vec!["› [1] Delete message", "  [2] Download image"]
+    );
+}
+
+#[test]
+fn message_url_picker_truncates_fragment_urls_to_menu_width() {
+    let urls = vec![super::MessageUrlItem {
+        url: "https://thisis.com/a.test?with=querystrings#page".to_owned(),
+        label: "https://thisis.com/a.test?with=querystrings#page".to_owned(),
+    }];
+
+    let lines = message_url_picker_lines_for_width(&urls, 0, 30);
+
+    assert_eq!(
+        line_texts_from_ratatui(&lines),
+        vec!["› [1] https://thisis.com/a...."]
     );
 }
 

--- a/src/tui/ui/types.rs
+++ b/src/tui/ui/types.rs
@@ -30,10 +30,10 @@ pub struct ImagePreview<'a> {
     pub state: ImagePreviewState<'a>,
 }
 
-pub struct AvatarImage {
+pub struct AvatarImage<'a> {
     pub row: isize,
     pub visible_height: u16,
-    pub protocol: Protocol,
+    pub protocol: &'a Protocol,
 }
 
 pub struct EmojiImage<'a> {


### PR DESCRIPTION
## Problem

When someone posts a link or multiple links in a message, I'd like to be able to open them.

## Proposed solution

In the "Message actions" window, I have added the "Open URL" option with the current shortcut key `o` (the lowercase letter O).  If only a single URL is detected in the message, the `o` key immediately opens the URL in the browser.  If multiple links are detected, it will open a submenu where the first 10 messages are available via the shortcut keys of 1-0, and the rest must simply be scrolled to.

I also added some simple highlighting of URLs to make them more obvious.

### Screenshots

Message
<img width="934" height="95" alt="Screenshot 2026-05-14 at 9 31 44 PM" src="https://github.com/user-attachments/assets/2e15db8f-ceec-4bf9-b5aa-a25610eb47f5" />

Initial Menu
<img width="416" height="264" alt="Screenshot 2026-05-14 at 9 22 54 PM" src="https://github.com/user-attachments/assets/4401f900-a090-4e8f-b707-d7af37a1fa94" />

Selection Menu
<img width="421" height="182" alt="Screenshot 2026-05-14 at 9 23 00 PM" src="https://github.com/user-attachments/assets/bbfbce42-e252-4346-b4ec-35e2b5378aec" />