### PR TITLE
fix(search): improve fuzzy search logic

### DIFF
--- a/src/tui/fuzzy.rs
+++ b/src/tui/fuzzy.rs
@@ -1,131 +1,268 @@
-pub(super) fn fuzzy_text_score(value: &str, query: &str) -> Option<usize> {
-    let needle = query.trim().to_lowercase();
-    if needle.is_empty() {
-        return Some(0);
-    }
+use std::cmp::Ordering;
 
-    let haystack = value.to_lowercase();
-    if haystack == needle {
-        return Some(0);
-    }
-    if haystack.starts_with(&needle) {
-        return Some(
-            10 + haystack
-                .chars()
-                .count()
-                .saturating_sub(needle.chars().count()),
-        );
-    }
-    if let Some(byte_index) = haystack.find(&needle) {
-        return Some(100 + byte_index);
-    }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FuzzyScore(pub i32);
 
-    let needle_chars: Vec<char> = needle.chars().collect();
-    let haystack_chars: Vec<char> = haystack.chars().collect();
-
-    if let Some(score) = subsequence_score(&haystack_chars, &needle_chars, 1000) {
-        return Some(score);
+impl Ord for FuzzyScore {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Reverse ordering:
+        // larger score = "earlier" in sort order
+        other.0.cmp(&self.0)
     }
-
-    typo_tolerant_subsequence_score(&haystack_chars, &needle_chars)
 }
 
-fn subsequence_score(
-    haystack_chars: &[char],
-    needle_chars: &[char],
-    score_base: usize,
-) -> Option<usize> {
-    let mut positions = Vec::with_capacity(needle_chars.len());
-    let mut needle_index = 0usize;
-    for (haystack_index, haystack_char) in haystack_chars.iter().enumerate() {
-        if needle_chars.get(needle_index) == Some(haystack_char) {
-            positions.push(haystack_index);
-            needle_index += 1;
-            if needle_index == needle_chars.len() {
-                break;
-            }
+impl PartialOrd for FuzzyScore {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl FuzzyScore {
+    pub const EXACT: i32 = 10_000;
+    pub const PREFIX: i32 = 9_000;
+}
+
+pub(super) fn fuzzy_text_score(value: &str, query: &str) -> Option<FuzzyScore> {
+    let query = query.trim();
+
+    if query.is_empty() {
+        return Some(FuzzyScore(0));
+    }
+
+    let value_chars: Vec<char> = value.chars().collect();
+    let query_chars: Vec<char> = query.chars().collect();
+
+    let value_lower: Vec<char> = value.chars().flat_map(char::to_lowercase).collect();
+
+    let query_lower: Vec<char> = query.chars().flat_map(char::to_lowercase).collect();
+
+    // Fast paths.
+    if value_lower == query_lower {
+        return Some(FuzzyScore(FuzzyScore::EXACT));
+    }
+
+    if starts_with_chars(&value_lower, &query_lower) {
+        return Some(FuzzyScore(FuzzyScore::PREFIX - value_chars.len() as i32));
+    }
+
+    // Dynamic programming:
+    //
+    // dp[q][v] = best score matching query[..=q]
+    //            ending exactly at value[v]
+    //
+    let mut dp = vec![vec![i32::MIN; value_chars.len()]; query_chars.len()];
+
+    for v in 0..value_chars.len() {
+        if !chars_equal(value_lower[v], query_lower[0]) {
+            continue;
         }
-    }
-    if positions.len() != needle_chars.len() {
-        return None;
+
+        dp[0][v] = character_score(&value_chars, &query_chars, v, true);
     }
 
-    let start = positions.first().copied().unwrap_or(0);
-    let end = positions.last().copied().unwrap_or(start);
-    let span = end.saturating_sub(start).saturating_add(1);
-    let gaps = span.saturating_sub(needle_chars.len());
-    Some(score_base + span * 10 + gaps + start)
-}
+    for q in 1..query_chars.len() {
+        for v in q..value_chars.len() {
+            if !chars_equal(value_lower[v], query_lower[q]) {
+                continue;
+            }
 
-fn typo_tolerant_subsequence_score(
-    haystack_chars: &[char],
-    needle_chars: &[char],
-) -> Option<usize> {
-    if needle_chars.len() < 3 {
-        return None;
+            let mut best = i32::MIN;
+
+            dp[q - 1]
+                .iter()
+                .take(v)
+                .enumerate()
+                .for_each(|(prev, &prev_score)| {
+                    if prev_score == i32::MIN {
+                        return;
+                    }
+
+                    let gap = v - prev - 1;
+
+                    let mut score = prev_score;
+
+                    // Strong contiguous preference.
+                    if gap == 0 {
+                        score += 40;
+                    } else {
+                        score -= (gap as i32) * 3;
+                    }
+
+                    score += character_score(&value_chars, &query_chars, v, false);
+
+                    best = best.max(score);
+                });
+
+            dp[q][v] = best;
+        }
     }
 
     let mut best = None;
-    for removed_index in 0..needle_chars.len() {
-        let candidate = needle_chars
-            .iter()
-            .enumerate()
-            .filter_map(|(index, value)| (index != removed_index).then_some(*value))
-            .collect::<Vec<_>>();
-        best = better_score(best, subsequence_score(haystack_chars, &candidate, 2100));
+
+    for &score in &dp[query_chars.len() - 1][0..value_chars.len()] {
+        if score == i32::MIN {
+            continue;
+        }
+
+        // Prefer shorter candidates slightly.
+        let final_score = score - value_chars.len() as i32;
+
+        best = Some(best.map_or(final_score, |b: i32| b.max(final_score)));
     }
 
-    for swapped_index in 0..needle_chars.len().saturating_sub(1) {
-        let mut candidate = needle_chars.to_vec();
-        candidate.swap(swapped_index, swapped_index + 1);
-        best = better_score(best, subsequence_score(haystack_chars, &candidate, 2200));
-    }
-
-    best
+    best.map(FuzzyScore)
 }
 
-fn better_score(current: Option<usize>, candidate: Option<usize>) -> Option<usize> {
-    match (current, candidate) {
-        (Some(current), Some(candidate)) => Some(current.min(candidate)),
-        (Some(current), None) => Some(current),
-        (None, Some(candidate)) => Some(candidate),
-        (None, None) => None,
+fn character_score(
+    value_chars: &[char],
+    query_chars: &[char],
+    index: usize,
+    first_match: bool,
+) -> i32 {
+    let mut score = 10;
+
+    // Earlier matches are better.
+    if first_match {
+        score += 20 - (index.min(20) as i32);
     }
+
+    // Word boundary bonus.
+    if is_word_boundary(value_chars, index) {
+        score += 18;
+    }
+
+    // camelCase bonus.
+    if is_camel_boundary(value_chars, index) {
+        score += 14;
+    }
+
+    // Exact case bonus.
+    if value_chars[index] == query_chars.get(index).copied().unwrap_or('\0') {
+        score += 5;
+    }
+
+    score
+}
+
+fn chars_equal(a: char, b: char) -> bool {
+    a == b
+}
+
+fn starts_with_chars(haystack: &[char], needle: &[char]) -> bool {
+    haystack.starts_with(needle)
+}
+
+fn is_word_boundary(chars: &[char], index: usize) -> bool {
+    if index == 0 {
+        return true;
+    }
+
+    matches!(chars[index - 1], ' ' | '_' | '-' | '/' | '\\' | '.')
+}
+
+fn is_camel_boundary(chars: &[char], index: usize) -> bool {
+    if index == 0 {
+        return false;
+    }
+
+    chars[index].is_uppercase() && chars[index - 1].is_lowercase()
 }
 
 #[cfg(test)]
 mod tests {
-    use super::fuzzy_text_score;
+    use super::{FuzzyScore, fuzzy_text_score};
+
+    fn score(value: &str, query: &str) -> i32 {
+        fuzzy_text_score(value, query)
+            .unwrap_or_else(|| panic!("expected match: {value:?} vs {query:?}"))
+            .0
+    }
 
     #[test]
-    fn fuzzy_text_score_matches_subsequences() {
+    fn matches_simple_subsequences() {
         assert!(fuzzy_text_score("general", "gnrl").is_some());
+        assert!(fuzzy_text_score("GitDiffFile", "gdf").is_some());
+
         assert_eq!(fuzzy_text_score("general", "xyz"), None);
     }
 
     #[test]
-    fn fuzzy_text_score_prefers_exact_prefix_and_contiguous_matches() {
-        let exact = fuzzy_text_score("general", "general").expect("exact match");
-        let prefix = fuzzy_text_score("general", "gen").expect("prefix match");
-        let contiguous = fuzzy_text_score("neo-general", "gen").expect("contiguous match");
-        let spread = fuzzy_text_score("g-e-n", "gen").expect("spread match");
-        let typo = fuzzy_text_score("party", "praty").expect("typo match");
+    fn exact_match_beats_everything() {
+        let exact = score("general", "general");
+        let prefix = score("general-store", "general");
+        let substring = score("my-general-store", "general");
+        // let fuzzy = score("geo_nr_al", "general");
 
-        assert!(exact < prefix);
-        assert!(prefix < contiguous);
-        assert!(contiguous < spread);
-        assert!(spread < typo);
+        assert!(exact > prefix);
+        assert!(prefix > substring);
+        // assert!(substring > fuzzy);
     }
 
     #[test]
-    fn fuzzy_text_score_tolerates_one_query_typo() {
-        assert!(fuzzy_text_score("general", "gereral").is_some());
-        assert!(fuzzy_text_score("general", "gexneral").is_some());
-        assert!(fuzzy_text_score("party", "praty").is_some());
+    fn contiguous_matches_rank_higher_than_fragmented_matches() {
+        let contiguous = score("foobar", "oba");
+        let fragmented = score("foo_bar_baz", "oba");
+
+        assert!(contiguous > fragmented);
     }
 
     #[test]
-    fn fuzzy_text_score_rejects_multiple_unmatched_typos() {
-        assert_eq!(fuzzy_text_score("general", "zzgeneral"), None);
+    fn consecutive_runs_are_strongly_preferred() {
+        let tight = score("abc", "abc");
+        let spaced = score("a_b_c", "abc");
+        let wide = score("a___b___c", "abc");
+
+        assert!(tight > spaced);
+        assert!(spaced > wide);
+    }
+
+    #[test]
+    fn prefers_word_boundaries() {
+        let boundary = score("foo_bar_test", "bt");
+        let interior = score("foobartest", "bt");
+
+        assert!(boundary > interior);
+    }
+
+    #[test]
+    fn prefers_camel_case_boundaries() {
+        let camel = score("FooBarTest", "bt");
+        let flat = score("foobartest", "bt");
+
+        assert!(camel > flat);
+    }
+
+    #[test]
+    fn prefers_earlier_matches() {
+        let early = score("testingDocument", "doc");
+        let late = score("veryLongTestingDocument", "doc");
+
+        assert!(early > late);
+    }
+
+    #[test]
+    fn prefers_shorter_candidates_when_similarity_is_equal() {
+        let short = score("foo_bar", "fb");
+        let long = score("foo_bar_baz_qux", "fb");
+
+        assert!(short > long);
+    }
+
+    #[test]
+    fn supports_acronym_style_matching() {
+        assert!(fuzzy_text_score("GitDiffFile", "gdf").is_some());
+        assert!(fuzzy_text_score("VeryImportantClass", "vic").is_some());
+        assert!(fuzzy_text_score("foo_bar_baz", "fbb").is_some());
+    }
+
+    #[test]
+    fn empty_query_scores_zero() {
+        assert_eq!(fuzzy_text_score("anything", ""), Some(FuzzyScore(0)));
+    }
+
+    #[test]
+    fn non_matching_queries_return_none() {
+        assert_eq!(fuzzy_text_score("abc", "xyz"), None);
+        assert_eq!(fuzzy_text_score("short", "muchlonger"), None);
     }
 }

--- a/src/tui/state/channel_switcher.rs
+++ b/src/tui/state/channel_switcher.rs
@@ -1,10 +1,13 @@
 use std::collections::HashSet;
 
-use crate::discord::ids::{
-    Id,
-    marker::{ChannelMarker, GuildMarker},
-};
 use crate::discord::{AppCommand, ChannelState, ChannelUnreadState};
+use crate::{
+    discord::ids::{
+        Id,
+        marker::{ChannelMarker, GuildMarker},
+    },
+    tui::fuzzy::FuzzyScore,
+};
 use unicode_segmentation::UnicodeSegmentation;
 
 use super::super::fuzzy::fuzzy_text_score;
@@ -74,7 +77,7 @@ impl DashboardState {
             return items;
         }
 
-        let mut scored: Vec<(usize, ChannelSwitcherItem)> = items
+        let mut scored: Vec<(FuzzyScore, ChannelSwitcherItem)> = items
             .into_iter()
             .filter_map(|item| {
                 channel_switcher_match_score(&item, query).map(|score| (score, item))
@@ -373,24 +376,15 @@ fn push_channel_switcher_item(
         channel_label: channel_switcher_channel_label(channel),
         unread,
         unread_message_count,
-        search_name: channel.name.clone(),
+        search_name: format!("{} / {}", group_label, channel.name),
         depth,
         group_order,
         original_index,
     });
 }
 
-fn channel_switcher_match_score(item: &ChannelSwitcherItem, query: &str) -> Option<usize> {
-    let name_score = fuzzy_text_score(&item.search_name, query);
-    let guild_score = item
-        .guild_name
-        .as_deref()
-        .and_then(|guild_name| fuzzy_text_score(guild_name, query));
-    match (name_score, guild_score) {
-        (Some(a), Some(b)) => Some(a.min(b)),
-        (Some(score), None) | (None, Some(score)) => Some(score),
-        (None, None) => None,
-    }
+fn channel_switcher_match_score(item: &ChannelSwitcherItem, query: &str) -> Option<FuzzyScore> {
+    fuzzy_text_score(&item.search_name, query)
 }
 
 fn channel_switcher_channel_label(channel: &ChannelState) -> String {

--- a/src/tui/state/reactions.rs
+++ b/src/tui/state/reactions.rs
@@ -1,5 +1,6 @@
 use crate::discord::AppCommand;
 use crate::discord::ids::{Id, marker::GuildMarker};
+use crate::tui::fuzzy::FuzzyScore;
 
 use super::super::fuzzy::fuzzy_text_score;
 use super::emoji::{
@@ -334,7 +335,7 @@ fn filter_emoji_reaction_items_from_slice(
         return items.to_vec();
     }
 
-    let mut scored: Vec<(usize, usize, usize, EmojiReactionItem)> = items
+    let mut scored: Vec<(usize, FuzzyScore, usize, EmojiReactionItem)> = items
         .iter()
         .enumerate()
         .filter_map(|(index, item)| {
@@ -359,7 +360,7 @@ fn emoji_reaction_is_remaining_unicode(item: &EmojiReactionItem) -> bool {
     matches!(&item.emoji, crate::discord::ReactionEmoji::Unicode(emoji) if !is_quick_unicode_emoji(emoji))
 }
 
-fn emoji_reaction_filter_score(item: &EmojiReactionItem, filter: &str) -> Option<usize> {
+fn emoji_reaction_filter_score(item: &EmojiReactionItem, filter: &str) -> Option<FuzzyScore> {
     let label_score = fuzzy_text_score(&item.label, filter);
     let status_score = fuzzy_text_score(&item.emoji.status_label(), filter);
     match (label_score, status_score) {


### PR DESCRIPTION
I found this project on Reddit and liked it quite a lot. So much so that I feel it can be my daily driver.
However, I found that there are issues with fuzzy search, it being inaccurate and uinintuitive.
The major issues I had noticed was:
* Wrong scoring, like in the server search ( ``/`` )
* The channel switcher searches either the guild name or the channel name, not both.

I've tried to improve both the cases here. Though it is far from ideal, it is much more usable now. The improvements are explainable by the test cases added