### PR TITLE
feat: add emojis as links

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,7 @@ pub struct DisplayOptions {
     pub server_width: u16,
     pub channel_list_width: u16,
     pub member_list_width: u16,
+    pub emojis_as_links: bool,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
@@ -295,6 +296,7 @@ impl Default for DisplayOptions {
             server_width: 20,
             channel_list_width: 24,
             member_list_width: 26,
+            emojis_as_links: false,
         }
     }
 }
@@ -463,6 +465,7 @@ mod tests {
             server_width: 20,
             channel_list_width: 24,
             member_list_width: 26,
+            emojis_as_links: false,
         };
 
         assert!(!options.avatars_visible());
@@ -761,6 +764,7 @@ mod tests {
                 server_width: 12,
                 channel_list_width: 30,
                 member_list_width: 18,
+                emojis_as_links: false,
             },
             notifications: NotificationOptions {
                 desktop_notifications: false,

--- a/src/discord/guild/state.rs
+++ b/src/discord/guild/state.rs
@@ -31,6 +31,15 @@ impl DiscordState {
         self.navigation.guilds.values().collect()
     }
 
+    pub fn all_custom_emojis(
+        &self,
+    ) -> impl Iterator<Item = (&Id<GuildMarker>, &Vec<CustomEmojiInfo>)> {
+        self.navigation.custom_emojis.iter()
+    }
+    pub fn custom_emojis(&self) -> impl Iterator<Item = &CustomEmojiInfo> {
+        self.navigation.custom_emojis.values().flatten()
+    }
+
     pub fn custom_emojis_for_guild(&self, guild_id: Id<GuildMarker>) -> &[CustomEmojiInfo] {
         self.navigation
             .custom_emojis

--- a/src/tui/input/tests/options.rs
+++ b/src/tui/input/tests/options.rs
@@ -138,7 +138,7 @@ fn options_popup_selection_aliases_move_selection() {
     assert_eq!(state.selected_option_index(), Some(0));
 
     handle_key(&mut state, ctrl_key('d'));
-    assert_eq!(state.selected_option_index(), Some(5));
+    assert_eq!(state.selected_option_index(), Some(6));
 
     handle_key(&mut state, ctrl_key('u'));
     assert_eq!(state.selected_option_index(), Some(0));

--- a/src/tui/state/composer/completions.rs
+++ b/src/tui/state/composer/completions.rs
@@ -323,20 +323,20 @@ pub(super) fn move_picker_selection(selected: usize, len: usize, delta: isize) -
     (current + delta).clamp(0, len as isize - 1) as usize
 }
 
-pub(super) fn build_emoji_candidates(
+pub(super) fn build_emoji_candidates<'a>(
     query: &str,
-    custom_emojis: &[CustomEmojiInfo],
+    foreign_emojis: impl Iterator<Item = &'a CustomEmojiInfo>,
+    guild_emojis: impl Iterator<Item = &'a CustomEmojiInfo>,
     can_use_animated_custom_emojis: bool,
+    emojis_as_links: bool,
 ) -> Vec<EmojiPickerEntry> {
     let needle = query.to_ascii_lowercase();
     if needle.chars().count() < 2 {
         return Vec::new();
     }
 
-    let mut scored: Vec<(u8, String, EmojiPickerEntry)> = custom_emojis
-        .iter()
-        .filter(|emoji| emoji.name.to_ascii_lowercase().starts_with(&needle))
-        .map(|emoji| {
+    let make_entry = |is_foreign| {
+        move |emoji: &CustomEmojiInfo| {
             let shortcode = emoji.name.clone();
             let marker = if emoji.animated { "◇" } else { "◆" };
             let label = if emoji.animated {
@@ -351,14 +351,31 @@ pub(super) fn build_emoji_candidates(
                     emoji: marker.to_owned(),
                     shortcode: shortcode.clone(),
                     name: label.to_owned(),
-                    wire_format: Some(custom_emoji_markup(&shortcode, emoji.id, emoji.animated)),
+                    wire_format: Some(custom_emoji_markup(
+                        &shortcode,
+                        emoji.id,
+                        emoji.animated,
+                        is_foreign && emojis_as_links,
+                    )),
                     available: emoji.available
-                        && (!emoji.animated || can_use_animated_custom_emojis),
+                        && (!emoji.animated || can_use_animated_custom_emojis || emojis_as_links),
                     custom_image_url: Some(custom_emoji_image_url(emoji.id, emoji.animated)),
                 },
             )
-        })
+        }
+    };
+    let mut scored: Vec<(u8, String, EmojiPickerEntry)> = guild_emojis
+        .filter(|emoji| emoji.name.to_ascii_lowercase().starts_with(&needle))
+        .map(|emoji| make_entry(false)(emoji))
         .collect();
+
+    if emojis_as_links {
+        scored.extend(
+            foreign_emojis
+                .filter(|emoji| emoji.name.to_ascii_lowercase().starts_with(&needle))
+                .map(|emoji| make_entry(true)(emoji)),
+        );
+    }
 
     scored.extend(emojis::iter().flat_map(|emoji| {
         emoji
@@ -383,8 +400,11 @@ pub(super) fn build_emoji_candidates(
     scored.into_iter().map(|(_, _, entry)| entry).collect()
 }
 
-fn custom_emoji_markup(name: &str, id: Id<EmojiMarker>, animated: bool) -> String {
-    if animated {
+fn custom_emoji_markup(name: &str, id: Id<EmojiMarker>, animated: bool, as_link: bool) -> String {
+    if as_link {
+        let link = custom_emoji_image_url(id, animated);
+        format!("[{name}]({link}?size=48&name={name}&lossless=true)")
+    } else if animated {
         format!("<a:{name}:{}>", id.get())
     } else {
         format!("<:{name}:{}>", id.get())

--- a/src/tui/state/composer/state.rs
+++ b/src/tui/state/composer/state.rs
@@ -1096,16 +1096,31 @@ impl DashboardState {
     }
 
     fn emoji_candidates_for_query(&self, query: &str) -> Vec<EmojiPickerEntry> {
-        let custom_emojis = self
+        let selected_guild_channle = self.selected_channel_guild_id();
+
+        let foreign_emojis = self
+            .discord
+            .cache
+            .all_custom_emojis()
+            .filter(|(id, _)| {
+                selected_guild_channle.is_none_or(|guild_channel| **id != guild_channel)
+            })
+            .flat_map(|(_, emojis)| emojis);
+
+        let guild_emojis = self
             .selected_channel_guild_id()
             .map(|guild_id| self.discord.cache.custom_emojis_for_guild(guild_id))
-            .unwrap_or_default();
+            .unwrap_or_default()
+            .iter();
+
         build_emoji_candidates(
             query,
-            custom_emojis,
+            foreign_emojis,
+            guild_emojis,
             self.discord
                 .current_user_can_use_animated_custom_emojis
                 .unwrap_or(false),
+            self.options.display_options.emojis_as_links,
         )
     }
 }

--- a/src/tui/state/popups/options.rs
+++ b/src/tui/state/popups/options.rs
@@ -5,7 +5,7 @@ use crate::tui::keybindings::OptionsCategoryShortcut;
 use super::super::{DashboardState, DisplayOptionItem};
 use super::{ActiveModalPopupKind, ModalPopup, OptionsCategory, OptionsPopupState};
 
-const DISPLAY_OPTION_COUNT: usize = 6;
+const DISPLAY_OPTION_COUNT: usize = 7;
 const NOTIFICATION_OPTION_COUNT: usize = 1;
 const VOICE_OPTION_COUNT: usize = 6;
 const OPTION_CATEGORY_COUNT: usize = 3;
@@ -190,6 +190,14 @@ impl DashboardState {
                 effective: options.avatars_visible() && options.circular_avatars,
                 description: "Mask message and profile avatars into a circle.",
             },
+            DisplayOptionItem {
+                label: "Emojis as links",
+                enabled: options.emojis_as_links,
+                value: None,
+                gauge_percent: None,
+                effective: options.emojis_as_links,
+                description: "Sends unavailable emojis as a link instead.",
+            },
         ]
     }
 
@@ -298,6 +306,10 @@ impl DashboardState {
             (OptionsCategory::Display, 5) => {
                 self.options.display_options.circular_avatars =
                     !self.options.display_options.circular_avatars
+            }
+            (OptionsCategory::Display, 6) => {
+                self.options.display_options.emojis_as_links =
+                    !self.options.display_options.emojis_as_links
             }
             (OptionsCategory::Notifications, 0) => {
                 self.options.notification_options.desktop_notifications =

--- a/src/tui/state/tests/options_voice.rs
+++ b/src/tui/state/tests/options_voice.rs
@@ -42,28 +42,28 @@ fn display_option_items_include_voice_state_controls() {
 
     let items = state.display_option_items();
 
-    assert_eq!(items.len(), 13);
-    assert_eq!(items[7].label, "Voice muted");
-    assert!(items[7].enabled);
-    assert!(items[7].effective);
-    assert_eq!(items[8].label, "Voice deafened");
+    assert_eq!(items.len(), 14);
+    assert_eq!(items[8].label, "Voice muted");
     assert!(items[8].enabled);
     assert!(items[8].effective);
-    assert_eq!(items[9].label, "Allow microphone transmit");
+    assert_eq!(items[9].label, "Voice deafened");
     assert!(items[9].enabled);
     assert!(items[9].effective);
-    assert_eq!(items[10].label, "Microphone sensitivity");
-    assert_eq!(items[10].value, Some("-30 dB".to_owned()));
-    assert_eq!(items[10].gauge_percent, Some(70));
+    assert_eq!(items[10].label, "Allow microphone transmit");
+    assert!(items[10].enabled);
     assert!(items[10].effective);
-    assert_eq!(items[11].label, "Microphone volume");
-    assert_eq!(items[11].value, Some("100%".to_owned()));
-    assert_eq!(items[11].gauge_percent, Some(100));
+    assert_eq!(items[11].label, "Microphone sensitivity");
+    assert_eq!(items[11].value, Some("-30 dB".to_owned()));
+    assert_eq!(items[11].gauge_percent, Some(70));
     assert!(items[11].effective);
-    assert_eq!(items[12].label, "Voice volume");
+    assert_eq!(items[12].label, "Microphone volume");
     assert_eq!(items[12].value, Some("100%".to_owned()));
     assert_eq!(items[12].gauge_percent, Some(100));
-    assert!(!items[12].effective);
+    assert!(items[12].effective);
+    assert_eq!(items[13].label, "Voice volume");
+    assert_eq!(items[13].value, Some("100%".to_owned()));
+    assert_eq!(items[13].gauge_percent, Some(100));
+    assert!(!items[13].effective);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds an option that sends emojis as links similar to "fake nitro" plugins on other clients such as Vencord.

<!-- What does this change do, in one or two sentences? -->

## Why

Closes #143 
<!-- The motivation. Link the issue it closes, e.g. "Closes #123". -->
<!-- Feature additions must have a related issue first. Feature PRs without a related issue may be closed without review. -->

## How

I ended up putting the option in `DisplayOptions` which doesn't seem like the right place but I wasn't sure if I should just make another option menu.
<!-- Notable implementation choices and any non-obvious trade-offs. -->

## Testing

<!-- How you verified the change. Mention the OS, terminal, and graphics protocol used for manual checks. -->

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] Manual test in a real terminal (describe below)

## Screenshots or recordings

<!-- For UI changes, attach a screenshot or asciinema/gif. Delete this section if not applicable. -->

## Checklist

- [ ] One logical change per PR.
- [ ] Link a related issue.
- [ ] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [ ] Change does not add self-bot automation, mass actions, or scraping.
- [ ] Updated `README.md`, if behavior or workflows changed.
