### PR TITLE
feat: allow leaving of server

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Tokens are saved under Concord's config directory in plain text. See the Securit
 - Highlight active voice speakers in voice channel participant rows
 - Track unread messages and mention counts per channel
 - Mute and unmute channels and servers
+- Leave the selected server after confirmation
 
 ### Messaging
 
@@ -274,6 +275,7 @@ Press `Space` to open the leader shortcut window.
 | `Space`, `4`     | Toggle the Members pane           |
 | `Space`, `a`     | Open actions for the focused pane |
 | `Space`, `o`     | Choose concord option category    |
+| `Space`, `s`     | Server management prefix          |
 | `Space`, `v`     | Voice command prefix              |
 | `Space`, `Space` | Open the fuzzy channel switcher   |
 
@@ -306,6 +308,12 @@ Server actions:
 | -------- | ------------------- | ----------------------------------------------------- |
 | `m`      | Mark server as read | Mark all unread viewable channels in this server read |
 | `u`      | Mute / unmute       | Toggle server notification mute                       |
+
+Server management commands:
+
+| Sequence          | Action               | Description                                    |
+| ----------------- | -------------------- | ---------------------------------------------- |
+| `Space`, `s`, `l` | Leave current server | Open a confirmation before leaving this server |
 
 Channel actions:
 
@@ -471,8 +479,10 @@ OpenThread = { keys = ["t"], description = "open thread" }
 VoiceDeafen = "<leader>vd"
 VoiceMute = "<leader>vm"
 VoiceLeave = "<leader>vl"
+LeaveServer = "<leader>sl"
 
 [keymap.groups]
+"<leader>s" = "Server Management"
 "<leader>v" = "Voice"
 
 [keymap.channel_actions]
@@ -583,20 +593,21 @@ Message actions:
 
 Pane, options, and voice actions:
 
-| Action name               | Default config                     | Action                                       |
-| ------------------------- | ---------------------------------- | -------------------------------------------- |
-| `ToggleGuildPane`         | `"<leader>1"`                      | Toggle the Servers pane.                     |
-| `ToggleChannelPane`       | `"<leader>2"`                      | Toggle the Channels pane.                    |
-| `ToggleMemberPane`        | `"<leader>4"`                      | Toggle the Members pane.                     |
-| `OpenFocusedPaneAction`   | `"<leader>a"`                      | Open actions for the currently focused pane. |
-| `OpenOptions`             | `"<leader>o"`                      | Open the options category picker.            |
-| `ChannelSwitcher`         | `"<leader><leader>"`               | Open channel switcher.                       |
-| `OpenDisplayOptions`      | Contextual `d` after `OpenOptions` | Open Display options.                        |
-| `OpenNotificationOptions` | Contextual `n` after `OpenOptions` | Open Notification options.                   |
-| `OpenVoiceOptions`        | Contextual `v` after `OpenOptions` | Open Voice options.                          |
-| `VoiceDeafen`             | `"<leader>vd"`                     | Toggle voice deafen.                         |
-| `VoiceMute`               | `"<leader>vm"`                     | Toggle voice mute.                           |
-| `VoiceLeave`              | `"<leader>vl"`                     | Leave the current Concord voice channel.     |
+| Action name               | Default config                     | Action                                          |
+| ------------------------- | ---------------------------------- | ----------------------------------------------- |
+| `ToggleGuildPane`         | `"<leader>1"`                      | Toggle the Servers pane.                        |
+| `ToggleChannelPane`       | `"<leader>2"`                      | Toggle the Channels pane.                       |
+| `ToggleMemberPane`        | `"<leader>4"`                      | Toggle the Members pane.                        |
+| `OpenFocusedPaneAction`   | `"<leader>a"`                      | Open actions for the currently focused pane.    |
+| `OpenOptions`             | `"<leader>o"`                      | Open the options category picker.               |
+| `ChannelSwitcher`         | `"<leader><leader>"`               | Open channel switcher.                          |
+| `OpenDisplayOptions`      | Contextual `d` after `OpenOptions` | Open Display options.                           |
+| `OpenNotificationOptions` | Contextual `n` after `OpenOptions` | Open Notification options.                      |
+| `OpenVoiceOptions`        | Contextual `v` after `OpenOptions` | Open Voice options.                             |
+| `LeaveServer`             | `"<leader>sl"`                     | Open confirmation to leave the selected server. |
+| `VoiceDeafen`             | `"<leader>vd"`                     | Toggle voice deafen.                            |
+| `VoiceMute`               | `"<leader>vm"`                     | Toggle voice mute.                              |
+| `VoiceLeave`              | `"<leader>vl"`                     | Leave the current Concord voice channel.        |
 
 ##### Composer actions
 
@@ -738,8 +749,10 @@ ChannelSwitcher = "<leader><leader>"
 VoiceDeafen = "<leader>vd"
 VoiceMute = "<leader>vm"
 VoiceLeave = "<leader>vl"
+LeaveServer = "<leader>sl"
 
 [keymap.groups]
