### PR TITLE
fix(voice): isolate audio path on its own runtime + fix send pacing

### DIFF
--- a/src/discord/voice.rs
+++ b/src/discord/voice.rs
@@ -9,6 +9,7 @@ use std::{
 
 #[cfg(feature = "voice-playback")]
 mod audio_buffer;
+mod audio_runtime;
 mod dave;
 mod gateway;
 mod info;
@@ -48,6 +49,7 @@ use self::opus::mix_voice_decoded_samples;
 use ::opus::{Channels, Decoder as OpusDecoder};
 #[cfg(all(test, feature = "voice-playback"))]
 use audio_buffer::VoiceAudioBuffer;
+use audio_runtime::VoiceAudioRuntime;
 use dave::{VoiceDaveState, VoiceMediaPayload, voice_speaking_microphone_active};
 #[cfg(test)]
 use dave::{VoiceSpeakingState, looks_like_dave_media_frame};
@@ -82,10 +84,6 @@ use serde_json::{Value, json};
 use std::sync::Mutex as StdMutex;
 #[cfg(feature = "voice-playback")]
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
-#[cfg(feature = "voice-playback")]
-use std::sync::mpsc::{Receiver as StdReceiver, SyncSender, TryRecvError, sync_channel};
-#[cfg(feature = "voice-playback")]
-use tokio::time::MissedTickBehavior;
 use tokio::{
     net::UdpSocket,
     sync::{Mutex, Mutex as AsyncMutex, mpsc, watch},
@@ -142,7 +140,7 @@ const DISCORD_TRAILING_SILENCE_FRAMES: usize = 5;
 #[allow(dead_code)]
 const OPUS_MAX_ENCODED_FRAME_BYTES: usize = 4000;
 #[cfg(feature = "voice-playback")]
-const VOICE_MIC_PCM_FRAME_QUEUE: usize = 4;
+const VOICE_MIC_PCM_FRAME_QUEUE: usize = 16;
 #[cfg(feature = "voice-playback")]
 const VOICE_MIC_PREFERRED_BUFFER_FRAMES: u32 = 480;
 #[cfg(feature = "voice-playback")]
@@ -487,12 +485,15 @@ struct VoiceChildTasks {
     #[cfg(feature = "voice-playback")]
     playback_volume: Option<Arc<AtomicU8>>,
     #[cfg(feature = "voice-playback")]
-    microphone_pcm_tx: Option<SyncSender<Vec<i16>>>,
+    microphone_pcm_tx: Option<mpsc::Sender<Vec<i16>>>,
     opus_decode: Option<JoinHandle<()>>,
     #[cfg(feature = "voice-playback")]
     audio_output: Option<VoiceAudioOutput>,
     #[cfg(feature = "voice-playback")]
     microphone_capture: Option<VoiceMicrophoneCapture>,
+    // Declared last so it is dropped after the task handles above — aborting
+    // them before the runtime they ran on tears down.
+    audio_runtime: Option<VoiceAudioRuntime>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -520,7 +521,7 @@ struct VoiceMicrophoneCapture {
 
 #[cfg(feature = "voice-playback")]
 struct VoiceMicrophonePcmFrames {
-    frames_tx: SyncSender<Vec<i16>>,
+    frames_tx: mpsc::Sender<Vec<i16>>,
     stats: Arc<VoiceMicrophoneCaptureStats>,
     source_sample_rate: u32,
     source_pending: Vec<i16>,
@@ -544,12 +545,10 @@ struct VoiceMicrophoneCaptureStats {
 #[derive(Default)]
 struct VoiceUdpTransmitStats {
     sent_packets: u64,
-    stale_frames_drained: u64,
-    empty_ticks_while_speaking: u64,
     overload_smoothed_frames: u64,
     limited_samples: u64,
-    max_tick_gap_ms: u128,
-    last_tick_at: Option<Instant>,
+    max_frame_gap_ms: u128,
+    last_frame_at: Option<Instant>,
 }
 
 #[cfg(any(test, feature = "voice-playback"))]
@@ -575,14 +574,6 @@ struct VoiceMicrophoneGateState {
     hangover_frames: u8,
     overload_recovery_frames: u8,
     handling_noise_suppression_frames: u8,
-}
-
-#[cfg(feature = "voice-playback")]
-#[derive(Debug, Eq, PartialEq)]
-enum VoiceMicrophonePcmRead {
-    Frame(Vec<i16>),
-    Empty,
-    Disconnected,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -627,7 +618,7 @@ impl VoiceChildTasks {
         &mut self,
         task: JoinHandle<()>,
         gate: watch::Sender<VoiceCaptureGate>,
-        microphone_pcm_tx: SyncSender<Vec<i16>>,
+        microphone_pcm_tx: mpsc::Sender<Vec<i16>>,
     ) {
         if let Some(task) = self.udp_transmit.take() {
             logging::debug("voice", "stopping previous voice UDP transmit task");

--- a/src/discord/voice/audio_runtime.rs
+++ b/src/discord/voice/audio_runtime.rs
@@ -1,0 +1,76 @@
+use std::sync::mpsc::sync_channel;
+use std::thread::{self, JoinHandle as ThreadJoinHandle};
+
+use tokio::runtime::{Builder, Handle};
+use tokio::sync::oneshot;
+
+use crate::logging;
+
+/// Dedicated tokio runtime for the voice data plane.
+///
+/// The audio path (mic capture pump, opus encode/decode, UDP send/receive) is
+/// real-time work that must not be starved by anything else the app does. We
+/// run it on a current-thread tokio runtime pinned to its own OS thread so
+/// TUI redraws, gateway events, and image decoding on the main runtime can't
+/// delay packet processing.
+pub(super) struct VoiceAudioRuntime {
+    handle: Handle,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+    worker: Option<ThreadJoinHandle<()>>,
+}
+
+impl VoiceAudioRuntime {
+    pub(super) fn start() -> Result<Self, String> {
+        let (handle_tx, handle_rx) = sync_channel::<Handle>(1);
+        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+        let worker = thread::Builder::new()
+            .name("voice-audio".to_owned())
+            .spawn(move || {
+                let runtime = match Builder::new_current_thread().enable_all().build() {
+                    Ok(runtime) => runtime,
+                    Err(error) => {
+                        logging::error(
+                            "voice",
+                            format!("voice audio runtime build failed: {error}"),
+                        );
+                        return;
+                    }
+                };
+                let _ = handle_tx.send(runtime.handle().clone());
+                runtime.block_on(async move {
+                    let _ = shutdown_rx.await;
+                });
+                logging::debug("voice", "voice audio runtime shut down");
+            })
+            .map_err(|error| format!("voice audio thread spawn failed: {error}"))?;
+        let handle = handle_rx
+            .recv()
+            .map_err(|_| "voice audio runtime handle receive failed".to_owned())?;
+        logging::debug("voice", "voice audio runtime started");
+        Ok(Self {
+            handle,
+            shutdown_tx: Some(shutdown_tx),
+            worker: Some(worker),
+        })
+    }
+
+    pub(super) fn handle(&self) -> &Handle {
+        &self.handle
+    }
+}
+
+impl Drop for VoiceAudioRuntime {
+    fn drop(&mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+        if let Some(worker) = self.worker.take()
+            && let Err(error) = worker.join()
+        {
+            logging::debug(
+                "voice",
+                format!("voice audio runtime thread panicked: {error:?}"),
+            );
+        }
+    }
+}

--- a/src/discord/voice/gateway.rs
+++ b/src/discord/voice/gateway.rs
@@ -71,6 +71,9 @@ pub(super) async fn connect_voice_gateway(
     let (writer, mut reader) = ws.split();
     let writer = Arc::new(Mutex::new(writer));
     let mut child_tasks = VoiceChildTasks::default();
+    let audio_runtime = VoiceAudioRuntime::start()?;
+    let audio_handle = audio_runtime.handle().clone();
+    child_tasks.audio_runtime = Some(audio_runtime);
     let mut speaking_tracker = VoiceSpeakingTracker::default();
     let mut speaking_sweep = tokio::time::interval(VOICE_REMOTE_SPEAKING_SWEEP_INTERVAL);
     #[cfg_attr(not(feature = "voice-playback"), allow(unused_variables))]
@@ -188,7 +191,19 @@ pub(super) async fn connect_voice_gateway(
                         );
                         let mode = choose_encryption_mode(&ready.modes)?;
                         logging::debug("voice", format!("voice encryption mode selected: {mode}"));
-                        let (socket, discovered) = discover_voice_udp_address(&ready).await?;
+                        // Bind the UDP socket on the audio runtime so its tokio
+                        // reactor owns the I/O; subsequent send/recv stay on the
+                        // dedicated thread instead of competing with the TUI.
+                        let ready_for_discover = ready.clone();
+                        let (socket, discovered) =
+                            audio_handle
+                                .spawn(async move {
+                                    discover_voice_udp_address(&ready_for_discover).await
+                                })
+                                .await
+                                .map_err(|error| {
+                                    format!("voice UDP discovery task join failed: {error}")
+                                })??;
                         send_voice_text(&writer, voice_select_protocol_payload(&discovered, &mode))
                             .await?;
                         logging::debug(
@@ -218,25 +233,28 @@ pub(super) async fn connect_voice_gateway(
                         }
                         if let Some(socket) = udp_socket.as_ref() {
                             logging::debug("voice", "starting voice UDP receive task");
-                            let opus_decode = VoiceOpusDecode::start(current_playback_gate);
+                            let opus_decode =
+                                VoiceOpusDecode::start(current_playback_gate, &audio_handle);
                             let playback_tx = Some(opus_decode.frames_tx.clone());
                             child_tasks.replace_opus_decode(opus_decode);
                             child_tasks.set_voice_playback_gate(current_playback_gate);
                             #[cfg_attr(not(feature = "voice-playback"), allow(unused_variables))]
                             let transmit_description = description.clone();
-                            child_tasks.replace_udp_receive(tokio::spawn(run_voice_udp_receive(
-                                Arc::clone(socket),
-                                description,
-                                Arc::clone(&dave_state),
-                                playback_tx,
-                                remote_speaking_tx.clone(),
-                            )));
+                            child_tasks.replace_udp_receive(audio_handle.spawn(
+                                run_voice_udp_receive(
+                                    Arc::clone(socket),
+                                    description,
+                                    Arc::clone(&dave_state),
+                                    playback_tx,
+                                    remote_speaking_tx.clone(),
+                                ),
+                            ));
                             #[cfg(feature = "voice-playback")]
                             if let Some(ready) = voice_ready.as_ref() {
-                                let (pcm_tx, pcm_rx) = sync_channel(VOICE_MIC_PCM_FRAME_QUEUE);
+                                let (pcm_tx, pcm_rx) = mpsc::channel(VOICE_MIC_PCM_FRAME_QUEUE);
                                 let (gate_tx, gate_rx) = watch::channel(current_capture_gate);
                                 child_tasks.replace_udp_transmit(
-                                    tokio::spawn(run_voice_udp_transmit(
+                                    audio_handle.spawn(run_voice_udp_transmit(
                                         pcm_rx,
                                         gate_rx,
                                         VoiceUdpTransmitContext {

--- a/src/discord/voice/microphone.rs
+++ b/src/discord/voice/microphone.rs
@@ -4,7 +4,7 @@ use super::*;
 
 #[cfg(feature = "voice-playback")]
 impl VoiceMicrophoneCapture {
-    pub(super) fn start(samples_tx: Option<SyncSender<Vec<i16>>>) -> Result<Self, String> {
+    pub(super) fn start(samples_tx: Option<mpsc::Sender<Vec<i16>>>) -> Result<Self, String> {
         #[cfg(target_os = "linux")]
         let alsa_error_output = alsa::Output::local_error_handler().ok();
 
@@ -17,7 +17,7 @@ impl VoiceMicrophoneCapture {
     }
 
     pub(super) fn start_with_cpal(
-        samples_tx: Option<SyncSender<Vec<i16>>>,
+        samples_tx: Option<mpsc::Sender<Vec<i16>>>,
     ) -> Result<Self, String> {
         let host = cpal::default_host();
         let device = host
@@ -59,7 +59,7 @@ impl VoiceMicrophoneCapture {
 pub(super) fn build_preferred_voice_input_stream(
     device: &cpal::Device,
     stats: Arc<VoiceMicrophoneCaptureStats>,
-    samples_tx: Option<SyncSender<Vec<i16>>>,
+    samples_tx: Option<mpsc::Sender<Vec<i16>>>,
 ) -> Result<(cpal::Stream, cpal::StreamConfig, cpal::SampleFormat), String> {
     let supported_config = select_voice_input_config(device)?;
     let sample_format = supported_config.sample_format();
@@ -93,7 +93,7 @@ pub(super) fn build_preferred_voice_input_stream(
 pub(super) fn build_default_voice_input_stream(
     device: &cpal::Device,
     stats: Arc<VoiceMicrophoneCaptureStats>,
-    samples_tx: Option<SyncSender<Vec<i16>>>,
+    samples_tx: Option<mpsc::Sender<Vec<i16>>>,
 ) -> Result<(cpal::Stream, cpal::StreamConfig, cpal::SampleFormat), String> {
     let supported_config = device
         .default_input_config()
@@ -179,7 +179,7 @@ impl Default for VoiceMicrophoneCaptureStats {
 #[cfg(feature = "voice-playback")]
 impl VoiceMicrophonePcmFrames {
     pub(super) fn new(
-        frames_tx: SyncSender<Vec<i16>>,
+        frames_tx: mpsc::Sender<Vec<i16>>,
         stats: Arc<VoiceMicrophoneCaptureStats>,
         source_sample_rate: u32,
     ) -> Self {
@@ -287,7 +287,7 @@ pub(super) fn build_voice_input_stream(
     config: &cpal::StreamConfig,
     sample_format: cpal::SampleFormat,
     stats: Arc<VoiceMicrophoneCaptureStats>,
-    samples_tx: Option<SyncSender<Vec<i16>>>,
+    samples_tx: Option<mpsc::Sender<Vec<i16>>>,
 ) -> Result<cpal::Stream, String> {
     match sample_format {
         cpal::SampleFormat::F32 => build_voice_input_stream_f32(device, config, stats, samples_tx),
@@ -305,7 +305,7 @@ pub(super) fn build_voice_input_stream_f32(
     device: &cpal::Device,
     config: &cpal::StreamConfig,
     stats: Arc<VoiceMicrophoneCaptureStats>,
-    samples_tx: Option<SyncSender<Vec<i16>>>,
+    samples_tx: Option<mpsc::Sender<Vec<i16>>>,
 ) -> Result<cpal::Stream, String> {
     let channels = usize::from(config.channels);
     let pcm_frames = samples_tx.map(|tx| {
@@ -339,7 +339,7 @@ pub(super) fn build_voice_input_stream_i16(
     device: &cpal::Device,
     config: &cpal::StreamConfig,
     stats: Arc<VoiceMicrophoneCaptureStats>,
-    samples_tx: Option<SyncSender<Vec<i16>>>,
+    samples_tx: Option<mpsc::Sender<Vec<i16>>>,
 ) -> Result<cpal::Stream, String> {
     let channels = usize::from(config.channels);
     let pcm_frames = samples_tx.map(|tx| {
@@ -373,7 +373,7 @@ pub(super) fn build_voice_input_stream_u16(
     device: &cpal::Device,
     config: &cpal::StreamConfig,
     stats: Arc<VoiceMicrophoneCaptureStats>,
-    samples_tx: Option<SyncSender<Vec<i16>>>,
+    samples_tx: Option<mpsc::Sender<Vec<i16>>>,
 ) -> Result<cpal::Stream, String> {
     let channels = usize::from(config.channels);
     let pcm_frames = samples_tx.map(|tx| {
@@ -407,7 +407,7 @@ pub(super) fn build_voice_input_stream_u8(
     device: &cpal::Device,
     config: &cpal::StreamConfig,
     stats: Arc<VoiceMicrophoneCaptureStats>,
-    samples_tx: Option<SyncSender<Vec<i16>>>,
+    samples_tx: Option<mpsc::Sender<Vec<i16>>>,
 ) -> Result<cpal::Stream, String> {
     let channels = usize::from(config.channels);
     let pcm_frames = samples_tx.map(|tx| {
@@ -769,7 +769,7 @@ impl VoiceFakeOutboundSendState {
 
 #[cfg(feature = "voice-playback")]
 pub(super) async fn run_voice_udp_transmit(
-    pcm_rx: StdReceiver<Vec<i16>>,
+    mut pcm_rx: mpsc::Receiver<Vec<i16>>,
     mut gate_rx: watch::Receiver<VoiceCaptureGate>,
     context: VoiceUdpTransmitContext,
 ) {
@@ -799,8 +799,6 @@ pub(super) async fn run_voice_udp_transmit(
             return;
         }
     };
-    let mut transmit_tick = tokio::time::interval(Duration::from_millis(20));
-    transmit_tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
     let transmit_started_at = Instant::now();
     let mut transmit_stats = VoiceUdpTransmitStats::default();
     let mut microphone_gate = VoiceMicrophoneGateState::default();
@@ -810,7 +808,7 @@ pub(super) async fn run_voice_udp_transmit(
         tokio::select! {
             changed = gate_rx.changed() => {
                 if changed.is_err() {
-                    drain_voice_microphone_pcm_queue(&pcm_rx);
+                    drain_voice_microphone_pcm_queue(&mut pcm_rx);
                     if let Err(error) = flush_voice_outbound_events(
                         &context.udp_socket,
                         &context.writer,
@@ -828,7 +826,7 @@ pub(super) async fn run_voice_udp_transmit(
                 let gate = *gate_rx.borrow();
                 let was_enabled = sender.capture_gate_enabled();
                 if !(gate.enabled && was_enabled) {
-                    drain_voice_microphone_pcm_queue(&pcm_rx);
+                    drain_voice_microphone_pcm_queue(&mut pcm_rx);
                     microphone_gate.reset();
                 }
                 if !gate.enabled
@@ -849,92 +847,80 @@ pub(super) async fn run_voice_udp_transmit(
                 }
                 sender.set_capture_gate(gate.enabled, false);
             }
-            _ = transmit_tick.tick() => {
-                record_voice_transmit_tick(&mut transmit_stats, Instant::now());
+            received = pcm_rx.recv() => {
+                let Some(mut frame) = received else {
+                    if let Err(error) = flush_voice_outbound_events(
+                        &context.udp_socket,
+                        &context.writer,
+                        sender.stop_speaking_with_dave(&mut *context.dave_state.lock().await),
+                        &mut sender,
+                        &context.local_speaking_tx,
+                        &mut transmit_stats,
+                    ).await {
+                        logging::error("voice", error);
+                    }
+                    let _ = context.local_speaking_tx.send(false);
+                    sender.set_capture_gate(false, false);
+                    microphone_gate.reset();
+                    break;
+                };
+                record_voice_transmit_frame(&mut transmit_stats, Instant::now());
                 let gate = *gate_rx.borrow();
                 if !gate.enabled {
-                    drain_voice_microphone_pcm_queue(&pcm_rx);
                     microphone_gate.reset();
                     continue;
                 }
-                let (read, stale_frames) = latest_voice_microphone_pcm_frame_with_drain_count(&pcm_rx);
-                transmit_stats.stale_frames_drained += stale_frames;
-                match read {
-                    VoiceMicrophonePcmRead::Frame(mut frame) => {
-                        if !microphone_gate.allows_frame(&frame, gate.microphone_sensitivity) {
-                            if let Err(error) = flush_voice_outbound_events(
-                                &context.udp_socket,
-                                &context.writer,
-                                sender.stop_speaking_with_dave(&mut *context.dave_state.lock().await),
-                                &mut sender,
-                                &context.local_speaking_tx,
-                                &mut transmit_stats,
-                            ).await {
-                                logging::error("voice", error);
-                            }
-                            continue;
-                        }
-                        let raw_overload_decision = voice_microphone_overload_decision(&frame);
-                        let overload_decision = if voice_microphone_clipped_frame_needs_blank(
-                            &frame,
-                            raw_overload_decision,
-                        ) {
-                            Some(VoiceMicrophoneOverloadDecision {
-                                kind: VoiceMicrophoneOverloadKind::HandlingNoise,
-                                gain: VOICE_MIC_HANDLING_NOISE_GAIN,
-                            })
-                        } else {
-                            microphone_gate.overload_decision(&frame)
-                        };
-                        if let Some(decision) = overload_decision {
-                            transmit_stats.overload_smoothed_frames += 1;
-                            apply_voice_microphone_gain(&mut frame, decision.gain);
-                        }
-                        apply_voice_volume_to_i16_frame(&mut frame, gate.microphone_volume);
-                        apply_voice_microphone_gain(&mut frame, VOICE_MIC_TRANSMIT_BOOST_GAIN);
-                        transmit_stats.limited_samples += protect_voice_microphone_frame(&mut frame);
-                        let _ = context.local_speaking_tx.send(true);
-                        let opus = match encoder.encode_20ms_i16(&frame) {
-                            Ok(opus) => opus,
-                            Err(error) => {
-                                logging::debug("voice", error);
-                                continue;
-                            }
-                        };
-                        let outcome = sender.send_opus_frame_with_dave(&opus, &mut *context.dave_state.lock().await);
-                        if let Err(error) = flush_voice_outbound_events(
-                            &context.udp_socket,
-                            &context.writer,
-                            outcome,
-                            &mut sender,
-                            &context.local_speaking_tx,
-                            &mut transmit_stats,
-                        ).await {
-                            logging::error("voice", error);
-                            break;
-                        }
+                if !microphone_gate.allows_frame(&frame, gate.microphone_sensitivity) {
+                    if let Err(error) = flush_voice_outbound_events(
+                        &context.udp_socket,
+                        &context.writer,
+                        sender.stop_speaking_with_dave(&mut *context.dave_state.lock().await),
+                        &mut sender,
+                        &context.local_speaking_tx,
+                        &mut transmit_stats,
+                    ).await {
+                        logging::error("voice", error);
                     }
-                    VoiceMicrophonePcmRead::Empty => {
-                        if sender.speaking {
-                            transmit_stats.empty_ticks_while_speaking += 1;
-                        }
+                    continue;
+                }
+                let raw_overload_decision = voice_microphone_overload_decision(&frame);
+                let overload_decision = if voice_microphone_clipped_frame_needs_blank(
+                    &frame,
+                    raw_overload_decision,
+                ) {
+                    Some(VoiceMicrophoneOverloadDecision {
+                        kind: VoiceMicrophoneOverloadKind::HandlingNoise,
+                        gain: VOICE_MIC_HANDLING_NOISE_GAIN,
+                    })
+                } else {
+                    microphone_gate.overload_decision(&frame)
+                };
+                if let Some(decision) = overload_decision {
+                    transmit_stats.overload_smoothed_frames += 1;
+                    apply_voice_microphone_gain(&mut frame, decision.gain);
+                }
+                apply_voice_volume_to_i16_frame(&mut frame, gate.microphone_volume);
+                apply_voice_microphone_gain(&mut frame, VOICE_MIC_TRANSMIT_BOOST_GAIN);
+                transmit_stats.limited_samples += protect_voice_microphone_frame(&mut frame);
+                let _ = context.local_speaking_tx.send(true);
+                let opus = match encoder.encode_20ms_i16(&frame) {
+                    Ok(opus) => opus,
+                    Err(error) => {
+                        logging::debug("voice", error);
+                        continue;
                     }
-                    VoiceMicrophonePcmRead::Disconnected => {
-                        if let Err(error) = flush_voice_outbound_events(
-                            &context.udp_socket,
-                            &context.writer,
-                            sender.stop_speaking_with_dave(&mut *context.dave_state.lock().await),
-                            &mut sender,
-                            &context.local_speaking_tx,
-                            &mut transmit_stats,
-                        ).await {
-                            logging::error("voice", error);
-                        }
-                        let _ = context.local_speaking_tx.send(false);
-                        sender.set_capture_gate(false, false);
-                        microphone_gate.reset();
-                        break;
-                    }
+                };
+                let outcome = sender.send_opus_frame_with_dave(&opus, &mut *context.dave_state.lock().await);
+                if let Err(error) = flush_voice_outbound_events(
+                    &context.udp_socket,
+                    &context.writer,
+                    outcome,
+                    &mut sender,
+                    &context.local_speaking_tx,
+                    &mut transmit_stats,
+                ).await {
+                    logging::error("voice", error);
+                    break;
                 }
                 let now = Instant::now();
                 if now >= next_stats_log_at {
@@ -955,44 +941,6 @@ pub(super) async fn run_voice_udp_transmit(
         transmit_started_at,
         sender.rtp.timestamp,
     );
-}
-
-#[cfg(all(test, feature = "voice-playback"))]
-pub(super) fn latest_voice_microphone_pcm_frame(
-    pcm_rx: &StdReceiver<Vec<i16>>,
-) -> VoiceMicrophonePcmRead {
-    latest_voice_microphone_pcm_frame_with_drain_count(pcm_rx).0
-}
-
-#[cfg(feature = "voice-playback")]
-pub(super) fn latest_voice_microphone_pcm_frame_with_drain_count(
-    pcm_rx: &StdReceiver<Vec<i16>>,
-) -> (VoiceMicrophonePcmRead, u64) {
-    let mut latest = None;
-    let mut received_frames = 0u64;
-    loop {
-        match pcm_rx.try_recv() {
-            Ok(frame) => {
-                received_frames = received_frames.saturating_add(1);
-                latest = Some(frame);
-            }
-            Err(TryRecvError::Empty) => {
-                return (
-                    latest.map_or(VoiceMicrophonePcmRead::Empty, VoiceMicrophonePcmRead::Frame),
-                    received_frames.saturating_sub(1),
-                );
-            }
-            Err(TryRecvError::Disconnected) => {
-                return (
-                    latest.map_or(
-                        VoiceMicrophonePcmRead::Disconnected,
-                        VoiceMicrophonePcmRead::Frame,
-                    ),
-                    received_frames.saturating_sub(1),
-                );
-            }
-        }
-    }
 }
 
 #[cfg(feature = "voice-playback")]
@@ -1065,7 +1013,7 @@ impl VoiceMicrophoneGateState {
 }
 
 #[cfg(feature = "voice-playback")]
-pub(super) fn drain_voice_microphone_pcm_queue(pcm_rx: &StdReceiver<Vec<i16>>) {
+pub(super) fn drain_voice_microphone_pcm_queue(pcm_rx: &mut mpsc::Receiver<Vec<i16>>) {
     while pcm_rx.try_recv().is_ok() {}
 }
 
@@ -1115,13 +1063,13 @@ pub(super) async fn flush_voice_outbound_events(
 }
 
 #[cfg(feature = "voice-playback")]
-pub(super) fn record_voice_transmit_tick(stats: &mut VoiceUdpTransmitStats, now: Instant) {
-    if let Some(last_tick_at) = stats.last_tick_at {
-        stats.max_tick_gap_ms = stats
-            .max_tick_gap_ms
-            .max(now.duration_since(last_tick_at).as_millis());
+pub(super) fn record_voice_transmit_frame(stats: &mut VoiceUdpTransmitStats, now: Instant) {
+    if let Some(last_frame_at) = stats.last_frame_at {
+        stats.max_frame_gap_ms = stats
+            .max_frame_gap_ms
+            .max(now.duration_since(last_frame_at).as_millis());
     }
-    stats.last_tick_at = Some(now);
+    stats.last_frame_at = Some(now);
 }
 
 #[cfg(feature = "voice-playback")]
@@ -1137,16 +1085,14 @@ pub(super) fn log_voice_transmit_stats(
     logging::debug(
         "voice",
         format!(
-            "{label}: elapsed_ms={} sent_packets={} rtp_timestamp={} rtp_elapsed_ms={} stale_frames_drained={} empty_ticks_while_speaking={} overload_smoothed_frames={} limited_samples={} max_tick_gap_ms={}",
+            "{label}: elapsed_ms={} sent_packets={} rtp_timestamp={} rtp_elapsed_ms={} overload_smoothed_frames={} limited_samples={} max_frame_gap_ms={}",
             elapsed_ms,
             stats.sent_packets,
             rtp_timestamp,
             rtp_elapsed_ms,
-            stats.stale_frames_drained,
-            stats.empty_ticks_while_speaking,
             stats.overload_smoothed_frames,
             stats.limited_samples,
-            stats.max_tick_gap_ms,
+            stats.max_frame_gap_ms,
         ),
     );
 }

--- a/src/discord/voice/opus.rs
+++ b/src/discord/voice/opus.rs
@@ -52,10 +52,13 @@ struct VoiceDecodedAudio {
 
 impl VoiceOpusDecode {
     #[cfg(not(feature = "voice-playback"))]
-    pub(super) fn start(playback_gate: VoicePlaybackGate) -> Self {
+    pub(super) fn start(
+        playback_gate: VoicePlaybackGate,
+        audio_handle: &tokio::runtime::Handle,
+    ) -> Self {
         let _ = playback_gate;
         let (frames_tx, frames_rx) = mpsc::channel(VOICE_PLAYBACK_FRAME_QUEUE);
-        let task = tokio::spawn(run_voice_playback_decode(
+        let task = audio_handle.spawn(run_voice_playback_decode(
             frames_rx,
             VoiceDecodedAudio::decode_only(),
         ));
@@ -67,14 +70,17 @@ impl VoiceOpusDecode {
     }
 
     #[cfg(feature = "voice-playback")]
-    pub(super) fn start(playback_gate: VoicePlaybackGate) -> Self {
+    pub(super) fn start(
+        playback_gate: VoicePlaybackGate,
+        audio_handle: &tokio::runtime::Handle,
+    ) -> Self {
         let (frames_tx, frames_rx) = mpsc::channel(VOICE_PLAYBACK_FRAME_QUEUE);
         let playback_enabled = Arc::new(AtomicBool::new(playback_gate.enabled));
         let playback_volume = Arc::new(AtomicU8::new(playback_gate.volume.value()));
         match VoiceAudioOutput::start(Arc::clone(&playback_enabled), Arc::clone(&playback_volume)) {
             Ok(audio_output) => {
                 let decoded_audio = VoiceDecodedAudio::output(audio_output.samples_tx.clone());
-                let task = tokio::spawn(run_voice_playback_decode(frames_rx, decoded_audio));
+                let task = audio_handle.spawn(run_voice_playback_decode(frames_rx, decoded_audio));
                 logging::debug(
                     "voice",
                     "voice Opus playback worker started with audio output",
@@ -92,7 +98,7 @@ impl VoiceOpusDecode {
                     "voice",
                     format!("voice audio output unavailable, falling back to decode-only: {error}"),
                 );
-                let task = tokio::spawn(run_voice_playback_decode(
+                let task = audio_handle.spawn(run_voice_playback_decode(
                     frames_rx,
                     VoiceDecodedAudio::decode_only(),
                 ));

--- a/src/discord/voice/tests.rs
+++ b/src/discord/voice/tests.rs
@@ -581,7 +581,7 @@ fn assert_voice_sample_near(actual: f32, expected: f32) {
 #[cfg(feature = "voice-playback")]
 #[test]
 fn voice_audio_buffer_resamples_non_48khz_output_clock() {
-    let (tx, rx) = sync_channel(1);
+    let (tx, rx) = std::sync::mpsc::sync_channel(1);
     tx.try_send(vec![0.0, 0.0, 1.0, 1.0, 2.0, 2.0, 3.0, 3.0])
         .expect("decoded samples should queue");
     let mut buffer = VoiceAudioBuffer::new(rx, 24_000);
@@ -598,7 +598,7 @@ fn voice_audio_buffer_resamples_non_48khz_output_clock() {
 #[cfg(feature = "voice-playback")]
 #[test]
 fn voice_audio_buffer_fades_short_underruns() {
-    let (tx, rx) = sync_channel(1);
+    let (tx, rx) = std::sync::mpsc::sync_channel(1);
     tx.try_send(vec![1.0, -1.0])
         .expect("decoded samples should queue");
     let mut buffer = VoiceAudioBuffer::new(rx, DISCORD_VOICE_SAMPLE_RATE);
@@ -1341,7 +1341,7 @@ fn microphone_input_conversion_produces_20ms_stereo_frames() {
 #[cfg(feature = "voice-playback")]
 #[test]
 fn microphone_pcm_frames_resample_44100_to_48000() {
-    let (tx, rx) = sync_channel(4);
+    let (tx, mut rx) = tokio::sync::mpsc::channel(4);
     let stats = Arc::new(VoiceMicrophoneCaptureStats::default());
     let mut frames = VoiceMicrophonePcmFrames::new(tx, Arc::clone(&stats), 44_100);
     let input_frames = 883;
@@ -1369,7 +1369,7 @@ fn microphone_pcm_frames_resample_44100_to_48000() {
 #[cfg(feature = "voice-playback")]
 #[test]
 fn microphone_pcm_frames_count_full_queue_drops() {
-    let (tx, rx) = sync_channel(1);
+    let (tx, mut rx) = tokio::sync::mpsc::channel(1);
     let stats = Arc::new(VoiceMicrophoneCaptureStats::default());
     let mut frames =
         VoiceMicrophonePcmFrames::new(tx, Arc::clone(&stats), DISCORD_VOICE_SAMPLE_RATE);
@@ -1386,58 +1386,33 @@ fn microphone_pcm_frames_count_full_queue_drops() {
 }
 
 #[cfg(feature = "voice-playback")]
-#[test]
-fn microphone_pcm_read_keeps_newest_queued_frame() {
-    let (tx, rx) = sync_channel(VOICE_MIC_PCM_FRAME_QUEUE);
+#[tokio::test]
+async fn microphone_pcm_recv_returns_frames_in_fifo_order() {
+    let (tx, mut rx) = tokio::sync::mpsc::channel(VOICE_MIC_PCM_FRAME_QUEUE);
 
     tx.try_send(vec![1]).expect("first frame should queue");
     tx.try_send(vec![2]).expect("second frame should queue");
     tx.try_send(vec![3]).expect("third frame should queue");
 
-    assert_eq!(
-        latest_voice_microphone_pcm_frame(&rx),
-        VoiceMicrophonePcmRead::Frame(vec![3])
-    );
-    assert_eq!(
-        latest_voice_microphone_pcm_frame(&rx),
-        VoiceMicrophonePcmRead::Empty
-    );
+    assert_eq!(rx.recv().await, Some(vec![1]));
+    assert_eq!(rx.recv().await, Some(vec![2]));
+    assert_eq!(rx.recv().await, Some(vec![3]));
 }
 
 #[cfg(feature = "voice-playback")]
 #[test]
 fn microphone_pcm_drain_clears_backlog_before_reenable() {
-    let (tx, rx) = sync_channel(VOICE_MIC_PCM_FRAME_QUEUE);
+    let (tx, mut rx) = tokio::sync::mpsc::channel(VOICE_MIC_PCM_FRAME_QUEUE);
 
     tx.try_send(vec![10]).expect("first frame should queue");
     tx.try_send(vec![20]).expect("second frame should queue");
 
-    drain_voice_microphone_pcm_queue(&rx);
+    drain_voice_microphone_pcm_queue(&mut rx);
 
-    assert_eq!(
-        latest_voice_microphone_pcm_frame(&rx),
-        VoiceMicrophonePcmRead::Empty
-    );
-    drop(tx);
-    assert_eq!(
-        latest_voice_microphone_pcm_frame(&rx),
-        VoiceMicrophonePcmRead::Disconnected
-    );
-}
-
-#[cfg(feature = "voice-playback")]
-#[test]
-fn microphone_pcm_read_reports_stale_drained_frames() {
-    let (tx, rx) = sync_channel(VOICE_MIC_PCM_FRAME_QUEUE);
-
-    tx.try_send(vec![1]).expect("first frame should queue");
-    tx.try_send(vec![2]).expect("second frame should queue");
-    tx.try_send(vec![3]).expect("third frame should queue");
-
-    let (read, stale_frames) = latest_voice_microphone_pcm_frame_with_drain_count(&rx);
-
-    assert_eq!(read, VoiceMicrophonePcmRead::Frame(vec![3]));
-    assert_eq!(stale_frames, 2);
+    assert!(matches!(
+        rx.try_recv(),
+        Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+    ));
 }
 
 #[cfg(feature = "voice-playback")]


### PR DESCRIPTION
## Summary

Someone I was talking to in a voice channel told me my audio would pause and then "speed up like it was catching up." That report is what prompted me to dig in, and it turned out to be two issues with one root cause: the real-time audio data plane was sharing a tokio runtime with everything else the app does.

1. **The listener heard speech pause then "catch up" fast.** The transmit loop ticked on a `tokio::time::interval(20ms)` and, on each tick, kept only the *newest* queued mic frame (`latest_voice_microphone_pcm_frame_with_drain_count`), discarding the rest. RTP timestamps still advanced by 960 per packet, so the stream looked continuous to the receiver while 40–80 ms chunks of my speech were silently dropped — the remaining audio played back-to-back, sounding rushed. This is the effect that was reported to me.
2. **Local playback underran constantly.** Decode tasks shared the main tokio runtime with the TUI render loop, gateway, and image decoding, so under load the playback channel drained faster than it refilled.

## Changes

- **Dedicated audio runtime** (`voice/audio_runtime.rs`): a current-thread tokio runtime pinned to its own OS thread (`voice-audio`). UDP send/receive, opus encode, and opus decode all spawn here, so TUI/gateway work on the main runtime can't delay packet processing. The runtime is owned by the worker thread and torn down via a `oneshot` shutdown signal, so it's never dropped from within an async context.
- **Mic-clock pacing**: the mic PCM channel is now `tokio::sync::mpsc`, and `run_voice_udp_transmit` awaits `recv()` — one encode + send per frame, in arrival order. The mic hardware clock is the authoritative 20 ms tick. Removed the timer and the latest-only drain entirely.
- **Queue depth** bumped 4 → 16 frames to absorb residual scheduling jitter.
- **UDP socket** is bound on the audio runtime so its tokio reactor owns the I/O.
- Removed now-dead stats (`stale_frames_drained`, `empty_ticks_while_speaking`); renamed `max_tick_gap_ms` → `max_frame_gap_ms`.

## Test plan

- [x] `cargo build`, `cargo test` (1279 pass), `cargo clippy --no-deps`, `cargo fmt --check` all clean.
- [x] Updated mic-channel tests to tokio mpsc; added a FIFO-order recv test.
- [ ] Manual: hold a call while aggressively redrawing the TUI; confirm the other party's audio stays smooth (no clipping/catch-up) and the `voice UDP transmit stats` log shows `max_frame_gap_ms` near 20.