### PR TITLE
feat: Add reaction shortcut for selected messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,11 +326,12 @@ When the @mention picker is open, use `Up` / `Down`,
 
 #### Emoji picker
 
-Type `:` plus at least two emoji shortcode letters, such as `:he`, to open
-Unicode emoji and current-server custom emoji suggestions. Use `Up` / `Down`,
-`Ctrl+p` / `Ctrl+n`, `Tab`, or `Enter` to choose an emoji. Complete Unicode
-shortcodes such as `:heart:` are converted to their emoji when the message is
-sent; selected custom emojis are sent using Discord's custom emoji markup.
+Type `:` plus at least two letters, such as `:he`, to pick Unicode or server
+emoji while writing a message.
+
+To react from the composer, select a message, enter insert mode, then type
+`+:`. The reaction picker opens for that message. Press `/` to search, Enter to
+lock the filter, then Enter again or use a shown shortcut to react.
 
 #### Bot commands
 
@@ -497,13 +498,10 @@ OpenEditor = { keys = ["<C-o>"], description = "open editor" }
 DeletePreviousWord = "<A-backspace>"
 ```
 
-For directly assignable `[keymap]` actions, reserved keys cannot be configured.
-Reserved keys include `Enter`, `Esc`, `Backspace`, `Delete`, and `Ctrl+c`.
-These stay fixed outside composer because they are used for submit, cancel, text
-editing, or terminal-safe modal behavior. Invalid, reserved, or conflicting
-values are ignored for that action, so the action keeps its default key and other
-valid mappings still work. Composer shortcuts can remap composer editing keys,
-including `Enter`, `Esc`, `Backspace`, `Delete`, and `Ctrl+c`.
+Direct `[keymap]` actions and `leader` cannot use reserved keys: `Enter`, `Esc`,
+`Backspace`, `Delete`, or `Ctrl+c`. Invalid, reserved, or conflicting bindings
+are ignored for that action. `[keymap.composer]` is separate and can remap those
+editing keys.
 
 ##### Directly assignable actions
 

--- a/src/tui/input/keyboard.rs
+++ b/src/tui/input/keyboard.rs
@@ -40,6 +40,14 @@ pub fn handle_key(state: &mut DashboardState, key: KeyEvent) -> Option<AppComman
         return handle_message_pin_confirmation_key(state, key);
     }
 
+    if state.is_poll_vote_picker_open() {
+        return handle_poll_vote_picker_key(state, key);
+    }
+
+    if state.is_emoji_reaction_picker_open() {
+        return handle_emoji_reaction_picker_key(state, key);
+    }
+
     if state.is_composing() {
         return handle_composer_key(state, key);
     }
@@ -52,14 +60,6 @@ pub fn handle_key(state: &mut DashboardState, key: KeyEvent) -> Option<AppComman
     ) {
         state.toggle_debug_log_popup();
         return None;
-    }
-
-    if state.is_poll_vote_picker_open() {
-        return handle_poll_vote_picker_key(state, key);
-    }
-
-    if state.is_emoji_reaction_picker_open() {
-        return handle_emoji_reaction_picker_key(state, key);
     }
 
     if state.is_channel_switcher_open() {
@@ -835,7 +835,7 @@ fn handle_emoji_reaction_picker_key(
 ) -> Option<AppCommand> {
     match state
         .key_bindings()
-        .emoji_reaction_picker_action(key, state.is_filtering_emoji_reactions())
+        .emoji_reaction_picker_action(key, state.is_editing_emoji_reaction_filter())
     {
         Some(EmojiReactionPickerAction::Select(SelectionAction::Next)) => {
             state.move_emoji_reaction_down()
@@ -849,6 +849,10 @@ fn handle_emoji_reaction_picker_key(
         }
         Some(EmojiReactionPickerAction::DeleteFilterChar) => {
             state.pop_emoji_reaction_filter_char();
+            return None;
+        }
+        Some(EmojiReactionPickerAction::CommitFilter) => {
+            state.commit_emoji_reaction_filter();
             return None;
         }
         Some(EmojiReactionPickerAction::StartFilter) => {
@@ -1028,7 +1032,9 @@ fn handle_composer_key(state: &mut DashboardState, key: KeyEvent) -> Option<AppC
             None
         }
         ComposerAction::InsertChar(value) => {
-            state.push_composer_char(value);
+            if value != ':' || !state.open_composer_reaction_picker_from_plus_colon() {
+                state.push_composer_char(value);
+            }
             None
         }
         ComposerAction::Ignore => None,

--- a/src/tui/input/tests/composer.rs
+++ b/src/tui/input/tests/composer.rs
@@ -106,6 +106,52 @@ fn composer_treats_vim_keys_as_text() {
 }
 
 #[test]
+fn plus_colon_in_composer_opens_reaction_picker_for_selected_message() {
+    let mut state = state_with_messages(1);
+    state.focus_pane(FocusPane::Messages);
+    handle_key(&mut state, char_key('i'));
+
+    handle_key(&mut state, char_key('+'));
+    handle_key(&mut state, char_key(':'));
+
+    assert!(state.is_composing());
+    assert_eq!(state.composer_input(), "");
+    assert!(state.is_emoji_reaction_picker_open());
+    assert_eq!(state.emoji_reaction_filter(), None);
+    assert!(!state.is_editing_emoji_reaction_filter());
+
+    let command = handle_key(&mut state, char_key('2'));
+
+    assert_eq!(
+        command,
+        Some(AppCommand::AddReaction {
+            channel_id: Id::new(2),
+            message_id: Id::new(1),
+            emoji: ReactionEmoji::Unicode("❤️".to_owned()),
+        })
+    );
+    assert!(state.is_composing());
+    assert_eq!(state.composer_input(), "");
+    assert!(!state.is_emoji_reaction_picker_open());
+}
+
+#[test]
+fn plus_colon_without_selected_message_stays_composer_text() {
+    let mut state = state_with_channel_tree();
+    state.focus_pane(FocusPane::Channels);
+    handle_key(&mut state, key(KeyCode::Down));
+    handle_key(&mut state, key(KeyCode::Enter));
+    handle_key(&mut state, char_key('i'));
+
+    handle_key(&mut state, char_key('+'));
+    handle_key(&mut state, char_key(':'));
+
+    assert!(state.is_composing());
+    assert_eq!(state.composer_input(), "+:");
+    assert!(!state.is_emoji_reaction_picker_open());
+}
+
+#[test]
 fn composer_ignores_unhandled_control_characters() {
     let mut state = state_with_channel_tree();
     state.focus_pane(FocusPane::Channels);
@@ -815,6 +861,7 @@ fn emoji_picker_slash_filter_matches_name_and_implementation_case_insensitively(
     handle_key(&mut state, char_key('s'));
 
     assert_eq!(state.emoji_reaction_filter(), Some("Ts"));
+    assert!(state.is_editing_emoji_reaction_filter());
     assert_eq!(
         state.selected_emoji_reaction().map(|item| item.emoji),
         Some(ReactionEmoji::Custom {
@@ -823,6 +870,11 @@ fn emoji_picker_slash_filter_matches_name_and_implementation_case_insensitively(
             animated: false,
         })
     );
+
+    let command = handle_key(&mut state, key(KeyCode::Enter));
+    assert_eq!(command, None);
+    assert_eq!(state.emoji_reaction_filter(), Some("Ts"));
+    assert!(!state.is_editing_emoji_reaction_filter());
 
     let command = handle_key(&mut state, key(KeyCode::Enter));
 
@@ -851,6 +903,7 @@ fn emoji_picker_filter_treats_vim_keys_as_text() {
     handle_key(&mut state, char_key('k'));
 
     assert_eq!(state.emoji_reaction_filter(), Some("jk"));
+    assert!(state.is_editing_emoji_reaction_filter());
     assert_ne!(
         state.selected_emoji_reaction().map(|item| item.emoji),
         Some(ReactionEmoji::Unicode("❤️".to_owned()))
@@ -869,9 +922,40 @@ fn emoji_picker_filter_matches_remaining_unicode_emojis() {
     }
 
     assert_eq!(state.emoji_reaction_filter(), Some("rocket"));
+    assert!(state.is_editing_emoji_reaction_filter());
     assert_eq!(
         state.selected_emoji_reaction().map(|item| item.emoji),
         Some(ReactionEmoji::Unicode("🚀".to_owned()))
+    );
+}
+
+#[test]
+fn emoji_picker_enter_locks_filter_before_activating_reaction() {
+    let mut state = state_with_messages(1);
+    state.focus_pane(FocusPane::Messages);
+    open_emoji_picker(&mut state);
+
+    handle_key(&mut state, char_key('/'));
+    for value in "heart".chars() {
+        handle_key(&mut state, char_key(value));
+    }
+
+    let command = handle_key(&mut state, key(KeyCode::Enter));
+
+    assert_eq!(command, None);
+    assert!(state.is_emoji_reaction_picker_open());
+    assert_eq!(state.emoji_reaction_filter(), Some("heart"));
+    assert!(!state.is_editing_emoji_reaction_filter());
+
+    let command = handle_key(&mut state, key(KeyCode::Enter));
+
+    assert_eq!(
+        command,
+        Some(AppCommand::AddReaction {
+            channel_id: Id::new(2),
+            message_id: Id::new(1),
+            emoji: ReactionEmoji::Unicode("❤️".to_owned()),
+        })
     );
 }
 

--- a/src/tui/keybindings.rs
+++ b/src/tui/keybindings.rs
@@ -271,6 +271,7 @@ pub(in crate::tui) enum EmojiReactionPickerAction {
     Select(SelectionAction),
     Close,
     StartFilter,
+    CommitFilter,
     DeleteFilterChar,
     InsertFilterChar(char),
     ActivateSelected,
@@ -2126,9 +2127,9 @@ impl KeyBindings {
     pub(in crate::tui) fn emoji_reaction_picker_action(
         &self,
         key: KeyEvent,
-        filtering: bool,
+        filter_editing: bool,
     ) -> Option<EmojiReactionPickerAction> {
-        let key_set = if filtering {
+        let key_set = if filter_editing {
             SelectionKeySet::TextSafe
         } else {
             SelectionKeySet::Navigation
@@ -2139,11 +2140,14 @@ impl KeyBindings {
 
         match key.code {
             KeyCode::Esc => Some(EmojiReactionPickerAction::Close),
-            KeyCode::Backspace if filtering => Some(EmojiReactionPickerAction::DeleteFilterChar),
-            KeyCode::Char('/') if is_shortcut_key(key) && !filtering => {
+            KeyCode::Enter if filter_editing => Some(EmojiReactionPickerAction::CommitFilter),
+            KeyCode::Backspace if filter_editing => {
+                Some(EmojiReactionPickerAction::DeleteFilterChar)
+            }
+            KeyCode::Char('/') if is_shortcut_key(key) && !filter_editing => {
                 Some(EmojiReactionPickerAction::StartFilter)
             }
-            KeyCode::Char(value) if is_shortcut_key(key) && filtering => {
+            KeyCode::Char(value) if is_shortcut_key(key) && filter_editing => {
                 Some(EmojiReactionPickerAction::InsertFilterChar(value))
             }
             code if is_confirm_key(code) => Some(EmojiReactionPickerAction::ActivateSelected),

--- a/src/tui/state/composer/state.rs
+++ b/src/tui/state/composer/state.rs
@@ -259,6 +259,22 @@ impl DashboardState {
         self.replace_composer_range(cursor..cursor, value);
     }
 
+    pub fn open_composer_reaction_picker_from_plus_colon(&mut self) -> bool {
+        let cursor = self.composer.composer_cursor_byte_index();
+        if !composer_plus_colon_trigger_before_cursor(&self.composer.composer_input, cursor) {
+            return false;
+        }
+
+        self.open_emoji_reaction_picker();
+        if !self.is_emoji_reaction_picker_open() {
+            return false;
+        }
+
+        let plus_start = cursor - '+'.len_utf8();
+        self.replace_composer_range(plus_start..cursor, "");
+        true
+    }
+
     pub fn pop_composer_char(&mut self) {
         let end = self.composer.composer_cursor_byte_index();
         if end == 0 {
@@ -1223,9 +1239,25 @@ fn shift_byte_index(index: usize, delta: isize) -> usize {
     }
 }
 
+fn composer_plus_colon_trigger_before_cursor(input: &str, cursor: usize) -> bool {
+    if cursor == 0 || cursor > input.len() || !input.is_char_boundary(cursor) {
+        return false;
+    }
+    let plus_start = previous_char_boundary(input, cursor);
+    if &input[plus_start..cursor] != "+" {
+        return false;
+    }
+    input[..plus_start]
+        .chars()
+        .last()
+        .is_none_or(char::is_whitespace)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{next_word_boundary, previous_word_boundary};
+    use super::{
+        composer_plus_colon_trigger_before_cursor, next_word_boundary, previous_word_boundary,
+    };
 
     #[derive(Clone, Copy)]
     enum Dir {
@@ -1284,6 +1316,25 @@ mod tests {
                 step(*dir, before),
                 *expected,
                 "{arrow} on {before:?} should land at {expected:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn plus_colon_trigger_requires_boundary_plus_before_cursor() {
+        let cases = [
+            ("+", true),
+            ("draft +", true),
+            ("draft+", false),
+            ("", false),
+            ("draft", false),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(
+                composer_plus_colon_trigger_before_cursor(input, input.len()),
+                expected,
+                "{input:?} should return {expected}",
             );
         }
     }

--- a/src/tui/state/popups.rs
+++ b/src/tui/state/popups.rs
@@ -136,6 +136,7 @@ pub(super) enum ChannelLeaderActionState {
 pub struct EmojiReactionPickerState {
     pub(super) selected: usize,
     pub(super) filter: Option<String>,
+    pub(super) filter_editing: bool,
     pub(super) items: Vec<EmojiReactionItem>,
     pub(super) filtered_items: Vec<EmojiReactionItem>,
     pub(super) existing_reactions: Vec<ReactionEmoji>,

--- a/src/tui/state/reactions.rs
+++ b/src/tui/state/reactions.rs
@@ -100,6 +100,13 @@ impl DashboardState {
         self.emoji_reaction_filter().is_some()
     }
 
+    pub fn is_editing_emoji_reaction_filter(&self) -> bool {
+        self.popups
+            .emoji_reaction_picker
+            .as_ref()
+            .is_some_and(|picker| picker.filter_editing)
+    }
+
     pub fn close_emoji_reaction_picker(&mut self) {
         self.popups.emoji_reaction_picker = None;
     }
@@ -227,8 +234,15 @@ impl DashboardState {
     pub fn start_emoji_reaction_filter(&mut self) {
         if let Some(picker) = &mut self.popups.emoji_reaction_picker {
             picker.filter = Some(String::new());
+            picker.filter_editing = true;
             picker.filtered_items = picker.items.clone();
             picker.selected = 0;
+        }
+    }
+
+    pub fn commit_emoji_reaction_filter(&mut self) {
+        if let Some(picker) = &mut self.popups.emoji_reaction_picker {
+            picker.filter_editing = false;
         }
     }
 
@@ -289,6 +303,7 @@ impl DashboardState {
             self.popups.emoji_reaction_picker = Some(EmojiReactionPickerState {
                 selected: 0,
                 filter: None,
+                filter_editing: false,
                 filtered_items: items.clone(),
                 items,
                 existing_reactions,


### PR DESCRIPTION
<!--
Thanks for the contribution. Please keep the subject under ~72 characters
and use a semantic prefix (feat:, fix:, refactor:, docs:, chore:, test:).

By submitting this PR you agree it will be distributed under GPL-3.0-only.
-->

## Summary

<!-- What does this change do, in one or two sentences? -->

## Why

Closes #69 

<!-- The motivation. Link the issue it closes, e.g. "Closes #123". -->
<!-- Feature additions must have a related issue first. Feature PRs without a related issue may be closed without review. -->

## How

<!-- Notable implementation choices and any non-obvious trade-offs. -->

## Testing

<!-- How you verified the change. Mention the OS, terminal, and graphics protocol used for manual checks. -->

- [ ] `cargo fmt --all --check`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo test --all-features`
- [ ] Manual test in a real terminal (describe below)

## Screenshots or recordings

<!-- For UI changes, attach a screenshot or asciinema/gif. Delete this section if not applicable. -->

## Checklist

- [ ] One logical change per PR.
- [ ] Link a related issue.
- [ ] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [ ] Change does not add self-bot automation, mass actions, or scraping.
- [ ] Updated `README.md`, if behavior or workflows changed.
