### PR TITLE
feat: added option for notification icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,11 @@ circular_avatars = false
 # Show desktop notifications for Discord messages that pass notification rules.
 desktop_notifications = true
 
+# Optional notification icon to include in notifications. May not work on all platforms.
+# When unset, no icon is used. It must either be a name of an icon (typically in /usr/share/icons)
+# or a path to an icon.
+notification_icon = "/path/to/icon.svg"
+
 # Optional WAV files for voice join and leave notification sounds.
 # When unset, Concord uses built-in generated tones.
 voice_join_sound = "/path/to/join.wav"

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,6 +32,8 @@ pub struct DisplayOptions {
 pub struct NotificationOptions {
     pub desktop_notifications: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub notification_icon: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub voice_join_sound: Option<PathBuf>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub voice_leave_sound: Option<PathBuf>,
@@ -278,6 +280,7 @@ impl Default for NotificationOptions {
     fn default() -> Self {
         Self {
             desktop_notifications: true,
+            notification_icon: None,
             voice_join_sound: None,
             voice_leave_sound: None,
         }
@@ -768,6 +771,7 @@ mod tests {
             },
             notifications: NotificationOptions {
                 desktop_notifications: false,
+                notification_icon: Some("/tmp/icon.svg".to_string()),
                 voice_join_sound: Some(std::path::PathBuf::from("/tmp/join.wav")),
                 voice_leave_sound: Some(std::path::PathBuf::from("/tmp/leave.wav")),
             },

--- a/src/tui/runtime/effects.rs
+++ b/src/tui/runtime/effects.rs
@@ -93,7 +93,7 @@ pub(super) fn process_effect_event(
         _ => None,
     };
     if let Some(notification) = ctx.state.desktop_notification_for_event(&event) {
-        dispatch_desktop_notification(notification);
+        dispatch_desktop_notification(notification, ctx.state.desktop_notification_icon());
     }
     if let AppEvent::VoiceSound { kind } = event {
         dispatch_voice_sound(kind, ctx.state.notification_options());
@@ -125,12 +125,14 @@ pub(super) fn process_effect_event(
     outcome
 }
 
-fn dispatch_desktop_notification(notification: DesktopNotification) {
+fn dispatch_desktop_notification(notification: DesktopNotification, icon: Option<String>) {
     tokio::spawn(async move {
         let title = notification.title;
         let body = notification.body;
-        let result =
-            tokio::task::spawn_blocking(move || deliver_desktop_notification(&title, &body)).await;
+        let result = tokio::task::spawn_blocking(move || {
+            deliver_desktop_notification(&title, &body, icon.as_deref())
+        })
+        .await;
 
         match result {
             Ok(Ok(())) => {}
@@ -176,14 +178,18 @@ fn log_notification_failure_once(target: &str, message: String) {
     }
 }
 
-fn deliver_desktop_notification(title: &str, body: &str) -> std::result::Result<(), String> {
+fn deliver_desktop_notification(
+    title: &str,
+    body: &str,
+    icon: Option<&str>,
+) -> std::result::Result<(), String> {
     #[cfg(target_os = "macos")]
     {
         deliver_macos_notification(title, body)
     }
     #[cfg(not(target_os = "macos"))]
     {
-        deliver_notify_rust_notification(title, body)
+        deliver_notify_rust_notification(title, body, icon)
     }
 }
 
@@ -210,8 +216,16 @@ fn voice_sound_path(kind: VoiceSoundKind, options: &NotificationOptions) -> Opti
 }
 
 #[cfg(not(target_os = "macos"))]
-fn deliver_notify_rust_notification(title: &str, body: &str) -> std::result::Result<(), String> {
-    notify_rust::Notification::new()
+fn deliver_notify_rust_notification(
+    title: &str,
+    body: &str,
+    icon: Option<&str>,
+) -> std::result::Result<(), String> {
+    let mut notification = notify_rust::Notification::new();
+    if let Some(icon) = icon {
+        notification.icon(icon);
+    }
+    notification
         .summary(title)
         .body(body)
         .show()

--- a/src/tui/state/options.rs
+++ b/src/tui/state/options.rs
@@ -187,6 +187,10 @@ impl DashboardState {
         self.options.notification_options.desktop_notifications
     }
 
+    pub fn desktop_notification_icon(&self) -> Option<String> {
+        self.options.notification_options.notification_icon.clone()
+    }
+
     pub fn pane_width(&self, pane: FocusPane) -> u16 {
         match pane {
             FocusPane::Guilds => self.options.display_options.server_width,


### PR DESCRIPTION
<!--
Thanks for the contribution. Please keep the subject under ~72 characters
and use a semantic prefix (feat:, fix:, refactor:, docs:, chore:, test:).

By submitting this PR you agree it will be distributed under GPL-3.0-only.
-->

## Summary

<!-- What does this change do, in one or two sentences? -->
Added a new `notification_icon` option in the `[notifications]` section of the config. It can either be unset or a string containing an icon name or path. Message notifications (not on macos) will then include the icon.

## Why

<!-- The motivation. Link the issue it closes, e.g. "Closes #123". -->
<!-- Feature additions must have a related issue first. Feature PRs without a related issue may be closed without review. -->
Closes #147 .

## How

<!-- Notable implementation choices and any non-obvious trade-offs. -->
I added an additional argument for an optional icon in various notification functions and then used `notify-rust`'s `.icon` function to set the icon.

## Testing

<!-- How you verified the change. Mention the OS, terminal, and graphics protocol used for manual checks. -->

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] Manual test in a real terminal (describe below)

I tested on NixOS, kitty with the kitty protocol.
Also, on my machine (using the devshell in flake.nix) clippy mentions two issues in `fuzzy.rs`, but they have nothing to do with this PR.

## Checklist

- [x] One logical change per PR.
- [x] Link a related issue.
- [x] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [x] Change does not add self-bot automation, mass actions, or scraping.
- [x] Updated `README.md`, if behavior or workflows changed.
