### PR TITLE
feat: add optional circular avatar masking

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ show_avatars = true
 show_images = true
 image_preview_quality = "balanced"
 show_custom_emoji = true
+circular_avatars = false
 
 [notifications]
 desktop_notifications = true

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,7 @@ pub struct DisplayOptions {
     pub show_images: bool,
     pub image_preview_quality: ImagePreviewQualityPreset,
     pub show_custom_emoji: bool,
+    pub circular_avatars: bool,
     pub server_width: u16,
     pub channel_list_width: u16,
     pub member_list_width: u16,
@@ -212,6 +213,7 @@ impl Default for DisplayOptions {
             show_images: true,
             image_preview_quality: ImagePreviewQualityPreset::default(),
             show_custom_emoji: true,
+            circular_avatars: false,
             server_width: 20,
             channel_list_width: 24,
             member_list_width: 26,
@@ -356,6 +358,7 @@ mod tests {
             show_images: true,
             image_preview_quality: ImagePreviewQualityPreset::Balanced,
             show_custom_emoji: true,
+            circular_avatars: false,
             server_width: 20,
             channel_list_width: 24,
             member_list_width: 26,
@@ -459,6 +462,7 @@ mod tests {
             assert!(config.display.show_images);
             assert_eq!(config.display.image_preview_quality, image_preview_quality);
             assert!(config.display.show_custom_emoji);
+            assert!(!config.display.circular_avatars);
             let expected_desktop_notifications =
                 !toml.contains("[notifications]\ndesktop_notifications = false");
             assert_eq!(
@@ -506,6 +510,7 @@ mod tests {
                 show_images: false,
                 image_preview_quality: ImagePreviewQualityPreset::Original,
                 show_custom_emoji: false,
+                circular_avatars: true,
                 server_width: 12,
                 channel_list_width: 30,
                 member_list_width: 18,

--- a/src/tui/media.rs
+++ b/src/tui/media.rs
@@ -767,12 +767,16 @@ mod tests {
         };
 
         assert_ne!(
-            AvatarProtocolKey::message_avatar(&full),
-            AvatarProtocolKey::message_avatar(&clipped)
+            AvatarProtocolKey::message_avatar(&full, false),
+            AvatarProtocolKey::message_avatar(&clipped, false)
         );
         assert_ne!(
-            AvatarProtocolKey::message_avatar(&full),
-            AvatarProtocolKey::profile_popup()
+            AvatarProtocolKey::message_avatar(&full, false),
+            AvatarProtocolKey::profile_popup(false)
+        );
+        assert_ne!(
+            AvatarProtocolKey::message_avatar(&full, false),
+            AvatarProtocolKey::message_avatar(&full, true)
         );
     }
 
@@ -1615,6 +1619,7 @@ mod tests {
             visible_preview_height: 3,
             top_clip_rows: 0,
             accent_color: None,
+            mask_circular: false,
         };
 
         let resized = clipped_preview_image(&image, (10, 20), render_info)

--- a/src/tui/media/cache.rs
+++ b/src/tui/media/cache.rs
@@ -45,24 +45,27 @@ pub(super) struct AvatarProtocolKey {
     preview_height: u16,
     visible_preview_height: u16,
     top_clip_rows: u16,
+    circular: bool,
 }
 
 impl AvatarProtocolKey {
-    pub(super) fn message_avatar(target: &AvatarTarget) -> Self {
+    pub(super) fn message_avatar(target: &AvatarTarget, circular: bool) -> Self {
         Self {
             preview_width: AVATAR_PREVIEW_WIDTH,
             preview_height: AVATAR_PREVIEW_HEIGHT,
             visible_preview_height: target.visible_height,
             top_clip_rows: target.top_clip_rows,
+            circular,
         }
     }
 
-    pub(super) fn profile_popup() -> Self {
+    pub(super) fn profile_popup(circular: bool) -> Self {
         Self {
             preview_width: PROFILE_POPUP_AVATAR_WIDTH,
             preview_height: PROFILE_POPUP_AVATAR_HEIGHT,
             visible_preview_height: PROFILE_POPUP_AVATAR_HEIGHT,
             top_clip_rows: 0,
+            circular,
         }
     }
 
@@ -78,6 +81,7 @@ impl AvatarProtocolKey {
             visible_preview_height: self.visible_preview_height,
             top_clip_rows: self.top_clip_rows,
             accent_color: None,
+            mask_circular: self.circular,
         }
     }
 }
@@ -156,6 +160,7 @@ impl AvatarImageCache {
         &mut self,
         targets: &[AvatarTarget],
         popup_url: Option<&str>,
+        circular: bool,
     ) -> (Vec<AvatarImage<'_>>, Option<AvatarImage<'_>>) {
         let touch_tick = self.next_tick();
         for target in targets {
@@ -182,7 +187,7 @@ impl AvatarImageCache {
             for target in targets {
                 let url =
                     avatar_preview_url(&target.url, AVATAR_PREVIEW_WIDTH, AVATAR_PREVIEW_HEIGHT);
-                let key = AvatarProtocolKey::message_avatar(target);
+                let key = AvatarProtocolKey::message_avatar(target, circular);
                 let Some(AvatarImageEntry::Ready {
                     image, protocols, ..
                 }) = self.entries.get_mut(&url)
@@ -202,7 +207,7 @@ impl AvatarImageCache {
                     image, protocols, ..
                 }) = self.entries.get_mut(url)
             {
-                let key = AvatarProtocolKey::profile_popup();
+                let key = AvatarProtocolKey::profile_popup(circular);
                 if !protocols.contains_key(&key)
                     && let Some(protocol) =
                         clipped_preview_protocol(picker, image, key.render_info())
@@ -220,7 +225,7 @@ impl AvatarImageCache {
                 let AvatarImageEntry::Ready { protocols, .. } = self.entries.get(&url)? else {
                     return None;
                 };
-                let key = AvatarProtocolKey::message_avatar(target);
+                let key = AvatarProtocolKey::message_avatar(target, circular);
                 protocols.get(&key).map(|protocol| AvatarImage {
                     row: target.row,
                     visible_height: target.visible_height,
@@ -232,7 +237,7 @@ impl AvatarImageCache {
             let AvatarImageEntry::Ready { protocols, .. } = self.entries.get(&url)? else {
                 return None;
             };
-            let key = AvatarProtocolKey::profile_popup();
+            let key = AvatarProtocolKey::profile_popup(circular);
             protocols.get(&key).map(|protocol| AvatarImage {
                 row: 0,
                 visible_height: PROFILE_POPUP_AVATAR_HEIGHT,

--- a/src/tui/media/preview.rs
+++ b/src/tui/media/preview.rs
@@ -469,6 +469,7 @@ impl ImagePreviewTarget {
             top_clip_rows: self.top_clip_rows,
             accent_color: self.accent_color,
             viewer: self.viewer,
+            mask_circular: false,
         }
     }
 }

--- a/src/tui/media/protocol.rs
+++ b/src/tui/media/protocol.rs
@@ -73,6 +73,7 @@ pub(super) struct ImagePreviewRenderInfo {
     pub(super) visible_preview_height: u16,
     pub(super) top_clip_rows: u16,
     pub(super) accent_color: Option<u32>,
+    pub(super) mask_circular: bool,
 }
 
 pub(super) fn clipped_preview_image(
@@ -99,7 +100,37 @@ pub(super) fn clipped_preview_image(
     }
 
     let fitted = fit_image_to_canvas(image, full_width, full_height);
-    Some(fitted.crop_imm(0, crop_top, full_width, crop_height))
+    let mut cropped = fitted.crop_imm(0, crop_top, full_width, crop_height);
+    if render_info.mask_circular {
+        apply_circular_alpha_mask(&mut cropped, full_width, full_height, crop_top);
+    }
+    Some(cropped)
+}
+
+/// Zeroes the alpha channel for pixels outside the circle inscribed in the
+/// full (uncropped) image bounds. The mask is computed against the full image
+/// because vertical clipping (`top_clip_rows`) shifts the crop window, but the
+/// circle should stay anchored to the original avatar — otherwise scrolling
+/// would deform it.
+fn apply_circular_alpha_mask(
+    image: &mut DynamicImage,
+    full_width: u32,
+    full_height: u32,
+    crop_top: u32,
+) {
+    let mut rgba = image.to_rgba8();
+    let cx = full_width as f32 / 2.0 - 0.5;
+    let cy = full_height as f32 / 2.0 - 0.5;
+    let radius = (full_width.min(full_height) as f32 / 2.0) - 0.5;
+    let radius_sq = radius * radius;
+    for (x, y, pixel) in rgba.enumerate_pixels_mut() {
+        let dx = x as f32 - cx;
+        let dy = (y + crop_top) as f32 - cy;
+        if dx * dx + dy * dy > radius_sq {
+            pixel.0[3] = 0;
+        }
+    }
+    *image = DynamicImage::ImageRgba8(rgba);
 }
 
 pub(super) fn clipped_preview_protocol(

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -128,8 +128,11 @@ pub(super) async fn run_dashboard(
                     .show_avatars()
                     .then(|| state.user_profile_popup_avatar_url())
                     .flatten();
-                let (rendered_avatars, popup_avatar) =
-                    avatar_images.render_state_with_popup(&avatar_targets, popup_avatar_url);
+                let (rendered_avatars, popup_avatar) = avatar_images.render_state_with_popup(
+                    &avatar_targets,
+                    popup_avatar_url,
+                    state.circular_avatars(),
+                );
                 ui::render(
                     frame,
                     &state,

--- a/src/tui/state/options.rs
+++ b/src/tui/state/options.rs
@@ -9,7 +9,7 @@ use super::{
     popups::{OptionsCategory, OptionsPopupState},
 };
 
-const DISPLAY_OPTION_COUNT: usize = 5;
+const DISPLAY_OPTION_COUNT: usize = 6;
 const NOTIFICATION_OPTION_COUNT: usize = 1;
 const VOICE_OPTION_COUNT: usize = 6;
 const OPTION_CATEGORY_COUNT: usize = 3;
@@ -136,6 +136,10 @@ impl DashboardState {
 
     pub fn show_avatars(&self) -> bool {
         self.options.display_options.avatars_visible()
+    }
+
+    pub fn circular_avatars(&self) -> bool {
+        self.options.display_options.circular_avatars
     }
 
     pub fn show_images(&self) -> bool {
@@ -370,6 +374,14 @@ impl DashboardState {
                 effective: options.custom_emoji_visible(),
                 description: "When off, custom emoji are shown as their emoji id.",
             },
+            DisplayOptionItem {
+                label: "Circular avatars",
+                enabled: options.circular_avatars,
+                value: None,
+                gauge_percent: None,
+                effective: options.avatars_visible() && options.circular_avatars,
+                description: "Mask message and profile avatars into a circle.",
+            },
         ]
     }
 
@@ -479,6 +491,10 @@ impl DashboardState {
             (OptionsCategory::Display, 4) => {
                 self.options.display_options.show_custom_emoji =
                     !self.options.display_options.show_custom_emoji
+            }
+            (OptionsCategory::Display, 5) => {
+                self.options.display_options.circular_avatars =
+                    !self.options.display_options.circular_avatars
             }
             (OptionsCategory::Notifications, 0) => {
                 self.options.notification_options.desktop_notifications =

--- a/src/tui/state/tests/options_voice.rs
+++ b/src/tui/state/tests/options_voice.rs
@@ -40,28 +40,28 @@ fn display_option_items_include_voice_state_controls() {
 
     let items = state.display_option_items();
 
-    assert_eq!(items.len(), 12);
-    assert_eq!(items[6].label, "Voice muted");
-    assert!(items[6].enabled);
-    assert!(items[6].effective);
-    assert_eq!(items[7].label, "Voice deafened");
+    assert_eq!(items.len(), 13);
+    assert_eq!(items[7].label, "Voice muted");
     assert!(items[7].enabled);
     assert!(items[7].effective);
-    assert_eq!(items[8].label, "Allow microphone transmit");
+    assert_eq!(items[8].label, "Voice deafened");
     assert!(items[8].enabled);
     assert!(items[8].effective);
-    assert_eq!(items[9].label, "Microphone sensitivity");
-    assert_eq!(items[9].value, Some("-30 dB".to_owned()));
-    assert_eq!(items[9].gauge_percent, Some(70));
+    assert_eq!(items[9].label, "Allow microphone transmit");
+    assert!(items[9].enabled);
     assert!(items[9].effective);
-    assert_eq!(items[10].label, "Microphone volume");
-    assert_eq!(items[10].value, Some("100%".to_owned()));
-    assert_eq!(items[10].gauge_percent, Some(100));
+    assert_eq!(items[10].label, "Microphone sensitivity");
+    assert_eq!(items[10].value, Some("-30 dB".to_owned()));
+    assert_eq!(items[10].gauge_percent, Some(70));
     assert!(items[10].effective);
-    assert_eq!(items[11].label, "Voice volume");
+    assert_eq!(items[11].label, "Microphone volume");
     assert_eq!(items[11].value, Some("100%".to_owned()));
     assert_eq!(items[11].gauge_percent, Some(100));
-    assert!(!items[11].effective);
+    assert!(items[11].effective);
+    assert_eq!(items[12].label, "Voice volume");
+    assert_eq!(items[12].value, Some("100%".to_owned()));
+    assert_eq!(items[12].gauge_percent, Some(100));
+    assert!(!items[12].effective);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

  Adds a `circular_avatars` toggle in the Display options popup (off by default). When on, message-row and profile-popup avatars get a circular alpha mask.

  ## Why

  I don't like the sharp square look on avatars, and I think I'm not the only one. Off by default so anyone who prefers the squares keeps them.

  ## How

  - New `mask_circular` flag on `ImagePreviewRenderInfo`, set only by the avatar code path. Inline image previews are untouched.
  - Mask anchored to the full image bounds, not the cropped slice, so a partially-scrolled avatar doesn't deform into an ellipse.
  - `AvatarProtocolKey` carries the flag, so the cache keeps square and circular variants side by side and the toggle takes effect immediately.

  ## Testing

  Arch Linux, ghostty, kitty graphics protocol.

  - [x] `cargo fmt --all --check`
  - [x] `cargo clippy --all-targets --all-features -- -D warnings`
  - [x] `cargo test --all-features`
  - [x] Manual test in a real terminal: toggled the option from the Display popup, verified message-row and profile-popup avatars switch between square and circular without restart.

  ## Screenshots or recordings

  
<img width="715" height="663" alt="circle-messages" src="https://github.com/user-attachments/assets/6b3d1199-e9a3-47e9-b7e4-b00c826be01b" />
<img width="301" height="82" alt="circle-popup" src="https://github.com/user-attachments/assets/00c00cff-c9cd-48a6-8395-f41e60565941" />

#checklist


  - [x] One logical change per PR.
  - [ ] Link a related issue.
  - [x] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
  - [x] Change does not add self-bot automation, mass actions, or scraping.
  - [x] Updated `README.md`, if behavior or workflows changed.