### PR TITLE
chore: add Twilight attribution for Discord IDs

### DIFF
--- a/src/discord/ids.rs
+++ b/src/discord/ids.rs
@@ -2,6 +2,11 @@ use std::{fmt, marker::PhantomData, num::NonZeroU64};
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 
+// Type adapted from Twilight <https://github.com/twilight-rs/twilight>
+// Copyright (c) 2025 Twilight Contributors
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[repr(transparent)]
 pub struct Id<T> {


### PR DESCRIPTION
<!--
Thanks for the contribution. Please keep the subject under ~72 characters
and use a semantic prefix (feat:, fix:, refactor:, docs:, chore:, test:).

By submitting this PR you agree it will be distributed under GPL-3.0-only.
-->

## Summary

<!-- What does this change do, in one or two sentences? -->

## Why

<!-- The motivation. Link the issue it closes, e.g. "Closes #123". -->
Closes #94 

## How

<!-- Notable implementation choices and any non-obvious trade-offs. -->

## Testing

<!-- How you verified the change. Mention the OS, terminal, and graphics protocol used for manual checks. -->

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] Manual test in a real terminal (describe below)

## Screenshots or recordings

<!-- For UI changes, attach a screenshot or asciinema/gif. Delete this section if not applicable. -->

## Checklist

- [x] One logical change per PR.
- [x] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [x] Change does not add self-bot automation, mass actions, or scraping.
- [x] Updated `README.md`, if behavior or workflows changed.