+"<leader>s" = "Server Management"
 "<leader>v" = "Voice"
 
 [keymap.guild_actions]

--- a/README.md
+++ b/README.md
@@ -275,7 +275,6 @@ Press `Space` to open the leader shortcut window.
 | `Space`, `4`     | Toggle the Members pane           |
 | `Space`, `a`     | Open actions for the focused pane |
 | `Space`, `o`     | Choose concord option category    |
-| `Space`, `s`     | Server management prefix          |
 | `Space`, `v`     | Voice command prefix              |
 | `Space`, `Space` | Open the fuzzy channel switcher   |
 
@@ -308,12 +307,7 @@ Server actions:
 | -------- | ------------------- | ----------------------------------------------------- |
 | `m`      | Mark server as read | Mark all unread viewable channels in this server read |
 | `u`      | Mute / unmute       | Toggle server notification mute                       |
-
-Server management commands:
-
-| Sequence          | Action               | Description                                    |
-| ----------------- | -------------------- | ---------------------------------------------- |
-| `Space`, `s`, `l` | Leave current server | Open a confirmation before leaving this server |
+| `l`      | Leave server        | Open a confirmation before leaving this server        |
 
 Channel actions:
 
@@ -479,11 +473,12 @@ OpenThread = { keys = ["t"], description = "open thread" }
 VoiceDeafen = "<leader>vd"
 VoiceMute = "<leader>vm"
 VoiceLeave = "<leader>vl"
-LeaveServer = "<leader>sl"
 
 [keymap.groups]
-"<leader>s" = "Server Management"
 "<leader>v" = "Voice"
+
+[keymap.guild_actions]
+LeaveServer = { keys = ["l"], description = "leave server" }
 
 [keymap.channel_actions]
 MuteChannel = { keys = ["x"], description = "mute channel" }
@@ -604,7 +599,6 @@ Pane, options, and voice actions:
 | `OpenDisplayOptions`      | Contextual `d` after `OpenOptions` | Open Display options.                           |
 | `OpenNotificationOptions` | Contextual `n` after `OpenOptions` | Open Notification options.                      |
 | `OpenVoiceOptions`        | Contextual `v` after `OpenOptions` | Open Voice options.                             |
-| `LeaveServer`             | `"<leader>sl"`                     | Open confirmation to leave the selected server. |
 | `VoiceDeafen`             | `"<leader>vd"`                     | Toggle voice deafen.                            |
 | `VoiceMute`               | `"<leader>vm"`                     | Toggle voice mute.                              |
 | `VoiceLeave`              | `"<leader>vl"`                     | Leave the current Concord voice channel.        |
@@ -650,12 +644,14 @@ Server pane actions:
 [keymap.guild_actions]
 MarkAsRead = { keys = ["m"], description = "mark server as read" }
 MuteServer = { keys = ["u"], description = "mute server" }
