### PR TITLE
fix: Fix composer draft clearing on mouse focus change

### DIFF
--- a/src/tui/input/mouse.rs
+++ b/src/tui/input/mouse.rs
@@ -81,7 +81,7 @@ pub fn handle_mouse_event(
     }
     if blurred_composer {
         clicks.clear();
-        state.cancel_composer();
+        state.close_composer();
     }
 
     match mouse.kind {

--- a/src/tui/input/tests.rs
+++ b/src/tui/input/tests.rs
@@ -1096,7 +1096,7 @@ fn mouse_click_outside_dashboard_panes_does_not_change_focus() {
 }
 
 #[test]
-fn mouse_click_outside_composer_blurs_and_focuses_clicked_pane() {
+fn mouse_click_outside_composer_blurs_and_focuses_clicked_pane_without_clearing_draft() {
     let mut state = state_with_channel_tree();
     state.focus_pane(FocusPane::Channels);
     handle_key(&mut state, key(KeyCode::Down));
@@ -1111,7 +1111,7 @@ fn mouse_click_outside_composer_blurs_and_focuses_clicked_pane() {
     ));
     assert_eq!(state.focus(), FocusPane::Members);
     assert!(!state.is_composing());
-    assert_eq!(state.composer_input(), "");
+    assert_eq!(state.composer_input(), "d");
 }
 
 #[test]


### PR DESCRIPTION
<!--
Thanks for the contribution. Please keep the subject under ~72 characters
and use a semantic prefix (feat:, fix:, refactor:, docs:, chore:, test:).

By submitting this PR you agree it will be distributed under GPL-3.0-only.
-->

## Summary

<!-- What does this change do, in one or two sentences? -->

## Why

Closes #99 
<!-- The motivation. Link the issue it closes, e.g. "Closes #123". -->

## How

<!-- Notable implementation choices and any non-obvious trade-offs. -->

## Testing

<!-- How you verified the change. Mention the OS, terminal, and graphics protocol used for manual checks. -->

- [ ] `cargo fmt --all --check`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo test --all-features`
- [ ] Manual test in a real terminal (describe below)

## Screenshots or recordings

<!-- For UI changes, attach a screenshot or asciinema/gif. Delete this section if not applicable. -->

## Checklist

- [ ] One logical change per PR.
- [ ] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [ ] Change does not add self-bot automation, mass actions, or scraping.
- [ ] Updated `README.md`, if behavior or workflows changed.
