### PR TITLE
fix: Force image protocol refresh after popup overlay changes

### DIFF
--- a/src/tui/media/preview.rs
+++ b/src/tui/media/preview.rs
@@ -33,6 +33,7 @@ pub(in crate::tui) struct ImagePreviewCache {
     pub(super) entries: HashMap<ImagePreviewKey, ImagePreviewEntry>,
     pub(super) tick: u64,
     pub(super) decode_generation: u64,
+    pub(super) protocol_generation: u64,
 }
 
 pub(in crate::tui) struct ImagePreviewDecodeJob {
@@ -63,6 +64,7 @@ pub(super) enum ImagePreviewEntry {
         filename: String,
         image: DynamicImage,
         protocol_render_info: ImagePreviewRenderInfo,
+        protocol_generation: u64,
         protocol: Box<StatefulProtocol>,
         last_used: u64,
     },
@@ -80,11 +82,16 @@ impl ImagePreviewCache {
             entries: HashMap::new(),
             tick: 0,
             decode_generation: 0,
+            protocol_generation: 0,
         }
     }
 
     pub(in crate::tui) fn font_size(&self) -> Option<(u16, u16)> {
         self.picker.as_ref().map(Picker::font_size)
+    }
+
+    pub(in crate::tui) fn refresh_protocols(&mut self) {
+        self.protocol_generation = self.protocol_generation.saturating_add(1);
     }
 
     pub(in crate::tui) fn render_state(
@@ -115,16 +122,19 @@ impl ImagePreviewCache {
                 ImagePreviewEntry::Ready {
                     image,
                     protocol,
+                    protocol_generation,
                     protocol_render_info,
                     ..
                 } => {
-                    if *protocol_render_info != render_info
+                    if (*protocol_render_info != render_info
+                        || *protocol_generation != self.protocol_generation)
                         && let Some(picker) = picker.as_ref()
                         && let Some(updated_protocol) =
                             clipped_preview_stateful_protocol(picker, image, render_info)
                     {
                         *protocol = updated_protocol;
                         *protocol_render_info = render_info;
+                        *protocol_generation = self.protocol_generation;
                     }
                     ImagePreviewState::Ready {
                         protocol: protocol.as_mut(),
@@ -345,6 +355,7 @@ impl ImagePreviewCache {
                         filename,
                         image,
                         protocol_render_info: render_info,
+                        protocol_generation: self.protocol_generation,
                         protocol,
                         last_used,
                     },

--- a/src/tui/media/tests.rs
+++ b/src/tui/media/tests.rs
@@ -957,6 +957,7 @@ fn image_preview_request_is_created_for_draw_target() {
         entries: HashMap::new(),
         tick: 0,
         decode_generation: 0,
+        protocol_generation: 0,
     };
     let target = image_preview_target(1);
 
@@ -976,12 +977,28 @@ fn image_preview_request_is_created_for_draw_target() {
 }
 
 #[test]
+fn image_preview_refresh_protocols_advances_generation() {
+    let mut cache = ImagePreviewCache {
+        picker: None,
+        entries: HashMap::new(),
+        tick: 0,
+        decode_generation: 0,
+        protocol_generation: 0,
+    };
+
+    cache.refresh_protocols();
+
+    assert_eq!(cache.protocol_generation, 1);
+}
+
+#[test]
 fn image_preview_render_state_preserves_target_order() {
     let mut cache = ImagePreviewCache {
         picker: None,
         entries: HashMap::new(),
         tick: 0,
         decode_generation: 0,
+        protocol_generation: 0,
     };
     let first = image_preview_target(1);
     let second = ImagePreviewTarget {
@@ -1028,6 +1045,7 @@ fn image_preview_cache_keeps_duplicate_urls_as_separate_preview_instances() {
         entries: HashMap::new(),
         tick: 0,
         decode_generation: 0,
+        protocol_generation: 0,
     };
     let first = image_preview_target(1);
     let second = ImagePreviewTarget {
@@ -1061,6 +1079,7 @@ fn image_preview_cache_deduplicates_url_already_loading_from_previous_frame() {
         entries: HashMap::new(),
         tick: 0,
         decode_generation: 0,
+        protocol_generation: 0,
     };
     let first = image_preview_target(1);
     cache.next_requests(std::slice::from_ref(&first));
@@ -1083,6 +1102,7 @@ fn image_preview_cache_keeps_viewer_and_inline_entries_separate() {
         entries: HashMap::new(),
         tick: 0,
         decode_generation: 0,
+        protocol_generation: 0,
     };
     let inline = image_preview_target(1);
     let viewer = ImagePreviewTarget {
@@ -1110,6 +1130,7 @@ fn image_preview_cache_evicts_least_recently_used_entries() {
         entries: HashMap::new(),
         tick: 0,
         decode_generation: 0,
+        protocol_generation: 0,
     };
     let existing_targets = (1..=MAX_IMAGE_PREVIEW_CACHE_ENTRIES as u64)
         .map(image_preview_target)
@@ -1133,6 +1154,7 @@ fn image_preview_cache_limits_visible_requests() {
         entries: HashMap::new(),
         tick: 0,
         decode_generation: 0,
+        protocol_generation: 0,
     };
     let targets = (1..=MAX_IMAGE_PREVIEW_CACHE_ENTRIES as u64 + 2)
         .map(image_preview_target)
@@ -1157,6 +1179,7 @@ fn image_preview_store_loaded_preserves_existing_non_loading_entries() {
         entries: HashMap::new(),
         tick: 0,
         decode_generation: 0,
+        protocol_generation: 0,
     };
     let existing = image_preview_target(1).key();
     let loading = ImagePreviewTarget {
@@ -1201,6 +1224,7 @@ fn image_preview_loaded_bytes_start_decode_jobs_for_loading_entries() {
         entries: HashMap::new(),
         tick: 0,
         decode_generation: 0,
+        protocol_generation: 0,
     };
     let target = image_preview_target(1);
     let key = target.key();
@@ -1234,6 +1258,7 @@ fn image_preview_store_decoded_records_decode_failure() {
         entries: HashMap::new(),
         tick: 0,
         decode_generation: 0,
+        protocol_generation: 0,
     };
     let target = image_preview_target(1);
     let key = target.key();
@@ -1268,6 +1293,7 @@ fn image_preview_store_decoded_ignores_stale_results() {
         entries: HashMap::new(),
         tick: 0,
         decode_generation: 0,
+        protocol_generation: 0,
     };
     let key = image_preview_target(1).key();
     cache.entries.insert(
@@ -1299,6 +1325,7 @@ fn image_preview_store_decoded_ignores_replaced_decoding_generation() {
         entries: HashMap::new(),
         tick: 0,
         decode_generation: 0,
+        protocol_generation: 0,
     };
     let target = image_preview_target(1);
     let key = target.key();
@@ -1341,6 +1368,7 @@ fn image_preview_store_failed_preserves_existing_non_loading_entries() {
         entries: HashMap::new(),
         tick: 0,
         decode_generation: 0,
+        protocol_generation: 0,
     };
     let existing = image_preview_target(1).key();
     let loading = ImagePreviewTarget {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -71,6 +71,7 @@ mod tests {
             effects::{self, effect_forces_redraw},
             redraw::{
                 should_redraw_after_visible_signature_change,
+                should_refresh_image_protocols_after_visible_signature_change,
                 should_suppress_image_redraw_for_signature_change, visible_dashboard_signature,
             },
         },
@@ -219,6 +220,33 @@ mod tests {
         assert!(should_redraw_after_visible_signature_change(
             &before, &after, false, false,
         ));
+    }
+
+    #[test]
+    fn overlay_changes_refresh_image_protocols_when_images_are_visible() {
+        let mut state = state_with_messages(1);
+        push_image_message(&mut state, 2);
+        state.focus_pane(FocusPane::Messages);
+        let before = visible_dashboard_signature(&state);
+
+        state.open_selected_message_actions();
+        let open = visible_dashboard_signature(&state);
+
+        assert_ne!(before, open);
+        assert!(
+            should_refresh_image_protocols_after_visible_signature_change(&before, &open, true)
+        );
+        assert!(
+            !should_refresh_image_protocols_after_visible_signature_change(&before, &open, false)
+        );
+
+        state.close_message_action_menu();
+        let closed = visible_dashboard_signature(&state);
+
+        assert_ne!(open, closed);
+        assert!(
+            should_refresh_image_protocols_after_visible_signature_change(&open, &closed, true)
+        );
     }
 
     #[test]

--- a/src/tui/runtime/mod.rs
+++ b/src/tui/runtime/mod.rs
@@ -34,7 +34,7 @@ pub(super) mod redraw;
 use effects as effect_helpers;
 use redraw::{
     image_surfaces_visible, should_redraw_after_visible_signature_change,
-    visible_dashboard_signature,
+    should_refresh_image_protocols_after_visible_signature_change, visible_dashboard_signature,
 };
 
 type ClipboardPasteResult = std::result::Result<
@@ -199,6 +199,8 @@ pub(super) async fn run_dashboard(
             maybe_event = terminal_events.next() => {
                 match maybe_event {
                     Some(Ok(event)) => {
+                        let before_signature = visible_dashboard_signature(&state);
+                        let image_previews_visible_before_event = !image_targets.is_empty();
                         let outcome = events::handle_terminal_event(
                             &mut state,
                             event,
@@ -242,6 +244,15 @@ pub(super) async fn run_dashboard(
                             && commands.send(command).await.is_err()
                         {
                             command_helpers::record_command_channel_closed(&mut state);
+                        }
+                        let after_signature = visible_dashboard_signature(&state);
+                        if should_refresh_image_protocols_after_visible_signature_change(
+                            &before_signature,
+                            &after_signature,
+                            image_previews_visible_before_event,
+                        ) {
+                            image_previews.refresh_protocols();
+                            dirty = true;
                         }
                         if outcome.dirty {
                             dirty = true;

--- a/src/tui/runtime/redraw.rs
+++ b/src/tui/runtime/redraw.rs
@@ -629,6 +629,14 @@ pub(in crate::tui) fn should_redraw_after_visible_signature_change(
             ))
 }
 
+pub(in crate::tui) fn should_refresh_image_protocols_after_visible_signature_change(
+    before: &VisibleDashboardSignature,
+    after: &VisibleDashboardSignature,
+    image_previews_visible: bool,
+) -> bool {
+    image_previews_visible && before.overlay != after.overlay
+}
+
 pub(super) fn image_surfaces_visible(
     state: &DashboardState,
     image_targets_visible: bool,


### PR DESCRIPTION
<!--
Thanks for the contribution. Please keep the subject under ~72 characters
and use a semantic prefix (feat:, fix:, refactor:, docs:, chore:, test:).

By submitting this PR you agree it will be distributed under GPL-3.0-only.
-->

## Summary

<!-- What does this change do, in one or two sentences? -->

## Why

Closes #150 
<!-- The motivation. Link the issue it closes, e.g. "Closes #123". -->
<!-- Feature additions must have a related issue first. Feature PRs without a related issue may be closed without review. -->

## How

<!-- Notable implementation choices and any non-obvious trade-offs. -->

## Testing

<!-- How you verified the change. Mention the OS, terminal, and graphics protocol used for manual checks. -->

- [ ] `cargo fmt --all --check`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo test --all-features`
- [ ] Manual test in a real terminal (describe below)

## Screenshots or recordings

<!-- For UI changes, attach a screenshot or asciinema/gif. Delete this section if not applicable. -->

## Checklist

- [ ] One logical change per PR.
- [ ] Link a related issue.
- [ ] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [ ] Change does not add self-bot automation, mass actions, or scraping.
- [ ] Updated `README.md`, if behavior or workflows changed.
