### PR TITLE
fix: Fix stale MESSAGE_ACK from reopening unread state

### DIFF
--- a/src/discord/client.rs
+++ b/src/discord/client.rs
@@ -39,6 +39,14 @@ const MEMBER_SEARCH_MAX_QUERY_CHARS: usize = 64;
 const MEMBER_SEARCH_MAX_LIMIT: u16 = 10;
 
 type ApplicationCommandCache = HashMap<Option<Id<GuildMarker>>, Vec<ApplicationCommandInfo>>;
+type MemberListRange = (u32, u32);
+type MemberListSubscriptionRequest = (
+    Id<GuildMarker>,
+    Id<ChannelMarker>,
+    u32,
+    Vec<MemberListRange>,
+);
+type DueMemberListSubscription = (Id<GuildMarker>, Id<ChannelMarker>, Vec<MemberListRange>);
 
 #[derive(Clone, Debug)]
 pub struct DiscordClient {
@@ -298,7 +306,7 @@ impl DiscordClient {
 
     pub(crate) fn set_member_list_subscription_target(
         &self,
-        target: Option<(Id<GuildMarker>, Id<ChannelMarker>, u32, Vec<(u32, u32)>)>,
+        target: Option<MemberListSubscriptionRequest>,
         now: std::time::Instant,
     ) {
         let target =
@@ -326,7 +334,7 @@ impl DiscordClient {
     pub(crate) fn next_due_member_list_subscription(
         &self,
         now: std::time::Instant,
-    ) -> Option<(Id<GuildMarker>, Id<ChannelMarker>, Vec<(u32, u32)>)> {
+    ) -> Option<DueMemberListSubscription> {
         self.request_lifecycle
             .lock()
             .expect("request lifecycle lock is not poisoned")

--- a/src/discord/state.rs
+++ b/src/discord/state.rs
@@ -1239,6 +1239,12 @@ impl DiscordState {
                     .read_states
                     .entry(*channel_id)
                     .or_default();
+                if entry
+                    .last_acked_message_id
+                    .is_some_and(|acked| acked > *message_id)
+                {
+                    return;
+                }
                 entry.last_acked_message_id = Some(*message_id);
                 entry.mention_count = *mention_count;
                 entry.notification_count = 0;

--- a/src/discord/state/tests/reads.rs
+++ b/src/discord/state/tests/reads.rs
@@ -148,6 +148,54 @@ fn message_ack_clears_outstanding_mentions_and_advances_pointer() {
 }
 
 #[test]
+fn stale_message_ack_does_not_reopen_unread_state() {
+    let guild_id = Id::new(1);
+    let channel_id = Id::new(7);
+    let mut state = DiscordState::default();
+    state.apply_event(&AppEvent::Ready {
+        user: "me".to_owned(),
+        user_id: Some(Id::new(10)),
+    });
+    state.apply_event(&AppEvent::ChannelUpsert(channel_with_last_message(
+        channel_id, 500,
+    )));
+    state.apply_event(&AppEvent::UserGuildNotificationSettingsInit {
+        settings: vec![notification_settings(
+            guild_id,
+            NotificationLevel::AllMessages,
+        )],
+    });
+    state.apply_event(&latest_history_loaded(
+        channel_id,
+        (101..=105)
+            .map(|message_id| MessageInfo {
+                guild_id: Some(guild_id),
+                ..message_info(channel_id, message_id, "hello")
+            })
+            .collect(),
+    ));
+    state.apply_event(&AppEvent::ReadStateInit {
+        entries: vec![read_state_info(channel_id, Some(Id::new(100)), 0)],
+    });
+    assert_eq!(state.channel_unread_message_count(channel_id), 5);
+
+    state.apply_event(&AppEvent::MessageAck {
+        channel_id,
+        message_id: Id::new(500),
+        mention_count: 0,
+    });
+    state.apply_event(&AppEvent::MessageAck {
+        channel_id,
+        message_id: Id::new(100),
+        mention_count: 5,
+    });
+
+    assert_eq!(state.channel_unread(channel_id), ChannelUnreadState::Seen);
+    assert_eq!(state.channel_unread_message_count(channel_id), 0);
+    assert_eq!(state.channel_ack_target(channel_id), None);
+}
+
+#[test]
 fn channel_ack_target_returns_latest_when_unread() {
     let channel_id = Id::new(7);
     let mut state = DiscordState::default();


### PR DESCRIPTION
<!--
Thanks for the contribution. Please keep the subject under ~72 characters
and use a semantic prefix (feat:, fix:, refactor:, docs:, chore:, test:).

By submitting this PR you agree it will be distributed under GPL-3.0-only.
-->

## Summary

<!-- What does this change do, in one or two sentences? -->

## Why

Fixes #116 
<!-- The motivation. Link the issue it closes, e.g. "Closes #123". -->
<!-- Feature additions must have a related issue first. Feature PRs without a related issue may be closed without review. -->

## How

<!-- Notable implementation choices and any non-obvious trade-offs. -->

## Testing

<!-- How you verified the change. Mention the OS, terminal, and graphics protocol used for manual checks. -->

- [ ] `cargo fmt --all --check`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo test --all-features`
- [ ] Manual test in a real terminal (describe below)

## Screenshots or recordings

<!-- For UI changes, attach a screenshot or asciinema/gif. Delete this section if not applicable. -->

## Checklist

- [ ] One logical change per PR.
- [ ] Link a related issue.
- [ ] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [ ] Change does not add self-bot automation, mass actions, or scraping.
- [ ] Updated `README.md`, if behavior or workflows changed.
