### PR TITLE
feat: better server/channel collapsing

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,10 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
+use crate::discord::ids::{
+    Id,
+    marker::{ChannelMarker, GuildMarker},
+};
 use crate::{Result, paths};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
@@ -37,12 +41,21 @@ pub struct VoiceOptions {
     pub voice_output_volume: VoiceVolumePercent,
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(default)]
 pub struct AppOptions {
     pub display: DisplayOptions,
     pub notifications: NotificationOptions,
     pub voice: VoiceOptions,
+    pub ui_state: UiStateOptions,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct UiStateOptions {
+    pub collapsed_channel_categories: Vec<Id<ChannelMarker>>,
+    pub collapsed_server_folder_ids: Vec<u64>,
+    pub collapsed_server_folder_guilds: Vec<Vec<Id<GuildMarker>>>,
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
@@ -508,6 +521,7 @@ mod tests {
                 microphone_volume: VoiceVolumePercent::new(80),
                 voice_output_volume: VoiceVolumePercent::new(60),
             },
+            ui_state: Default::default(),
         };
 
         save_options_to_path(&path, &options).expect("config should save");

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -39,6 +39,7 @@ pub(super) fn handle_terminal_event(
                 input::handle_mouse_event(state, mouse, *last_frame_area, mouse_clicks);
             outcome.command = mouse_outcome.command;
             if mouse_outcome.handled {
+                save_options_if_needed(state);
                 outcome.dirty = true;
             }
         }

--- a/src/tui/input/tests.rs
+++ b/src/tui/input/tests.rs
@@ -146,6 +146,25 @@ fn channel_filter_opens_child_inside_collapsed_category() {
 }
 
 #[test]
+fn guild_filter_opens_child_inside_collapsed_folder() {
+    let mut state = state_with_folder();
+    state.focus_pane(FocusPane::Guilds);
+    handle_key(&mut state, key(KeyCode::Enter));
+    assert_selected_folder_collapsed(&state, true);
+
+    handle_key(&mut state, char_key('/'));
+    for value in "second".chars() {
+        handle_key(&mut state, char_key(value));
+    }
+    handle_key(&mut state, key(KeyCode::Enter));
+
+    assert_eq!(state.selected_guild_id(), Some(Id::new(2)));
+    assert_eq!(state.selected_guild_cursor_id(), Some(Id::new(2)));
+    assert_eq!(state.selected_guild(), 2);
+    assert_selected_folder_collapsed(&state, true);
+}
+
+#[test]
 fn movement_waits_for_enter_to_activate_channel() {
     let mut state = state_with_channel_tree();
     state.focus_pane(FocusPane::Channels);

--- a/src/tui/input/tests.rs
+++ b/src/tui/input/tests.rs
@@ -597,6 +597,7 @@ fn alt_arrows_adjust_focused_side_pane_width() {
             display: state.display_options(),
             notifications: state.notification_options(),
             voice: state.voice_options(),
+            ui_state: Default::default(),
         })
     );
 
@@ -1876,6 +1877,7 @@ fn options_popup_toggles_selected_setting() {
             display: state.display_options(),
             notifications: state.notification_options(),
             voice: state.voice_options(),
+            ui_state: Default::default(),
         })
     );
 }
@@ -1900,6 +1902,7 @@ fn options_popup_cycles_image_preview_quality() {
             display: state.display_options(),
             notifications: state.notification_options(),
             voice: state.voice_options(),
+            ui_state: Default::default(),
         })
     );
 }
@@ -1957,6 +1960,7 @@ fn options_popup_h_l_adjust_microphone_sensitivity_by_one_or_ten_db() {
             display: state.display_options(),
             notifications: state.notification_options(),
             voice: state.voice_options(),
+            ui_state: Default::default(),
         })
     );
 }

--- a/src/tui/input/tests.rs
+++ b/src/tui/input/tests.rs
@@ -141,6 +141,7 @@ fn channel_filter_opens_child_inside_collapsed_category() {
         })
     );
     assert_eq!(state.selected_channel_id(), Some(Id::new(12)));
+    assert_eq!(state.selected_channel(), 1);
     assert_selected_channel_category_collapsed(&state, true);
 }
 

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -50,8 +50,12 @@ pub(super) async fn run_dashboard(
             config::AppOptions::default()
         }
     };