+LeaveServer = { keys = ["l"], description = "leave server" }
 ```
 
 | Scoped action | Default | Action                                                                     |
 | ------------- | ------- | -------------------------------------------------------------------------- |
 | `MarkAsRead`  | `m`     | Mark all unread viewable channels in the selected server read.             |
 | `MuteServer`  | `u`     | Mute or unmute the selected server. Also accepts `ToggleMute` as an alias. |
+| `LeaveServer` | `l`     | Open confirmation to leave the selected server.                            |
 
 Channel pane actions:
 
@@ -749,15 +745,14 @@ ChannelSwitcher = "<leader><leader>"
 VoiceDeafen = "<leader>vd"
 VoiceMute = "<leader>vm"
 VoiceLeave = "<leader>vl"
-LeaveServer = "<leader>sl"
 
 [keymap.groups]
-"<leader>s" = "Server Management"
 "<leader>v" = "Voice"
 
 [keymap.guild_actions]
 MarkAsRead = "m"
 MuteServer = "u"
+LeaveServer = "l"
 
 [keymap.channel_actions]
 JoinVoice = "j"

--- a/src/app.rs
+++ b/src/app.rs
@@ -568,6 +568,23 @@ fn start_command_loop(
                                 .await;
                         }
                     },
+                    AppCommand::LeaveGuild { guild_id, label } => {
+                        match client.leave_guild(guild_id).await {
+                            Ok(()) => {
+                                client
+                                    .publish_event(AppEvent::GuildDelete { guild_id })
+                                    .await;
+                            }
+                            Err(error) => {
+                                log_app_error("leave guild failed", &error);
+                                client
+                                    .publish_event(AppEvent::GatewayError {
+                                        message: format!("leave server {label} failed: {error}"),
+                                    })
+                                    .await;
+                            }
+                        }
+                    }
                     AppCommand::OpenUrl { url } => {
                         if let Err(error) = open_url(&url) {
                             logging::error("app", format!("open url failed: {error}"));

--- a/src/discord/client.rs
+++ b/src/discord/client.rs
@@ -836,6 +836,10 @@ impl DiscordClient {
         self.rest.delete_message(channel_id, message_id).await
     }
 
+    pub async fn leave_guild(&self, guild_id: Id<GuildMarker>) -> Result<()> {
+        self.rest.leave_guild(guild_id).await
+    }
+
     pub async fn load_application_commands(
         &self,
         guild_id: Option<Id<GuildMarker>>,

--- a/src/discord/commands.rs
+++ b/src/discord/commands.rs
@@ -188,6 +188,10 @@ pub enum AppCommand {
     SetSelectedGuild {
         guild_id: Option<Id<GuildMarker>>,
     },
+    LeaveGuild {
+        guild_id: Id<GuildMarker>,
+        label: String,
+    },
     SetSelectedMessageChannel {
         channel_id: Option<Id<ChannelMarker>>,
     },

--- a/src/discord/rest.rs
+++ b/src/discord/rest.rs
@@ -234,6 +234,23 @@ impl DiscordRest {
         Ok(())
     }
 
+    pub async fn leave_guild(&self, guild_id: Id<GuildMarker>) -> Result<()> {
+        self.raw_http
+            .delete(format!(
+                "https://discord.com/api/v9/users/@me/guilds/{}",
+                guild_id.get()
+            ))
+            .header(AUTHORIZATION, &self.token)
+            .send()
+            .await
+            .map_err(|error| {
+                AppError::DiscordRequest(format!("leave guild request failed: {error}"))
+            })?
+            .error_for_status()
+            .map_err(|error| AppError::DiscordRequest(format!("leave guild failed: {error}")))?;
+        Ok(())
+    }
+
     /// `token: null` is the legacy anti-spam echo field. Modern clients
     /// always send null.
     pub async fn ack_channel(

--- a/src/tui/input/keyboard.rs
+++ b/src/tui/input/keyboard.rs
@@ -52,6 +52,10 @@ pub fn handle_key(state: &mut DashboardState, key: KeyEvent) -> Option<AppComman
         return handle_message_pin_confirmation_key(state, key);
     }
 
+    if state.is_guild_leave_confirmation_open() {
+        return handle_guild_leave_confirmation_key(state, key);
+    }
+
     if state.is_poll_vote_picker_open() {
         return handle_poll_vote_picker_key(state, key);
     }
@@ -359,6 +363,7 @@ pub(in crate::tui) fn execute_ui_action(
         UiAction::OpenVoiceOptions => {
             state.open_options_category_from_shortcut(OptionsCategoryShortcut::Voice)
         }
+        UiAction::LeaveServer => state.open_current_guild_leave_confirmation(),
         UiAction::VoiceDeafen => state.toggle_voice_deafen(),
         UiAction::VoiceMute => state.toggle_voice_mute(),
         UiAction::VoiceLeave => return state.leave_current_voice_channel_command(),
@@ -789,6 +794,20 @@ fn handle_message_pin_confirmation_key(
         Some(MessageConfirmationAction::Confirm) => state.confirm_message_pin(),
         Some(MessageConfirmationAction::Cancel) => {
             state.close_message_pin_confirmation();
+            None
+        }
+        None => None,
+    }
+}
+
+fn handle_guild_leave_confirmation_key(
+    state: &mut DashboardState,
+    key: KeyEvent,
+) -> Option<AppCommand> {
+    match state.key_bindings().message_confirmation_action(key) {
+        Some(MessageConfirmationAction::Confirm) => state.confirm_guild_leave(),
+        Some(MessageConfirmationAction::Cancel) => {
+            state.close_guild_leave_confirmation();
             None
         }
         None => None,

--- a/src/tui/input/keyboard.rs
+++ b/src/tui/input/keyboard.rs
@@ -363,7 +363,6 @@ pub(in crate::tui) fn execute_ui_action(
         UiAction::OpenVoiceOptions => {
             state.open_options_category_from_shortcut(OptionsCategoryShortcut::Voice)
         }
-        UiAction::LeaveServer => state.open_current_guild_leave_confirmation(),
         UiAction::VoiceDeafen => state.toggle_voice_deafen(),
         UiAction::VoiceMute => state.toggle_voice_mute(),
         UiAction::VoiceLeave => return state.leave_current_voice_channel_command(),

--- a/src/tui/input/tests/leader.rs
+++ b/src/tui/input/tests/leader.rs
@@ -639,6 +639,45 @@ fn leader_v_opens_voice_keymap_group() {
 }
 
 #[test]
+fn leader_s_opens_server_management_keymap_group() {
+    let mut state = DashboardState::new();
+
+    handle_key(&mut state, char_key(' '));
+    handle_key(&mut state, char_key('s'));
+
+    assert!(state.is_leader_active());
+    assert_eq!(state.leader_keymap_title(), "Server Management");
+    assert!(
+        state
+            .leader_keymap_shortcuts()
+            .iter()
+            .any(|item| item.key == "l" && item.label == "Leave current server")
+    );
+}
+
+#[test]
+fn leader_server_management_remove_opens_confirmation_then_leaves() {
+    let mut state = state_with_channel_tree();
+
+    handle_key(&mut state, char_key(' '));
+    handle_key(&mut state, char_key('s'));
+    handle_key(&mut state, char_key('l'));
+
+    assert!(!state.is_leader_active());
+    assert!(state.is_guild_leave_confirmation_open());
+
+    let command = handle_key(&mut state, char_key('y'));
+
+    assert_eq!(
+        command,
+        Some(AppCommand::LeaveGuild {
+            guild_id: Id::new(1),
+            label: "guild".to_owned(),
+        })
+    );
+}
+
+#[test]
 fn leader_o_category_shortcuts_open_scoped_options() {
     let mut state = DashboardState::new();
 

--- a/src/tui/input/tests/leader.rs
+++ b/src/tui/input/tests/leader.rs
@@ -639,28 +639,12 @@ fn leader_v_opens_voice_keymap_group() {
 }
 
 #[test]
-fn leader_s_opens_server_management_keymap_group() {
-    let mut state = DashboardState::new();
-
-    handle_key(&mut state, char_key(' '));
-    handle_key(&mut state, char_key('s'));
-
-    assert!(state.is_leader_active());
-    assert_eq!(state.leader_keymap_title(), "Server Management");
-    assert!(
-        state
-            .leader_keymap_shortcuts()
-            .iter()
-            .any(|item| item.key == "l" && item.label == "Leave current server")
-    );
-}
-
-#[test]
-fn leader_server_management_remove_opens_confirmation_then_leaves() {
+fn leader_server_actions_leave_opens_confirmation_then_leaves() {
     let mut state = state_with_channel_tree();
+    state.focus_pane(FocusPane::Guilds);
 
     handle_key(&mut state, char_key(' '));
-    handle_key(&mut state, char_key('s'));
+    handle_key(&mut state, char_key('a'));
     handle_key(&mut state, char_key('l'));
 
     assert!(!state.is_leader_active());

--- a/src/tui/keybindings.rs
+++ b/src/tui/keybindings.rs
@@ -148,6 +148,7 @@ pub(in crate::tui) enum UiAction {
     OpenDisplayOptions,
     OpenNotificationOptions,
     OpenVoiceOptions,
+    LeaveServer,
     VoiceDeafen,
     VoiceMute,
     VoiceLeave,
@@ -892,7 +893,13 @@ fn parse_keymap_groups_lossy(
 }
 
 fn default_keymap_group_titles(leader: KeyChord) -> Vec<(Vec<KeyChord>, String)> {
-    vec![(vec![leader, char_chord('v')], "Voice".to_owned())]
+    vec![
+        (
+            vec![leader, char_chord('s')],
+            "Server Management".to_owned(),
+        ),
+        (vec![leader, char_chord('v')], "Voice".to_owned()),
+    ]
 }
 
 fn keymap_group_titles_with_defaults(
@@ -1223,6 +1230,7 @@ impl UiAction {
             UiAction::OpenDisplayOptions => "OpenDisplayOptions",
             UiAction::OpenNotificationOptions => "OpenNotificationOptions",
             UiAction::OpenVoiceOptions => "OpenVoiceOptions",
+            UiAction::LeaveServer => "LeaveServer",
             UiAction::VoiceDeafen => "VoiceDeafen",
             UiAction::VoiceMute => "VoiceMute",
             UiAction::VoiceLeave => "VoiceLeave",
@@ -1273,6 +1281,7 @@ impl UiAction {
             UiAction::OpenDisplayOptions => "Display options",
             UiAction::OpenNotificationOptions => "Notification options",
             UiAction::OpenVoiceOptions => "Voice options",
+            UiAction::LeaveServer => "Leave current server",
             UiAction::VoiceDeafen => "deafen voice",
             UiAction::VoiceMute => "mute voice",
             UiAction::VoiceLeave => "leave voice",
@@ -1470,6 +1479,7 @@ fn all_ui_actions() -> &'static [UiAction] {
         UiAction::OpenDisplayOptions,
         UiAction::OpenNotificationOptions,
         UiAction::OpenVoiceOptions,
+        UiAction::LeaveServer,
         UiAction::VoiceDeafen,
         UiAction::VoiceMute,
         UiAction::VoiceLeave,
@@ -1865,6 +1875,7 @@ fn default_keymap_specs(leader: KeyChord) -> BTreeMap<UiAction, KeyMapActionSpec
             UiAction::OpenDisplayOptions
             | UiAction::OpenNotificationOptions
             | UiAction::OpenVoiceOptions => Vec::new(),
+            UiAction::LeaveServer => vec![vec![leader, char_chord('s'), char_chord('l')]],
             UiAction::VoiceDeafen => vec![vec![leader, char_chord('v'), char_chord('d')]],
             UiAction::VoiceMute => vec![vec![leader, char_chord('v'), char_chord('m')]],
             UiAction::VoiceLeave => vec![vec![leader, char_chord('v'), char_chord('l')]],

--- a/src/tui/keybindings.rs
+++ b/src/tui/keybindings.rs
@@ -148,7 +148,6 @@ pub(in crate::tui) enum UiAction {
     OpenDisplayOptions,
     OpenNotificationOptions,
     OpenVoiceOptions,
-    LeaveServer,
     VoiceDeafen,
     VoiceMute,
     VoiceLeave,
@@ -893,13 +892,7 @@ fn parse_keymap_groups_lossy(
 }
 
 fn default_keymap_group_titles(leader: KeyChord) -> Vec<(Vec<KeyChord>, String)> {
-    vec![
-        (
-            vec![leader, char_chord('s')],
-            "Server Management".to_owned(),
-        ),
-        (vec![leader, char_chord('v')], "Voice".to_owned()),
-    ]
+    vec![(vec![leader, char_chord('v')], "Voice".to_owned())]
 }
 
 fn keymap_group_titles_with_defaults(
@@ -1230,7 +1223,6 @@ impl UiAction {
             UiAction::OpenDisplayOptions => "OpenDisplayOptions",
             UiAction::OpenNotificationOptions => "OpenNotificationOptions",
             UiAction::OpenVoiceOptions => "OpenVoiceOptions",
-            UiAction::LeaveServer => "LeaveServer",
             UiAction::VoiceDeafen => "VoiceDeafen",
             UiAction::VoiceMute => "VoiceMute",
             UiAction::VoiceLeave => "VoiceLeave",
@@ -1281,7 +1273,6 @@ impl UiAction {
             UiAction::OpenDisplayOptions => "Display options",
             UiAction::OpenNotificationOptions => "Notification options",
             UiAction::OpenVoiceOptions => "Voice options",
-            UiAction::LeaveServer => "Leave current server",
             UiAction::VoiceDeafen => "deafen voice",
             UiAction::VoiceMute => "mute voice",
             UiAction::VoiceLeave => "leave voice",
@@ -1294,6 +1285,7 @@ impl GuildActionKind {
         match name {
             "MarkAsRead" => Some(Self::MarkAsRead),
             "MuteServer" | "ToggleMute" => Some(Self::ToggleMute),
+            "LeaveServer" => Some(Self::LeaveServer),
             _ => None,
         }
     }
@@ -1303,6 +1295,7 @@ impl GuildActionKind {
             Self::NoActionsYet => "NoActionsYet",
             Self::MarkAsRead => "MarkAsRead",
             Self::ToggleMute => "ToggleMute",
+            Self::LeaveServer => "LeaveServer",
         }
     }
 }
@@ -1479,7 +1472,6 @@ fn all_ui_actions() -> &'static [UiAction] {
         UiAction::OpenDisplayOptions,
         UiAction::OpenNotificationOptions,
         UiAction::OpenVoiceOptions,
-        UiAction::LeaveServer,
         UiAction::VoiceDeafen,
         UiAction::VoiceMute,
         UiAction::VoiceLeave,
@@ -1875,7 +1867,6 @@ fn default_keymap_specs(leader: KeyChord) -> BTreeMap<UiAction, KeyMapActionSpec
             UiAction::OpenDisplayOptions
             | UiAction::OpenNotificationOptions
             | UiAction::OpenVoiceOptions => Vec::new(),
-            UiAction::LeaveServer => vec![vec![leader, char_chord('s'), char_chord('l')]],
             UiAction::VoiceDeafen => vec![vec![leader, char_chord('v'), char_chord('d')]],
             UiAction::VoiceMute => vec![vec![leader, char_chord('v'), char_chord('m')]],
             UiAction::VoiceLeave => vec![vec![leader, char_chord('v'), char_chord('l')]],
@@ -2716,6 +2707,7 @@ impl KeyBindings {
         match kind {
             GuildActionKind::MarkAsRead => vec![char_chord('m')],
             GuildActionKind::ToggleMute => vec![char_chord('u')],
+            GuildActionKind::LeaveServer => vec![char_chord('l')],
             GuildActionKind::NoActionsYet => Vec::new(),
         }
     }

--- a/src/tui/state/guilds.rs
+++ b/src/tui/state/guilds.rs
@@ -304,6 +304,47 @@ impl DashboardState {
         self.popups.guild_leader_action = None;
     }
 
+    pub fn open_current_guild_leave_confirmation(&mut self) {
+        let guild_id = if self.navigation.focus == FocusPane::Guilds {
+            self.selected_guild_cursor_id()
+        } else {
+            self.selected_guild_id()
+        };
+        let Some(guild_id) = guild_id else {
+            return;
+        };
+        let name = self
+            .discord
+            .guild(guild_id)
+            .map(|guild| guild.name.clone())
+            .unwrap_or_else(|| format!("server-{}", guild_id.get()));
+        self.popups.guild_leave_confirmation =
+            Some(super::popups::GuildLeaveConfirmationState { guild_id, name });
+    }
+
+    pub fn is_guild_leave_confirmation_open(&self) -> bool {
+        self.popups.guild_leave_confirmation.is_some()
+    }
+
+    pub fn close_guild_leave_confirmation(&mut self) {
+        self.popups.guild_leave_confirmation = None;
+    }
+
+    pub fn confirm_guild_leave(&mut self) -> Option<AppCommand> {
+        let confirmation = self.popups.guild_leave_confirmation.take()?;
+        Some(AppCommand::LeaveGuild {
+            guild_id: confirmation.guild_id,
+            label: confirmation.name,
+        })
+    }
+
+    pub fn guild_leave_confirmation_name(&self) -> Option<String> {
+        self.popups
+            .guild_leave_confirmation
+            .as_ref()
+            .map(|confirmation| confirmation.name.clone())
+    }
+
     pub fn back_guild_leader_action(&mut self) -> bool {
         if matches!(
             self.popups.guild_leader_action,

--- a/src/tui/state/guilds.rs
+++ b/src/tui/state/guilds.rs
@@ -377,6 +377,11 @@ impl DashboardState {
                     },
                     enabled: true,
                 },
+                GuildActionItem {
+                    kind: GuildActionKind::LeaveServer,
+                    label: "Leave server".to_owned(),
+                    enabled: true,
+                },
             ],
             Some(GuildPaneEntry::DirectMessages) => vec![GuildActionItem {
                 kind: GuildActionKind::NoActionsYet,
@@ -435,6 +440,11 @@ impl DashboardState {
                                 Some(GuildLeaderActionState::MuteDuration { selected: 0 });
                             None
                         }
+                    }
+                    GuildActionKind::LeaveServer => {
+                        self.close_guild_leader_action();
+                        self.open_current_guild_leave_confirmation();
+                        None
                     }
                     GuildActionKind::NoActionsYet => None,
                 }

--- a/src/tui/state/model.rs
+++ b/src/tui/state/model.rs
@@ -141,6 +141,7 @@ pub enum GuildActionKind {
     NoActionsYet,
     MarkAsRead,
     ToggleMute,
+    LeaveServer,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/src/tui/state/popups.rs
+++ b/src/tui/state/popups.rs
@@ -30,6 +30,7 @@ pub(super) struct PopupUiState {
     pub(super) message_delete_confirmation: Option<MessageDeleteConfirmationState>,
     pub(super) message_pin_confirmation: Option<MessagePinConfirmationState>,
     pub(super) quit_confirmation_open: bool,
+    pub(super) guild_leave_confirmation: Option<GuildLeaveConfirmationState>,
     pub(super) options_popup: Option<OptionsPopupState>,
     pub(super) attachment_viewer: Option<AttachmentViewerState>,
     pub(super) guild_leader_action: Option<GuildLeaderActionState>,
@@ -91,6 +92,12 @@ pub struct MessagePinConfirmationState {
     pub(super) pinned: bool,
     pub(super) author: String,
     pub(super) content: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GuildLeaveConfirmationState {
+    pub(super) guild_id: Id<GuildMarker>,
+    pub(super) name: String,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/src/tui/state/tests/leader_actions.rs
+++ b/src/tui/state/tests/leader_actions.rs
@@ -108,12 +108,14 @@ fn guild_leader_action_lists_disabled_mark_server_read_when_guild_is_read() {
 
     assert!(state.is_guild_leader_action_active());
     let actions = state.selected_guild_action_items();
-    assert_eq!(actions.len(), 2);
+    assert_eq!(actions.len(), 3);
     assert_eq!(actions[0].kind, GuildActionKind::MarkAsRead);
     assert_eq!(actions[0].label, "Mark server as read");
     assert!(!actions[0].enabled);
     assert_eq!(actions[1].kind, GuildActionKind::ToggleMute);
     assert_eq!(actions[1].label, "Mute server");
+    assert_eq!(actions[2].kind, GuildActionKind::LeaveServer);
+    assert_eq!(actions[2].label, "Leave server");
     assert_eq!(state.activate_selected_guild_action(), None);
 }
 
@@ -242,6 +244,27 @@ fn focused_guild_cursor_leave_confirmation_does_not_require_active_guild() {
 
     state.open_current_guild_leave_confirmation();
 
+    assert!(state.is_guild_leave_confirmation_open());
+    assert_eq!(
+        state.confirm_guild_leave(),
+        Some(AppCommand::LeaveGuild {
+            guild_id: Id::new(1),
+            label: "guild 1".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn guild_leader_action_leave_server_opens_confirmation() {
+    let mut state = state_with_many_guilds(1);
+    state.focus_pane(FocusPane::Guilds);
+    state.move_down();
+    state.open_selected_guild_actions();
+    state.select_guild_action_row(2);
+
+    assert_eq!(state.activate_selected_guild_action(), None);
+
+    assert!(!state.is_guild_leader_action_active());
     assert!(state.is_guild_leave_confirmation_open());
     assert_eq!(
         state.confirm_guild_leave(),

--- a/src/tui/state/tests/leader_actions.rs
+++ b/src/tui/state/tests/leader_actions.rs
@@ -213,6 +213,57 @@ fn guild_leader_action_toggle_mute_opens_duration_then_dispatches_command() {
 }
 
 #[test]
+fn current_guild_leave_confirmation_dispatches_leave_command() {
+    let mut state = state_with_many_guilds(1);
+    state.activate_guild(super::ActiveGuildScope::Guild(Id::new(1)));
+
+    state.open_current_guild_leave_confirmation();
+
+    assert!(state.is_guild_leave_confirmation_open());
+    assert_eq!(
+        state.guild_leave_confirmation_name(),
+        Some("guild 1".to_owned())
+    );
+    assert_eq!(
+        state.confirm_guild_leave(),
+        Some(AppCommand::LeaveGuild {
+            guild_id: Id::new(1),
+            label: "guild 1".to_owned(),
+        })
+    );
+    assert!(!state.is_guild_leave_confirmation_open());
+}
+
+#[test]
+fn focused_guild_cursor_leave_confirmation_does_not_require_active_guild() {
+    let mut state = state_with_many_guilds(1);
+    state.focus_pane(FocusPane::Guilds);
+    state.move_down();
+
+    state.open_current_guild_leave_confirmation();
+
+    assert!(state.is_guild_leave_confirmation_open());
+    assert_eq!(
+        state.confirm_guild_leave(),
+        Some(AppCommand::LeaveGuild {
+            guild_id: Id::new(1),
+            label: "guild 1".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn direct_messages_do_not_open_guild_leave_confirmation() {
+    let mut state = state_with_many_guilds(1);
+    state.activate_guild(super::ActiveGuildScope::DirectMessages);
+    state.focus_pane(FocusPane::Messages);
+
+    state.open_current_guild_leave_confirmation();
+
+    assert!(!state.is_guild_leave_confirmation_open());
+}
+
+#[test]
 fn guild_leader_action_marks_unread_server_channels_as_read() {
     let guild_id: Id<GuildMarker> = Id::new(1);
     let mut state = DashboardState::new();

--- a/src/tui/state/tests/mod.rs
+++ b/src/tui/state/tests/mod.rs
@@ -13,7 +13,7 @@ use unicode_width::UnicodeWidthStr;
 use super::model::{ChannelBranch, GuildBranch};
 use super::{
     ActiveGuildScope, AttachmentViewerItem, ChannelActionKind, ChannelPaneEntry, DashboardState,
-    FocusPane, GuildPaneEntry, MessageActionItem, MessageActionKind,
+    FocusPane, GuildActionKind, GuildPaneEntry, MessageActionItem, MessageActionKind,
 };
 use crate::discord::{
     ActivityInfo, ActivityKind, AppCommand, AppEvent, AttachmentInfo, AttachmentUpdate,
@@ -32,6 +32,7 @@ mod direct_messages;
 mod emoji_reactions;
 mod fixtures;
 mod forums;
+mod leader_actions;
 mod members;
 mod message_actions;
 mod message_layout;

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -73,11 +73,11 @@ use self::panes::{render_channels, render_guilds, render_header, render_members}
 use self::popups::{
     keymap_popup_text_area, keymap_popup_total_lines, render_attachment_viewer,
     render_channel_switcher_popup, render_debug_log_popup, render_emoji_reaction_picker,
-    render_keymap_help_popup, render_leader_popup, render_message_action_menu,
-    render_message_delete_confirmation, render_message_pin_confirmation, render_message_url_picker,
-    render_options_popup, render_poll_vote_picker, render_quit_confirmation,
-    render_reaction_users_popup, render_toast, render_user_profile_popup,
-    user_profile_popup_has_avatar, user_profile_popup_text_geometry,
+    render_guild_leave_confirmation, render_keymap_help_popup, render_leader_popup,
+    render_message_action_menu, render_message_delete_confirmation,
+    render_message_pin_confirmation, render_message_url_picker, render_options_popup,
+    render_poll_vote_picker, render_quit_confirmation, render_reaction_users_popup, render_toast,
+    render_user_profile_popup, user_profile_popup_has_avatar, user_profile_popup_text_geometry,
     user_profile_popup_total_lines,
 };
 use self::types::{
@@ -223,6 +223,7 @@ pub fn render(
     render_message_delete_confirmation(frame, areas.messages, state);
     render_message_pin_confirmation(frame, areas.messages, state);
     render_quit_confirmation(frame, areas.messages, state);
+    render_guild_leave_confirmation(frame, areas.messages, state);
     render_options_popup(frame, areas.messages, state);
     render_poll_vote_picker(frame, areas.messages, state);
     render_user_profile_popup(frame, areas.messages, state, profile_avatar, &emoji_images);

--- a/src/tui/ui/popups.rs
+++ b/src/tui/ui/popups.rs
@@ -33,7 +33,8 @@ pub(super) use confirmation::{
     message_delete_confirmation_lines, message_pin_confirmation_lines, quit_confirmation_lines,
 };
 pub(super) use confirmation::{
-    render_message_delete_confirmation, render_message_pin_confirmation, render_quit_confirmation,
+    render_guild_leave_confirmation, render_message_delete_confirmation,
+    render_message_pin_confirmation, render_quit_confirmation,
 };
 #[cfg(test)]
 pub(super) use debug_log::debug_log_popup_lines;

--- a/src/tui/ui/popups/confirmation.rs
+++ b/src/tui/ui/popups/confirmation.rs
@@ -90,7 +90,7 @@ pub(in crate::tui::ui) fn render_guild_leave_confirmation(
     frame.render_widget(Clear, popup);
     frame.render_widget(
         Paragraph::new(lines)
-            .block(panel_block("Remove server?", true))
+            .block(panel_block("Leave server?", true))
             .wrap(Wrap { trim: false }),
         popup,
     );
@@ -198,7 +198,7 @@ fn guild_leave_confirmation_lines_with_key_bindings(
 ) -> Vec<Line<'static>> {
     let name = truncate_display_width(name, width.max(1).saturating_sub(2));
     vec![
-        Line::from(Span::raw("Remove the current server?")),
+        Line::from(Span::raw("Leave the current server?")),
         Line::from(Span::styled(
             format!("Server: {name}"),
             Style::default().fg(Color::Red),
@@ -209,7 +209,7 @@ fn guild_leave_confirmation_lines_with_key_bindings(
                 key_bindings.message_confirmation_confirm_label(),
                 Style::default().fg(ACCENT).bold(),
             ),
-            Span::raw(" remove server · "),
+            Span::raw(" leave server · "),
             Span::styled(
                 key_bindings.message_confirmation_cancel_label(),
                 Style::default().fg(ACCENT).bold(),

--- a/src/tui/ui/popups/confirmation.rs
+++ b/src/tui/ui/popups/confirmation.rs
@@ -76,6 +76,26 @@ pub(in crate::tui::ui) fn render_quit_confirmation(
     );
 }
 
+pub(in crate::tui::ui) fn render_guild_leave_confirmation(
+    frame: &mut Frame,
+    area: Rect,
+    state: &DashboardState,
+) {
+    let Some(name) = state.guild_leave_confirmation_name() else {
+        return;
+    };
+
+    let lines = guild_leave_confirmation_lines_with_key_bindings(&name, 56, state.key_bindings());
+    let popup = centered_rect(area, 60, (lines.len() as u16).saturating_add(2));
+    frame.render_widget(Clear, popup);
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(panel_block("Remove server?", true))
+            .wrap(Wrap { trim: false }),
+        popup,
+    );
+}
+
 #[cfg(test)]
 pub(in crate::tui::ui) fn message_delete_confirmation_lines(
     author: &str,
@@ -162,6 +182,34 @@ fn quit_confirmation_lines_with_key_bindings(
                 Style::default().fg(ACCENT).bold(),
             ),
             Span::raw(" quit · "),
+            Span::styled(
+                key_bindings.message_confirmation_cancel_label(),
+                Style::default().fg(ACCENT).bold(),
+            ),
+            Span::raw(" cancel"),
+        ]),
+    ]
+}
+
+fn guild_leave_confirmation_lines_with_key_bindings(
+    name: &str,
+    width: usize,
+    key_bindings: &crate::tui::keybindings::KeyBindings,
+) -> Vec<Line<'static>> {
+    let name = truncate_display_width(name, width.max(1).saturating_sub(2));
+    vec![
+        Line::from(Span::raw("Remove the current server?")),
+        Line::from(Span::styled(
+            format!("Server: {name}"),
+            Style::default().fg(Color::Red),
+        )),
+        Line::from(Span::raw(String::new())),
+        Line::from(vec![
+            Span::styled(
+                key_bindings.message_confirmation_confirm_label(),
+                Style::default().fg(ACCENT).bold(),
+            ),
+            Span::raw(" remove server · "),
             Span::styled(
                 key_bindings.message_confirmation_cancel_label(),
                 Style::default().fg(ACCENT).bold(),


### PR DESCRIPTION
## Summary

Allows a user to leave a guild they are currently a member of

## Why

There are guilds that people join that they want to leave for one reason or another

## How

I implemented a new section under the server's leader-key menu called "Server management".  Currently we only support leaving servers, but if this PR is accepted, there will be a fast-follow PR that supports joining new servers.

## Testing

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] Manual test in a real terminal (describe below)

OS: macOS Tahoe 26.5 
Terminal: Ghostty 1.3.1

## Screenshots or recordings

`[LEADER]` key is pressed:
<img width="663" height="180" alt="Screenshot 2026-05-25 at 6 59 16 PM" src="https://github.com/user-attachments/assets/e9b94cb6-9dc3-4e15-b987-785106573b5b" />

`s` is pressed:
<img width="563" height="150" alt="Screenshot 2026-05-25 at 6 59 26 PM" src="https://github.com/user-attachments/assets/8e2ab3bc-d4be-4d95-bf6c-8c99cd99dcab" />

`l` (lowercase "L") is pressed:
<img width="493" height="219" alt="Screenshot 2026-05-25 at 6 59 37 PM" src="https://github.com/user-attachments/assets/4fb837df-69ab-474c-af79-edb763818bb8" />

## Checklist

- [x] One logical change per PR.
- [x] Link a related issue.
- [x] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [x] Change does not add self-bot automation, mass actions, or scraping.
- [x] Updated `README.md`, if behavior or workflows changed.
