### PR TITLE
fix(tui): detect URLs in reply quotes and forwarded messages

### DIFF
--- a/src/tui/state/message_actions.rs
+++ b/src/tui/state/message_actions.rs
@@ -653,6 +653,17 @@ fn message_urls(message: &MessageState) -> Vec<String> {
     if let Some(content) = &message.content {
         urls.extend(detected_urls(content));
     }
+    // URLs in a reply quote or a forwarded message are shown to the user too.
+    if let Some(reply) = &message.reply
+        && let Some(content) = &reply.content
+    {
+        urls.extend(detected_urls(content));
+    }
+    for snapshot in &message.forwarded_snapshots {
+        if let Some(content) = &snapshot.content {
+            urls.extend(detected_urls(content));
+        }
+    }
     dedupe_urls(urls)
 }
 

--- a/src/tui/state/tests/mod.rs
+++ b/src/tui/state/tests/mod.rs
@@ -3277,6 +3277,44 @@ fn message_action_ignores_embed_urls() {
 }
 
 #[test]
+fn message_action_detects_urls_in_reply_quote_and_forwarded_snapshot() {
+    let mut state = state_with_messages(1);
+    state.push_event(AppEvent::MessageHistoryLoaded {
+        channel_id: Id::new(2),
+        before: None,
+        messages: vec![MessageInfo {
+            content: Some("see above".to_owned()),
+            reply: Some(ReplyInfo {
+                author_id: None,
+                author: "alice".to_owned(),
+                content: Some("check https://reply.example/page".to_owned()),
+                sticker_names: Vec::new(),
+                mentions: Vec::new(),
+            }),
+            forwarded_snapshots: vec![MessageSnapshotInfo {
+                content: Some("forwarded https://forward.example/doc".to_owned()),
+                sticker_names: Vec::new(),
+                mentions: Vec::new(),
+                attachments: Vec::new(),
+                embeds: Vec::new(),
+                source_channel_id: None,
+                timestamp: None,
+            }],
+            ..message_info(Id::new(2), 1)
+        }],
+    });
+    state.focus_pane(FocusPane::Messages);
+    state.open_selected_message_actions();
+
+    let urls = state.selected_message_url_items();
+
+    assert_eq!(
+        urls.into_iter().map(|item| item.url).collect::<Vec<_>>(),
+        vec!["https://reply.example/page", "https://forward.example/doc"]
+    );
+}
+
+#[test]
 fn non_regular_message_actions_do_not_include_attachment_downloads() {
     let mut state = state_with_message_ids([]);
     state.push_event(AppEvent::MessageCreate {


### PR DESCRIPTION
<!--
Thanks for the contribution. Please keep the subject under ~72 characters
and use a semantic prefix (feat:, fix:, refactor:, docs:, chore:, test:).

By submitting this PR you agree it will be distributed under GPL-3.0-only.
-->

## Summary

`message_urls` only scanned `message.content`, so pressing `o` on a message whose URL lives inside a reply quote or a forwarded message snapshot did nothing.

## Why

Closes #106. Reply-quote and forwarded-snapshot text is rendered as visible message content, so URLs there should be openable like any other.

## How

`message_urls` now also runs `detected_urls` over `reply.content` and each `forwarded_snapshots` content. Auto-generated embed URLs stay excluded, matching the existing behavior.

## Testing

Tested on macOS with `cargo test`.

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [ ] Manual test in a real terminal (describe below)

## Screenshots or recordings

<!-- For UI changes, attach a screenshot or asciinema/gif. Delete this section if not applicable. -->

## Checklist

- [x] One logical change per PR.
- [x] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [x] Change does not add self-bot automation, mass actions, or scraping.
- [ ] Updated `README.md`, if behavior or workflows changed.
