### PR TITLE
feat(attachment viewer): zoom controls and accurate image sizing

### DIFF
--- a/src/tui/input/keyboard.rs
+++ b/src/tui/input/keyboard.rs
@@ -803,6 +803,9 @@ fn handle_attachment_viewer_key(state: &mut DashboardState, key: KeyEvent) -> Op
         Some(AttachmentViewerAction::DownloadSelected) => {
             return state.download_selected_attachment_viewer_attachment();
         }
+        Some(AttachmentViewerAction::ToggleZoom) => state.toggle_attachment_viewer_fullscreen(),
+        Some(AttachmentViewerAction::ZoomIn) => state.zoom_attachment_viewer_in(),
+        Some(AttachmentViewerAction::ZoomOut) => state.zoom_attachment_viewer_out(),
         None => {}
     }
 

--- a/src/tui/keybindings.rs
+++ b/src/tui/keybindings.rs
@@ -256,6 +256,9 @@ pub(in crate::tui) enum AttachmentViewerAction {
     Previous,
     Next,
     DownloadSelected,
+    ToggleZoom,
+    ZoomIn,
+    ZoomOut,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -2253,6 +2256,13 @@ impl KeyBindings {
             KeyCode::Char('d') if is_shortcut_key(key) => {
                 Some(AttachmentViewerAction::DownloadSelected)
             }
+            KeyCode::Char('z') if is_shortcut_key(key) => Some(AttachmentViewerAction::ToggleZoom),
+            KeyCode::Char('+') | KeyCode::Char('=') if is_shortcut_key(key) => {
+                Some(AttachmentViewerAction::ZoomIn)
+            }
+            KeyCode::Char('-') | KeyCode::Char('_') if is_shortcut_key(key) => {
+                Some(AttachmentViewerAction::ZoomOut)
+            }
             _ => None,
         }
     }
@@ -2573,7 +2583,7 @@ impl KeyBindings {
     }
 
     pub fn attachment_viewer_download_hint(&self) -> &'static str {
-        "[d] download attachment"
+        "[d] download  [z] zoom  [+/-] zoom in/out"
     }
 
     pub fn unread_mark_as_read_hint(&self) -> &'static str {

--- a/src/tui/media/preview.rs
+++ b/src/tui/media/preview.rs
@@ -83,6 +83,10 @@ impl ImagePreviewCache {
         }
     }
 
