### PR TITLE
feat: add keyboard shortcut to open URLs from messages

### DIFF
--- a/src/tui/format.rs
+++ b/src/tui/format.rs
@@ -194,8 +194,10 @@ pub struct TextHighlight {
 pub enum TextHighlightKind {
     /// The current user is being notified (`<@me>`, `@everyone`, `@here`).
     SelfMention,
-    /// Some other user is being mentioned. Subdued background for information.
+    /// Some other user is mentioned. Subdued background for information.
     OtherMention,
+    /// A URL/link in message content.
+    Url,
 }
 
 pub fn render_user_mentions_with_highlights<U, R, C, H>(
@@ -559,16 +561,141 @@ fn parse_mention(value: &str, start: usize) -> Option<(usize, MentionTarget)> {
     Some((index.saturating_add(1), target))
 }
 
+pub fn extract_urls_from_text(text: &str) -> Vec<TextHighlight> {
+    let mut urls = Vec::new();
+    let bytes = text.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i..].starts_with(b"http://") || bytes[i..].starts_with(b"https://") {
+            let start = i;
+            i += if bytes[i..].starts_with(b"https://") {
+                8
+            } else {
+                7
+            };
+            while i < bytes.len() && !is_url_terminator(bytes[i]) {
+                i += 1;
+            }
+            let mut end = i;
+            while end > start {
+                let trailing = bytes[end.saturating_sub(1)];
+                if matches!(trailing, b')' | b',' | b'.' | b'!' | b';') {
+                    let has_open_paren = bytes[start..end].contains(&b'(');
+                    if trailing == b')' && !has_open_paren {
+                        end = end.saturating_sub(1);
+                        continue;
+                    }
+                    if trailing != b')' {
+                        end = end.saturating_sub(1);
+                        continue;
+                    }
+                }
+                break;
+            }
+            if end > start {
+                urls.push(TextHighlight {
+                    start,
+                    end,
+                    kind: TextHighlightKind::Url,
+                });
+            }
+        } else {
+            i += 1;
+        }
+    }
+    urls
+}
+
+fn is_url_terminator(b: u8) -> bool {
+    matches!(
+        b,
+        b' ' | b'\t'
+            | b'\n'
+            | b'\r'
+            | b'<'
+            | b'>'
+            | b'['
+            | b']'
+            | b'{'
+            | b'}'
+            | b'"'
+            | b'\''
+            | b'`'
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use unicode_width::UnicodeWidthStr;
 
     use super::{
-        InlineEmojiSlot, RenderedText, TextHighlight, TextHighlightKind, render_user_mentions,
-        replace_custom_emoji_markup, replace_custom_emoji_markup_in_rendered,
+        InlineEmojiSlot, RenderedText, TextHighlight, TextHighlightKind, extract_urls_from_text,
+        render_user_mentions, replace_custom_emoji_markup, replace_custom_emoji_markup_in_rendered,
         replace_custom_emoji_markup_in_rendered_with_images, sanitize_for_display_width,
         truncate_display_width, truncate_text,
     };
+
+    #[test]
+    fn extract_urls_finds_https_link() {
+        let text = "check this out https://example.com/path";
+        let urls = extract_urls_from_text(text);
+        assert_eq!(urls.len(), 1);
+        assert_eq!(
+            &text[urls[0].start..urls[0].end],
+            "https://example.com/path"
+        );
+    }
+
+    #[test]
+    fn extract_urls_finds_http_link() {
+        let text = "visit http://example.com today";
+        let urls = extract_urls_from_text(text);
+        assert_eq!(urls.len(), 1);
+        assert_eq!(&text[urls[0].start..urls[0].end], "http://example.com");
+    }
+
+    #[test]
+    fn extract_urls_finds_multiple_links() {
+        let text = "see https://a.com and https://b.org/page";
+        let urls = extract_urls_from_text(text);
+        assert_eq!(urls.len(), 2);
+        assert_eq!(&text[urls[0].start..urls[0].end], "https://a.com");
+        assert_eq!(&text[urls[1].start..urls[1].end], "https://b.org/page");
+    }
+
+    #[test]
+    fn extract_urls_strips_trailing_punctuation() {
+        let text = "go to https://example.com.";
+        let urls = extract_urls_from_text(text);
+        assert_eq!(urls.len(), 1);
+        assert_eq!(&text[urls[0].start..urls[0].end], "https://example.com");
+    }
+
+    #[test]
+    fn extract_urls_keeps_parentheses_in_url() {
+        let text = "see https://en.wikipedia.org/wiki/Rust_(programming_language)";
+        let urls = extract_urls_from_text(text);
+        assert_eq!(urls.len(), 1);
+        assert_eq!(
+            &text[urls[0].start..urls[0].end],
+            "https://en.wikipedia.org/wiki/Rust_(programming_language)"
+        );
+    }
+
+    #[test]
+    fn extract_urls_strips_unmatched_trailing_paren() {
+        let text = "link (https://example.com)";
+        let urls = extract_urls_from_text(text);
+        assert_eq!(urls.len(), 1);
+        assert_eq!(&text[urls[0].start..urls[0].end], "https://example.com");
+    }
+
+    #[test]
+    fn extract_urls_returns_empty_for_no_links() {
+        let text = "no links here";
+        let urls = extract_urls_from_text(text);
+        assert!(urls.is_empty());
+    }
 
     #[test]
     fn rendered_replacer_emits_text_fallback_and_records_slot() {

--- a/src/tui/input/keyboard.rs
+++ b/src/tui/input/keyboard.rs
@@ -68,6 +68,7 @@ enum MessageShortcutAction {
     ViewImage,
     ShowProfile,
     OpenPinConfirmation,
+    OpenUrl,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -461,6 +462,7 @@ fn handle_message_shortcut_action(
             state.direct_open_selected_message_pin_confirmation();
             None
         }
+        MessageShortcutAction::OpenUrl => state.direct_open_url_from_selected_message(),
     }
 }
 
@@ -1026,6 +1028,7 @@ fn message_shortcut_action(key: KeyEvent) -> Option<MessageShortcutAction> {
         KeyCode::Char('v') => Some(MessageShortcutAction::ViewImage),
         KeyCode::Char('p') => Some(MessageShortcutAction::ShowProfile),
         KeyCode::Char('P') => Some(MessageShortcutAction::OpenPinConfirmation),
+        KeyCode::Char('o') => Some(MessageShortcutAction::OpenUrl),
         _ => None,
     }
 }

--- a/src/tui/message_format.rs
+++ b/src/tui/message_format.rs
@@ -14,7 +14,7 @@ use unicode_width::UnicodeWidthStr;
 
 use super::{
     format::{
-        InlineEmojiSlot, RenderedText, TextHighlight, TextHighlightKind,
+        InlineEmojiSlot, RenderedText, TextHighlight, TextHighlightKind, extract_urls_from_text,
         replace_custom_emoji_markup_in_rendered_with_images, truncate_display_width, truncate_text,
     },
     message_time,
@@ -936,6 +936,10 @@ fn wrap_markdown_message_lines_with_loaded_custom_emoji_urls(
     if rendered.text.is_empty() {
         return wrap_rendered_text_lines(rendered, width, style);
     }
+
+    let mut rendered = rendered;
+    let url_highlights = extract_urls_from_text(&rendered.text);
+    rendered.highlights.extend(url_highlights);
 
     let mut lines = Vec::new();
     let mut line_start = 0usize;
@@ -2425,14 +2429,15 @@ fn format_attachment(attachment: &AttachmentInfo) -> String {
 
 pub(super) fn mention_highlight_style(kind: TextHighlightKind) -> Style {
     match kind {
-        // The current user got pinged, so match Discord's gold highlight.
         TextHighlightKind::SelfMention => Style::default()
             .bg(Color::Rgb(92, 76, 35))
             .fg(Color::Yellow),
-        // Someone else was pinged, so use Discord's softer blue tint.
         TextHighlightKind::OtherMention => Style::default()
             .bg(Color::Rgb(40, 50, 92))
             .fg(Color::Rgb(193, 206, 247)),
+        TextHighlightKind::Url => Style::default()
+            .fg(Color::Blue)
+            .add_modifier(Modifier::UNDERLINED),
     }
 }
 

--- a/src/tui/state/message_actions.rs
+++ b/src/tui/state/message_actions.rs
@@ -1,4 +1,5 @@
 use crate::discord::{AppCommand, MessageState, ReactionEmoji};
+use crate::tui::format::extract_urls_from_text;
 
 use super::scroll::{clamp_selected_index, move_index_down, move_index_up};
 use super::{
@@ -437,6 +438,17 @@ impl DashboardState {
             return;
         };
         self.open_selected_message_pin_confirmation(!message.pinned);
+    }
+
+    pub fn direct_open_url_from_selected_message(&mut self) -> Option<AppCommand> {
+        let message = self.selected_message_state()?;
+        let content = message.content.as_ref()?;
+        let urls = extract_urls_from_text(content);
+        if urls.is_empty() {
+            return None;
+        }
+        let url = content[urls[0].start..urls[0].end].to_owned();
+        Some(AppCommand::OpenUrl { url })
     }
 
     pub fn open_selected_message_delete_confirmation(&mut self) {


### PR DESCRIPTION
Press 'o' on a selected message to open the first URL found in its content. URLs are rendered with blue underlined styling.

<!--
Thanks for the contribution. Please keep the subject under ~72 characters
and use a semantic prefix (feat:, fix:, refactor:, docs:, chore:, test:).

By submitting this PR you agree it will be distributed under GPL-3.0-only.
-->

## Summary

<!-- What does this change do, in one or two sentences? -->

## Why

<!-- The motivation. Link the issue it closes, e.g. "Closes #123". -->

## How

<!-- Notable implementation choices and any non-obvious trade-offs. -->

## Testing

<!-- How you verified the change. Mention the OS, terminal, and graphics protocol used for manual checks. -->

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] Manual test in a real terminal (describe below)

## Screenshots or recordings

<!-- For UI changes, attach a screenshot or asciinema/gif. Delete this section if not applicable. -->

## Checklist

- [x] One logical change per PR.
- [x] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [x] Change does not add self-bot automation, mass actions, or scraping.
- [ ] Updated `README.md`, if behavior or workflows changed.