-    let mut state =
-        DashboardState::new_with_options(options.display, options.notifications, options.voice);
+    let mut state = DashboardState::new_with_options(
+        options.display,
+        options.notifications,
+        options.voice,
+        options.ui_state,
+    );
     drop(snapshots.borrow_and_update());
     let initial_snapshot = client.current_discord_snapshot();
     let mut current_snapshot_revision = initial_snapshot.revision.global;

--- a/src/tui/state/channels.rs
+++ b/src/tui/state/channels.rs
@@ -1,12 +1,11 @@
 use std::collections::{BTreeMap, HashSet};
 
-use crate::discord::{AppCommand, AppEvent, ChannelState, VoiceParticipantState};
+use crate::discord::ids::{
+    Id,
+    marker::{ChannelMarker, GuildMarker},
+};
 use crate::discord::{
-    TypingUserState,
-    ids::{
-        Id,
-        marker::{ChannelMarker, GuildMarker},
-    },
+    AppCommand, AppEvent, ChannelState, ChannelUnreadState, TypingUserState, VoiceParticipantState,
 };
 
 use super::{
@@ -726,9 +725,6 @@ impl DashboardState {
                 state: root,
                 collapsed,
             });
-            if collapsed {
-                continue;
-            }
 
             let mut children: Vec<&ChannelState> = channels
                 .iter()