+    pub(in crate::tui) fn font_size(&self) -> Option<(u16, u16)> {
+        self.picker.as_ref().map(Picker::font_size)
+    }
+
     pub(in crate::tui) fn render_state(
         &mut self,
         targets: &[ImagePreviewTarget],

--- a/src/tui/media/targets.rs
+++ b/src/tui/media/targets.rs
@@ -109,6 +109,8 @@ pub(in crate::tui) fn visible_image_preview_targets(
             layout.viewer_max_preview_height,
             preview.width,
             preview.height,
+            true,
+            layout.font_size,
         );
         if preview_height == 0 {
             return Vec::new();
@@ -210,6 +212,8 @@ fn image_preview_size_for_dimensions(
     max_preview_height: u16,
     image_width: Option<u64>,
     image_height: Option<u64>,
+    viewer: bool,
+    font_size: Option<(u16, u16)>,
 ) -> (u16, u16) {
     if max_preview_width == 0 || max_preview_height == 0 {
         return (0, 0);
@@ -222,21 +226,36 @@ fn image_preview_size_for_dimensions(
         return (max_preview_width, max_preview_height);
     }
 
-    let source_width_columns = image_width.div_ceil(IMAGE_PREVIEW_SOURCE_PIXELS_PER_COLUMN);
-    let width_for_height =
-        (u128::from(max_preview_height) * u128::from(image_width) * 3) / u128::from(image_height);
-    let preview_width = max_preview_width
-        .min(u16::try_from(source_width_columns).unwrap_or(u16::MAX))
+    let (cell_w, cell_h) = cell_aspect_ratio(font_size);
+    let width_for_height = (u128::from(max_preview_height) * u128::from(image_width) * cell_h)
+        / (u128::from(image_height) * cell_w);
+    let mut preview_width = max_preview_width
         .min(u16::try_from(width_for_height.max(1)).unwrap_or(u16::MAX))
         .max(1);
-    let preview_height = image_preview_height_for_dimensions(
+    if !viewer {
+        let source_width_columns = image_width.div_ceil(IMAGE_PREVIEW_SOURCE_PIXELS_PER_COLUMN);
+        preview_width = preview_width.min(u16::try_from(source_width_columns).unwrap_or(u16::MAX));
+    }
+    let preview_height = image_preview_height_for_dimensions_inner(
         preview_width,
         max_preview_height,
         Some(image_width),
         Some(image_height),
+        viewer,
+        font_size,
     );
 
     (preview_width, preview_height)
+}
+
+/// Returns (cell_width_px, cell_height_px) for the terminal's font cell.
+/// Falls back to the legacy 1:3 (width:height) ratio when the picker
+/// couldn't query the terminal — preserves prior behavior in that case.
+fn cell_aspect_ratio(font_size: Option<(u16, u16)>) -> (u128, u128) {
+    match font_size {
+        Some((w, h)) if w > 0 && h > 0 => (u128::from(w), u128::from(h)),
+        _ => (1, 3),
+    }
 }
 
 fn preview_request_url(
@@ -789,6 +808,24 @@ pub(in crate::tui) fn image_preview_height_for_dimensions(
     image_width: Option<u64>,
     image_height: Option<u64>,
 ) -> u16 {
+    image_preview_height_for_dimensions_inner(
+        preview_width,
+        max_preview_height,
+        image_width,
+        image_height,
+        false,
+        None,
+    )
+}
+
+fn image_preview_height_for_dimensions_inner(
+    preview_width: u16,
+    max_preview_height: u16,
+    image_width: Option<u64>,
+    image_height: Option<u64>,
+    viewer: bool,
+    font_size: Option<(u16, u16)>,
+) -> u16 {
     if preview_width == 0 || max_preview_height == 0 {
         return 0;
     }
@@ -800,11 +837,16 @@ pub(in crate::tui) fn image_preview_height_for_dimensions(
         return max_preview_height;
     }
 
-    let source_width_columns = image_width.div_ceil(IMAGE_PREVIEW_SOURCE_PIXELS_PER_COLUMN);
-    let preview_width = preview_width.min(u16::try_from(source_width_columns).unwrap_or(u16::MAX));
+    let preview_width = if viewer {
+        preview_width
+    } else {
+        let source_width_columns = image_width.div_ceil(IMAGE_PREVIEW_SOURCE_PIXELS_PER_COLUMN);
+        preview_width.min(u16::try_from(source_width_columns).unwrap_or(u16::MAX))
+    };
 
-    let rows = (u128::from(preview_width) * u128::from(image_height))
-        .div_ceil(u128::from(image_width) * 3);
+    let (cell_w, cell_h) = cell_aspect_ratio(font_size);
+    let rows = (u128::from(preview_width) * u128::from(image_height) * cell_w)
+        .div_ceil(u128::from(image_width) * cell_h);
     let rows = u16::try_from(rows).unwrap_or(u16::MAX);
 
     rows.clamp(3.min(max_preview_height), max_preview_height)

--- a/src/tui/media/tests.rs
+++ b/src/tui/media/tests.rs
@@ -29,6 +29,7 @@ fn layout(list_height: usize) -> ImagePreviewLayout {
         max_preview_height: 3,
         viewer_preview_width: 76,
         viewer_max_preview_height: 13,
+        font_size: None,
     }
 }
 

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -101,6 +101,7 @@ pub(super) async fn run_dashboard(
                 last_frame_area = frame.area();
                 ui::sync_view_heights(frame.area(), &mut state);
                 let mut preview_layout = ui::image_preview_layout(frame.area(), &state);
+                preview_layout.font_size = image_previews.font_size();
                 if !state.show_images() {
                     preview_layout.preview_width = 0;
                     preview_layout.max_preview_height = 0;

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -67,8 +67,8 @@ pub use model::{
 pub use model::{ChannelActionKind, GuildActionKind, MemberActionKind, MessageUrlItem};
 pub use options::DisplayOptionItem;
 pub use popups::{
-    EmojiReactionPickerState, MessageActionMenuState, MessageUrlPickerState, PollVotePickerState,
-    ReactionUsersPopupState,
+    AttachmentViewerZoom, EmojiReactionPickerState, MessageActionMenuState, MessageUrlPickerState,
+    PollVotePickerState, ReactionUsersPopupState,
 };
 pub use presentation::{discord_color, folder_color, presence_color, presence_marker};
 

--- a/src/tui/state/attachment_viewer.rs
+++ b/src/tui/state/attachment_viewer.rs
@@ -5,7 +5,7 @@ use crate::discord::{
 
 use super::scroll::clamp_selected_index;
 use super::{AttachmentViewerItem, DashboardState};
-use crate::tui::state::popups::AttachmentViewerState;
+use crate::tui::state::popups::{AttachmentViewerState, AttachmentViewerZoom};
 
 impl DashboardState {
     pub fn is_attachment_viewer_open(&self) -> bool {
@@ -24,12 +24,39 @@ impl DashboardState {
             message_id: message.id,
             selected: 0,
             download_message: None,
+            zoom: AttachmentViewerZoom::default(),
         });
         true
     }
 
     pub fn close_attachment_viewer(&mut self) {
         self.popups.attachment_viewer = None;
+    }
+
+    pub fn attachment_viewer_zoom(&self) -> AttachmentViewerZoom {
+        self.popups
+            .attachment_viewer
+            .as_ref()
+            .map(|viewer| viewer.zoom)
+            .unwrap_or_default()
+    }
+
+    pub fn toggle_attachment_viewer_fullscreen(&mut self) {
+        if let Some(viewer) = &mut self.popups.attachment_viewer {
+            viewer.zoom = viewer.zoom.toggle_fullscreen();
+        }
+    }
+
+    pub fn zoom_attachment_viewer_in(&mut self) {
+        if let Some(viewer) = &mut self.popups.attachment_viewer {
+            viewer.zoom = viewer.zoom.zoom_in();
+        }
+    }
+
+    pub fn zoom_attachment_viewer_out(&mut self) {
+        if let Some(viewer) = &mut self.popups.attachment_viewer {
+            viewer.zoom = viewer.zoom.zoom_out();
+        }
     }
 
     pub fn move_attachment_viewer_previous(&mut self) {
@@ -124,5 +151,44 @@ impl DashboardState {
             Some(attachments) => attachments.len(),
             None => 0,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AttachmentViewerZoom;
+
+    #[test]
+    fn zoom_in_steps_default_large_fullscreen_and_caps() {
+        let zoom = AttachmentViewerZoom::Default;
+        let zoom = zoom.zoom_in();
+        assert_eq!(zoom, AttachmentViewerZoom::Large);
+        let zoom = zoom.zoom_in();
+        assert_eq!(zoom, AttachmentViewerZoom::Fullscreen);
+        let zoom = zoom.zoom_in();
+        assert_eq!(zoom, AttachmentViewerZoom::Fullscreen);
+    }
+
+    #[test]
+    fn zoom_out_steps_fullscreen_large_default_and_caps() {
+        let zoom = AttachmentViewerZoom::Fullscreen;
+        let zoom = zoom.zoom_out();
+        assert_eq!(zoom, AttachmentViewerZoom::Large);
+        let zoom = zoom.zoom_out();
+        assert_eq!(zoom, AttachmentViewerZoom::Default);
+        let zoom = zoom.zoom_out();
+        assert_eq!(zoom, AttachmentViewerZoom::Default);
+    }
+
+    #[test]
+    fn toggle_fullscreen_round_trips() {
+        let zoom = AttachmentViewerZoom::Default;
+        let zoom = zoom.toggle_fullscreen();
+        assert_eq!(zoom, AttachmentViewerZoom::Fullscreen);
+        let zoom = zoom.toggle_fullscreen();
+        assert_eq!(zoom, AttachmentViewerZoom::Default);
+
+        let zoom = AttachmentViewerZoom::Large.toggle_fullscreen();
+        assert_eq!(zoom, AttachmentViewerZoom::Fullscreen);
     }
 }

--- a/src/tui/state/popups.rs
+++ b/src/tui/state/popups.rs
@@ -111,6 +111,38 @@ pub(super) struct AttachmentViewerState {
     pub(super) message_id: Id<MessageMarker>,
     pub(super) selected: usize,
     pub(super) download_message: Option<String>,
+    pub(super) zoom: AttachmentViewerZoom,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum AttachmentViewerZoom {
+    #[default]
+    Default,
+    Large,
+    Fullscreen,
+}
+
+impl AttachmentViewerZoom {
+    pub(super) fn zoom_in(self) -> Self {
+        match self {
+            Self::Default => Self::Large,
+            Self::Large | Self::Fullscreen => Self::Fullscreen,
+        }
+    }
+
+    pub(super) fn zoom_out(self) -> Self {
+        match self {
+            Self::Fullscreen => Self::Large,
+            Self::Large | Self::Default => Self::Default,
+        }
+    }
+
+    pub(super) fn toggle_fullscreen(self) -> Self {
+        match self {
+            Self::Fullscreen => Self::Default,
+            Self::Default | Self::Large => Self::Fullscreen,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -168,7 +168,8 @@ pub fn sync_view_heights(area: Rect, state: &mut DashboardState) {
 pub fn image_preview_layout(area: Rect, state: &DashboardState) -> ImagePreviewLayout {
     let areas = dashboard_areas(area, state);
     let list = message_list_area(areas.messages, state);
-    let viewer_image_area = attachment_viewer_image_area(areas.messages);
+    let viewer_image_area =
+        attachment_viewer_image_area(areas.messages, area, state.attachment_viewer_zoom());
     ImagePreviewLayout {
         list_height: list.height as usize,
         content_width: message_content_width(list),
@@ -176,6 +177,7 @@ pub fn image_preview_layout(area: Rect, state: &DashboardState) -> ImagePreviewL
         max_preview_height: inline_image_preview_height(list, true),
         viewer_preview_width: viewer_image_area.width,
         viewer_max_preview_height: viewer_image_area.height,
+        font_size: None,
     }
 }
 
@@ -228,7 +230,13 @@ pub fn render(
     render_user_profile_popup(frame, areas.messages, state, profile_avatar, &emoji_images);
     render_emoji_reaction_picker(frame, areas.messages, state, emoji_images);
     render_reaction_users_popup(frame, areas.messages, state);
-    render_attachment_viewer(frame, areas.messages, state, viewer_image_preview);
+    render_attachment_viewer(
+        frame,
+        areas.messages,
+        frame.area(),
+        state,
+        viewer_image_preview,
+    );
     render_debug_log_popup(frame, areas.messages, state);
     render_keymap_help_popup(frame, areas.messages, state);
     render_toast(frame, frame.area(), state);

--- a/src/tui/ui/layout.rs
+++ b/src/tui/ui/layout.rs
@@ -6,7 +6,7 @@ use unicode_width::UnicodeWidthStr;
 
 use super::super::{
     message_format::wrap_text_lines,
-    state::{DashboardState, FocusPane},
+    state::{AttachmentViewerZoom, DashboardState, FocusPane},
 };
 use super::types::{
     DashboardAreas, EMBED_PREVIEW_GUTTER_PREFIX, IMAGE_PREVIEW_HEIGHT, IMAGE_PREVIEW_WIDTH,
@@ -14,7 +14,8 @@ use super::types::{
     MessageAreas,
 };
 
-const ATTACHMENT_VIEWER_POPUP_PERCENT: u16 = 80;
+const ATTACHMENT_VIEWER_POPUP_PERCENT_DEFAULT: u16 = 80;
+const ATTACHMENT_VIEWER_POPUP_PERCENT_LARGE: u16 = 95;
 
 pub(super) fn dashboard_areas(area: Rect, state: &DashboardState) -> DashboardAreas {
     let [header, main] = Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).areas(area);
@@ -49,16 +50,35 @@ fn pane_width(visible: bool, width: u16) -> Constraint {
     Constraint::Length(if visible { width } else { 0 })
 }
 
-pub(super) fn attachment_viewer_popup(area: Rect) -> Rect {
-    centered_rect(
-        area,
-        percentage_of(area.width, ATTACHMENT_VIEWER_POPUP_PERCENT),
-        percentage_of(area.height, ATTACHMENT_VIEWER_POPUP_PERCENT),
-    )
+pub(super) fn attachment_viewer_popup(
+    messages_area: Rect,
+    frame_area: Rect,
+    zoom: AttachmentViewerZoom,
+) -> Rect {
+    match zoom {
+        AttachmentViewerZoom::Fullscreen => frame_area,
+        AttachmentViewerZoom::Default => centered_rect(
+            messages_area,
+            percentage_of(messages_area.width, ATTACHMENT_VIEWER_POPUP_PERCENT_DEFAULT),
+            percentage_of(
+                messages_area.height,
+                ATTACHMENT_VIEWER_POPUP_PERCENT_DEFAULT,
+            ),
+        ),
+        AttachmentViewerZoom::Large => centered_rect(
+            messages_area,
+            percentage_of(messages_area.width, ATTACHMENT_VIEWER_POPUP_PERCENT_LARGE),
+            percentage_of(messages_area.height, ATTACHMENT_VIEWER_POPUP_PERCENT_LARGE),
+        ),
+    }
 }
 
-pub(super) fn attachment_viewer_image_area(area: Rect) -> Rect {
-    let inner = attachment_viewer_popup(area).inner(Margin {
+pub(super) fn attachment_viewer_image_area(
+    messages_area: Rect,
+    frame_area: Rect,
+    zoom: AttachmentViewerZoom,
+) -> Rect {
+    let inner = attachment_viewer_popup(messages_area, frame_area, zoom).inner(Margin {
         vertical: 1,
         horizontal: 1,
     });

--- a/src/tui/ui/popups/attachment_viewer.rs
+++ b/src/tui/ui/popups/attachment_viewer.rs
@@ -2,7 +2,8 @@ use super::*;
 
 pub(in crate::tui::ui) fn render_attachment_viewer(
     frame: &mut Frame,
-    area: Rect,
+    messages_area: Rect,
+    frame_area: Rect,
     state: &DashboardState,
     image_preview: Option<ImagePreview<'_>>,
 ) {
@@ -10,7 +11,8 @@ pub(in crate::tui::ui) fn render_attachment_viewer(
         return;
     };
 
-    let popup = attachment_viewer_popup(area);
+    let zoom = state.attachment_viewer_zoom();
+    let popup = attachment_viewer_popup(messages_area, frame_area, zoom);
     let title_width = usize::from(popup.width.saturating_sub(4)).max(1);
     let title = truncate_display_width(&attachment_viewer_title(&item), title_width);
     frame.render_widget(Clear, popup);
@@ -27,7 +29,7 @@ pub(in crate::tui::ui) fn render_attachment_viewer(
         ..inner
     };
     let hint_y = popup.y.saturating_add(popup.height);
-    let hint_area = (hint_y < area.y.saturating_add(area.height)).then_some(Rect {
+    let hint_area = (hint_y < frame_area.y.saturating_add(frame_area.height)).then_some(Rect {
         y: hint_y,
         height: 1,
         ..popup

--- a/src/tui/ui/tests.rs
+++ b/src/tui/ui/tests.rs
@@ -62,9 +62,9 @@ use crate::{
             reaction_line_test_spans, wrap_text_lines,
         },
         state::{
-            ChannelSwitcherItem, ChannelThreadItem, DashboardState, DisplayOptionItem,
-            EmojiPickerEntry, EmojiReactionItem, FocusPane, MessageActionItem, MessageActionKind,
-            PollVotePickerItem,
+            AttachmentViewerZoom, ChannelSwitcherItem, ChannelThreadItem, DashboardState,
+            DisplayOptionItem, EmojiPickerEntry, EmojiReactionItem, FocusPane, MessageActionItem,
+            MessageActionKind, PollVotePickerItem,
         },
         ui::{MouseTarget, PopupListTarget, mouse_target_at},
     },

--- a/src/tui/ui/tests/popups.rs
+++ b/src/tui/ui/tests/popups.rs
@@ -163,18 +163,39 @@ fn attachment_viewer_render_shows_download_hint_below_popup() {
 
     assert!(rendered.contains("File: notes.txt"), "{rendered}");
     assert!(rendered.contains("Size: 42 B"), "{rendered}");
-    assert!(rendered.contains("[d] download attachment"), "{rendered}");
+    assert!(rendered.contains("[d] download"), "{rendered}");
+    assert!(rendered.contains("[z] zoom"), "{rendered}");
 }
 
 #[test]
 fn attachment_viewer_popup_uses_eighty_percent_of_message_area() {
     let area = Rect::new(10, 5, 100, 40);
 
-    let popup = attachment_viewer_popup(area);
-    let image_area = attachment_viewer_image_area(area);
+    let popup = attachment_viewer_popup(area, area, AttachmentViewerZoom::Default);
+    let image_area = attachment_viewer_image_area(area, area, AttachmentViewerZoom::Default);
 
     assert_eq!(popup, Rect::new(20, 9, 80, 32));
     assert_eq!(image_area, Rect::new(21, 10, 78, 29));
+}
+
+#[test]
+fn attachment_viewer_popup_large_uses_ninety_five_percent_of_message_area() {
+    let area = Rect::new(10, 5, 100, 40);
+
+    let popup = attachment_viewer_popup(area, area, AttachmentViewerZoom::Large);
+
+    assert_eq!(popup, Rect::new(12, 6, 95, 38));
+}
+
+#[test]
+fn attachment_viewer_popup_fullscreen_uses_full_frame_area() {
+    let messages_area = Rect::new(10, 5, 100, 40);
+    let frame_area = Rect::new(0, 0, 200, 60);
+
+    let popup =
+        attachment_viewer_popup(messages_area, frame_area, AttachmentViewerZoom::Fullscreen);
+
+    assert_eq!(popup, frame_area);
 }
 
 #[test]

--- a/src/tui/ui/types.rs
+++ b/src/tui/ui/types.rs
@@ -49,6 +49,7 @@ pub struct ImagePreviewLayout {
     pub max_preview_height: u16,
     pub viewer_preview_width: u16,
     pub viewer_max_preview_height: u16,
+    pub font_size: Option<(u16, u16)>,
 }
 
 #[derive(Clone, Copy)]


### PR DESCRIPTION
## Summary

Two related improvements to the image attachment viewer (opened with `v`):

- **Zoom controls.** New keys inside the viewer:
  - `z` — toggle fullscreen (uses the whole terminal frame, not just the messages pane).
  - `+` / `=` — zoom in (Default 80% → Large 95% → Fullscreen).
  - `-` / `_` — zoom out.
  Hint line under the popup now reads `[d] download  [z] zoom  [+/-] zoom in/out`.
- **Image now actually fills the popup.** Previously the viewer image rarely filled more than ~70% of the popup width, even when the popup had room. Two causes:
  1. `image_preview_size_for_dimensions` capped the preview width to `image_width_px / IMAGE_PREVIEW_SOURCE_PIXELS_PER_COLUMN` — a sensible guard for inline previews but wrong for the viewer, where the user explicitly asked to view this attachment.
  2. The aspect math used a hardcoded `* 3` for the terminal cell height/width ratio. Most terminals are closer to `2:1`, so ratatui-image was letterboxing the rendered image inside the cell rect we'd reserved.

Now the viewer skips the source-pixel cap and uses the real cell aspect from `Picker::font_size()` (falling back to `1:3` if the picker couldn't query the terminal). Inline preview behavior is unchanged — the public `image_preview_height_for_dimensions` wrapper still passes `None` and preserves the legacy ratio, avoiding any scroll/layout drift in `state/message_layout.rs`.

## Implementation notes

- New `AttachmentViewerZoom` enum (`Default` / `Large` / `Fullscreen`) on `AttachmentViewerState`, with `zoom_in` / `zoom_out` / `toggle_fullscreen` transitions.
- `attachment_viewer_popup` and `attachment_viewer_image_area` now take `(messages_area, frame_area, zoom)` so fullscreen can cover the side panes.
- `ImagePreviewLayout` gained a `font_size: Option<(u16, u16)>` field, populated from `ImagePreviewCache::font_size()` in the runtime loop.
- New `cell_aspect_ratio` helper in `media/targets.rs` returns `(cell_w, cell_h)` as a u128 pair, with the legacy `1:3` fallback when no picker is available.

## Test plan

- [x] `cargo build` and `cargo test` clean (1258 passing).
- [x] `cargo fmt --check` clean.
- [x] Manual: open an image attachment in Kitty/Ghostty; image now fills the popup width.
- [x] Manual: `z` toggles fullscreen; `+/-` step through Default → Large → Fullscreen; Esc closes from any zoom level.
- [x] Updated `attachment_viewer_popup_uses_eighty_percent_of_message_area` for the new signature, plus added sibling tests for Large and Fullscreen rects.
- [x] Added unit tests covering the zoom-step transitions on `AttachmentViewerZoom`.