@@ -736,6 +732,9 @@ impl DashboardState {
                 .filter(|channel| !channel.is_category() && channel.parent_id == Some(root.id))
                 .collect();
             sort_channels(&mut children);
+            if collapsed {
+                children.retain(|child| self.collapsed_category_child_visible(child));
+            }
             let last_child_index = children.len().saturating_sub(1);
             for (index, child) in children.into_iter().enumerate() {
                 let branch = if index == last_child_index {
@@ -753,6 +752,11 @@ impl DashboardState {
         }
 
         entries
+    }
+
+    fn collapsed_category_child_visible(&self, channel: &ChannelState) -> bool {
+        self.active_channel_id == Some(channel.id)
+            || self.sidebar_channel_unread(channel.id) != ChannelUnreadState::Seen
     }
 
     fn push_channel_pane_channel_entry<'a>(
@@ -1129,6 +1133,7 @@ impl DashboardState {
             return;
         };
         toggle_collapsed_key(&mut self.collapsed_channel_categories, category_id);
+        self.options_save_pending = true;
     }
 
     #[cfg(test)]

--- a/src/tui/state/channels.rs
+++ b/src/tui/state/channels.rs
@@ -847,6 +847,7 @@ impl DashboardState {
         };
         self.channel_pane_filter = None;
         if let Some(channel_id) = channel_id {
+            let command = self.activate_channel_command(channel_id);
             // Restore selection to the unfiltered position
             if let Some(idx) = self.channel_pane_entries().iter().position(
                 |e| matches!(e, ChannelPaneEntry::Channel { state, .. } if state.id == channel_id),
@@ -854,7 +855,7 @@ impl DashboardState {
                 self.selected_channel = idx;
             }
             self.channel_keep_selection_visible = true;
-            return self.activate_channel_command(channel_id);
+            return command;
         }
         None
     }

--- a/src/tui/state/guilds.rs
+++ b/src/tui/state/guilds.rs
@@ -518,6 +518,7 @@ impl DashboardState {
         let folder_key = self.selected_folder_key();
         if let Some(key) = folder_key {
             toggle_collapsed_key(&mut self.collapsed_folders, key);
+            self.options_save_pending = true;
         }
     }
 

--- a/src/tui/state/guilds.rs
+++ b/src/tui/state/guilds.rs
@@ -81,15 +81,14 @@ impl DashboardState {
                 placed.insert(*guild_id);
             }
 
-            if collapsed {
-                continue;
-            }
-
-            let child_guilds: Vec<&GuildState> = folder
+            let mut child_guilds: Vec<&GuildState> = folder
                 .guild_ids
                 .iter()
                 .filter_map(|guild_id| by_id.get(guild_id).copied())
                 .collect();
+            if collapsed {
+                child_guilds.retain(|guild| self.active_guild == ActiveGuildScope::Guild(guild.id));
+            }
             let last_child_index = child_guilds.len().saturating_sub(1);
             for (index, guild) in child_guilds.into_iter().enumerate() {
                 let branch = if index == last_child_index {
@@ -194,6 +193,7 @@ impl DashboardState {
         self.selected_guild = 0;
         self.guild_scroll = 0;
         if let Some(scope) = action {
+            self.activate_guild(scope);
             match scope {
                 ActiveGuildScope::DirectMessages => {
                     if let Some(idx) = self
@@ -213,7 +213,6 @@ impl DashboardState {
                 }
                 ActiveGuildScope::Unset => {}
             }
-            self.activate_guild(scope);
         }
     }
 

--- a/src/tui/state/options.rs
+++ b/src/tui/state/options.rs
@@ -1,10 +1,11 @@
 use crate::config::{
-    AppOptions, DisplayOptions, ImagePreviewQualityPreset, NotificationOptions, VoiceOptions,
+    AppOptions, DisplayOptions, ImagePreviewQualityPreset, NotificationOptions, UiStateOptions,
+    VoiceOptions,
 };
 use crate::discord::AppCommand;
 
 use super::{
-    DashboardState, FocusPane, OptionsCategoryShortcut,
+    DashboardState, FocusPane, FolderKey, OptionsCategoryShortcut,
     popups::{OptionsCategory, OptionsPopupState},
 };
 
@@ -30,13 +31,16 @@ impl DashboardState {
         display_options: DisplayOptions,
         notification_options: NotificationOptions,
         voice_options: VoiceOptions,
+        ui_state_options: UiStateOptions,
     ) -> Self {
-        Self {
+        let mut state = Self {
             display_options,
             notification_options,
             voice_options,
             ..Self::new()
-        }
+        };
+        state.apply_ui_state_options(ui_state_options);
+        state
     }
 
     pub fn display_options(&self) -> DisplayOptions {
@@ -49,6 +53,7 @@ impl DashboardState {
             display_options,
             NotificationOptions::default(),
             VoiceOptions::default(),
+            UiStateOptions::default(),
         )
     }
 
@@ -58,6 +63,7 @@ impl DashboardState {
             DisplayOptions::default(),
             NotificationOptions::default(),
             voice_options,
+            UiStateOptions::default(),
         )
     }
 
@@ -67,6 +73,7 @@ impl DashboardState {
             DisplayOptions::default(),
             notification_options,
             VoiceOptions::default(),
+            UiStateOptions::default(),
         )
     }
 
@@ -80,6 +87,49 @@ impl DashboardState {
 
     pub fn key_bindings(&self) -> &crate::tui::keybindings::KeyBindings {
         &self.key_bindings
+    }
+
+    fn apply_ui_state_options(&mut self, options: UiStateOptions) {
+        self.collapsed_channel_categories =
+            options.collapsed_channel_categories.into_iter().collect();
+        self.collapsed_folders = options
+            .collapsed_server_folder_ids
+            .into_iter()
+            .map(FolderKey::Id)
+            .chain(
+                options
+                    .collapsed_server_folder_guilds
+                    .into_iter()
+                    .map(FolderKey::Guilds),
+            )
+            .collect();
+    }
+
+    fn ui_state_options(&self) -> UiStateOptions {
+        let mut collapsed_channel_categories: Vec<_> =
+            self.collapsed_channel_categories.iter().copied().collect();
+        collapsed_channel_categories.sort_by_key(|id| id.get());
+
+        let mut collapsed_server_folder_ids = Vec::new();
+        let mut collapsed_server_folder_guilds = Vec::new();
+        for folder in &self.collapsed_folders {
+            match folder {
+                FolderKey::Id(id) => collapsed_server_folder_ids.push(*id),
+                FolderKey::Guilds(guilds) => collapsed_server_folder_guilds.push(guilds.clone()),
+            }
+        }
+        collapsed_server_folder_ids.sort_unstable();
+        collapsed_server_folder_guilds.sort_by(|left, right| {
+            left.iter()
+                .map(|id| id.get())
+                .cmp(right.iter().map(|id| id.get()))
+        });
+
+        UiStateOptions {
+            collapsed_channel_categories,
+            collapsed_server_folder_ids,
+            collapsed_server_folder_guilds,
+        }
     }
 
     pub fn show_avatars(&self) -> bool {
@@ -548,6 +598,7 @@ impl DashboardState {
             display: self.display_options,
             notifications: self.notification_options,
             voice: self.voice_options,
+            ui_state: self.ui_state_options(),
         })
     }
 }

--- a/src/tui/state/tests/mod.rs
+++ b/src/tui/state/tests/mod.rs
@@ -4,7 +4,7 @@ use fixtures::*;
 use ratatui::text::Line;
 
 use crate::{
-    config::{ImagePreviewQualityPreset, NotificationOptions, VoiceOptions},
+    config::{DisplayOptions, ImagePreviewQualityPreset, NotificationOptions, VoiceOptions},
     discord::ids::{
         Id,
         marker::{ChannelMarker, GuildMarker, MessageMarker, UserMarker},
@@ -8785,6 +8785,64 @@ fn selected_channel_child_can_close_parent_category() {
 }
 
 #[test]
+fn collapsed_category_keeps_unread_child_visible_until_another_channel_is_selected() {
+    let mut state = state_with_channel_tree();
+    state.push_event(AppEvent::ReadStateInit {
+        entries: vec![ReadStateInfo {
+            channel_id: Id::new(11),
+            last_acked_message_id: Some(Id::new(99)),
+            mention_count: 0,
+        }],
+    });
+    state.push_event(AppEvent::MessageCreate {
+        guild_id: Some(Id::new(1)),
+        channel_id: Id::new(11),
+        message_id: Id::new(100),
+        author_id: Id::new(20),
+        author: "alice".to_owned(),
+        author_avatar_url: None,
+        author_role_ids: Vec::new(),
+        message_kind: MessageKind::regular(),
+        reference: None,
+        reply: None,
+        poll: None,
+        content: Some("unread".to_owned()),
+        sticker_names: Vec::new(),
+        mentions: Vec::new(),
+        attachments: Vec::new(),
+        embeds: Vec::new(),
+        forwarded_snapshots: Vec::new(),
+    });
+
+    state.toggle_selected_channel_category();
+    assert_eq!(channel_entry_names(&state), vec!["general"]);
+
+    state.activate_channel(Id::new(11));
+    assert_eq!(channel_entry_names(&state), vec!["general"]);
+
+    state.activate_channel(Id::new(12));
+    assert_eq!(channel_entry_names(&state), vec!["random"]);
+}
+
+#[test]
+fn collapsed_category_state_is_saved_and_restored() {
+    let mut state = state_with_channel_tree();
+    state.toggle_selected_channel_category();
+
+    let options = state
+        .take_options_save_request()
+        .expect("collapse should request an options save");
+    let restored = DashboardState::new_with_options(
+        DisplayOptions::default(),
+        NotificationOptions::default(),
+        VoiceOptions::default(),
+        options.ui_state,
+    );
+
+    assert!(restored.collapsed_channel_categories.contains(&Id::new(10)));
+}
+
+#[test]
 fn moving_guild_cursor_does_not_activate_guild() {
     let mut state = state_with_two_guilds();
     state.focus_pane(FocusPane::Guilds);
@@ -8965,6 +9023,18 @@ fn selected_folder_child_can_close_parent() {
             ..
         }
     ));
+}
+
+#[test]
+fn collapsed_server_folder_state_is_saved() {
+    let mut state = state_with_folder(Some(42));
+
+    state.toggle_selected_folder();
+
+    let options = state
+        .take_options_save_request()
+        .expect("folder collapse should request an options save");
+    assert_eq!(options.ui_state.collapsed_server_folder_ids, vec![42]);
 }
 
 fn channel_entry_names(state: &DashboardState) -> Vec<&str> {


### PR DESCRIPTION
## Summary

When collapsing a group of servers or channels, this setting is remembered across restarts of the application.  It also mimics the official client in that channels with activity in an otherwise collapsed group will still appear

## Why

I am a part of many servers which only contain a few channels I actually care about.  This proposal allows me to reduce visual noise by hiding channels I don't care about and having that setting "stick".

## How

I created a `UiStateOptions` struct inside the `AppOptions` struct which holds the collapsed servers/channels and so is persisted in the user's `config.toml` and then we just read and apply the options at run time. 

## Testing

<!-- How you verified the change. Mention the OS, terminal, and graphics protocol used for manual checks. -->

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] Manual test in a real terminal (describe below)

OS: macOS Tahoe 26.5
Terminal: Ghostty 1.3.1

## Screenshots or recordings

An uncollapsed group:
<img width="304" height="133" alt="Screenshot 2026-05-19 at 1 50 07 PM" src="https://github.com/user-attachments/assets/ba39d7b6-96e6-44f2-b06f-7cdbfc8db558" />

A collapsed group with unread activity in one channel:
<img width="307" height="73" alt="Screenshot 2026-05-19 at 1 50 20 PM" src="https://github.com/user-attachments/assets/d964216a-48c8-40b2-b8c5-e0984fe801e5" />

## Checklist

- [x] One logical change per PR.
- [x] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [x] Change does not add self-bot automation, mass actions, or scraping.
- [x] Updated `README.md`, if behavior or workflows changed.
