### PR TITLE
fix: prevent half-page message scroll from skipping content

### DIFF
--- a/src/tui/input/keyboard/dashboard.rs
+++ b/src/tui/input/keyboard/dashboard.rs
@@ -69,7 +69,7 @@ pub(super) fn handle_dashboard_action(
         }
         DashboardAction::HalfPageUp => {
             state.half_page_up();
-            state.next_older_history_command()
+            state.next_older_history_command_for_half_page_up()
         }
         DashboardAction::JumpTop => {
             state.jump_top();

--- a/src/tui/input/tests/messages.rs
+++ b/src/tui/input/tests/messages.rs
@@ -23,15 +23,19 @@ fn message_keys_use_scroll_controls() {
     let mut state = state_with_messages(10);
     state.focus_pane(FocusPane::Messages);
     state.set_message_view_height(9);
+    state.clamp_message_viewport_for_image_previews(200, 16, 3);
 
     handle_key(&mut state, ctrl_key('u'));
-    assert_eq!(state.selected_message(), 5);
+    assert_eq!(state.selected_message(), 0);
+    assert_eq!(state.message_scroll(), 0);
     assert!(!state.message_auto_follow());
 
     handle_key(&mut state, ctrl_key('d'));
     assert_eq!(state.selected_message(), 9);
-    // Half-page-down landed the cursor on the latest message, so
-    // auto-follow re-engages.
+    assert_eq!(state.message_scroll(), 2);
+    assert!(!state.message_auto_follow());
+
+    handle_key(&mut state, ctrl_key('d'));
     assert!(state.message_auto_follow());
 }
 

--- a/src/tui/state/message_viewport.rs
+++ b/src/tui/state/message_viewport.rs
@@ -10,8 +10,9 @@ use crate::tui::format::{
 };
 
 use super::scroll::{
-    SCROLL_OFF, clamp_list_scroll, move_index_down, move_index_up, normalize_message_line_scroll,
-    pane_content_height, scroll_message_row_down, scroll_message_row_up,
+    SCROLL_OFF, clamp_list_scroll, move_index_down, move_index_down_by, move_index_up,
+    normalize_message_line_scroll, pane_content_height, scroll_message_row_down,
+    scroll_message_row_up,
 };
 use super::*;
 
@@ -500,6 +501,26 @@ impl DashboardState {
         }
     }
 
+    pub(super) fn half_page_message_down(&mut self, distance: usize) {
+        let distance = distance.max(1);
+        if self.message_pane_uses_forum_posts() || self.messages.message_content_width == usize::MAX
+        {
+            let len = self.message_pane_item_count();
+            move_index_down_by(&mut self.messages.selected_message, len, distance);
+            self.messages.message_keep_selection_visible = true;
+            self.clamp_message_viewport();
+            self.refresh_message_auto_follow();
+            return;
+        }
+
+        self.scroll_message_viewport_down_by_rows(distance);
+        if let Some(selected) = self.last_visible_message_index() {
+            self.messages.selected_message = selected;
+        }
+        self.messages.message_keep_selection_visible = false;
+        self.refresh_message_auto_follow();
+    }
+
     pub fn next_newer_history_command_for_down_by(&self, distance: usize) -> Option<AppCommand> {
         if !self.message_pane_can_load_message_history()
             || self.navigation.focus != FocusPane::Messages
@@ -519,7 +540,15 @@ impl DashboardState {
     }
 
     pub fn next_newer_history_command_for_half_page_down(&self) -> Option<AppCommand> {
-        self.next_newer_history_command_for_down_by((self.message_content_height() / 2).max(1))
+        let distance = (self.message_content_height() / 2).max(1);
+        if self.message_pane_uses_forum_posts() || self.messages.message_content_width == usize::MAX
+        {
+            return self.next_newer_history_command_for_down_by(distance);
+        }
+
+        self.newer_history_command_in_viewport_rows(
+            self.message_content_height().saturating_add(distance),
+        )
     }
 
     fn newer_history_command_in_message_range(
@@ -551,6 +580,45 @@ impl DashboardState {
         None
     }
 
+    fn newer_history_command_in_viewport_rows(&self, rows: usize) -> Option<AppCommand> {
+        if !self.message_pane_can_load_message_history()
+            || self.navigation.focus != FocusPane::Messages
+        {
+            return None;
+        }
+        let messages = self.messages();
+        if messages.is_empty() {
+            return None;
+        }
+
+        let mut top = self.messages.message_scroll;
+        let mut offset = self.messages.message_line_scroll;
+        for _ in 0..rows.max(1) {
+            let _ = messages.get(top)?;
+            let height = self
+                .message_rendered_height_at(
+                    top,
+                    self.messages.message_content_width,
+                    self.messages.message_preview_width,
+                    self.messages.message_max_preview_height,
+                )
+                .max(1);
+            if offset + 1 < height {
+                offset += 1;
+                continue;
+            }
+            if let Some(command) = self.newer_history_command_in_message_range(top, top) {
+                return Some(command);
+            }
+            if top + 1 >= messages.len() {
+                return None;
+            }
+            top += 1;
+            offset = 0;
+        }
+        None
+    }
+
     pub fn scroll_message_viewport_up(&mut self) {
         if self.navigation.focus != FocusPane::Messages
             || self.messages.message_content_width == usize::MAX
@@ -570,6 +638,24 @@ impl DashboardState {
             self.messages.message_preview_width,
             self.messages.message_max_preview_height,
         );
+    }
+
+    pub(super) fn half_page_message_up(&mut self, distance: usize) {
+        let distance = distance.max(1);
+        if self.message_pane_uses_forum_posts() || self.messages.message_content_width == usize::MAX
+        {
+            self.messages.selected_message =
+                self.messages.selected_message.saturating_sub(distance);
+            self.messages.message_keep_selection_visible = true;
+            self.clamp_message_viewport();
+            self.refresh_message_auto_follow();
+            return;
+        }
+
+        self.scroll_message_viewport_up_by_rows(distance);
+        self.messages.selected_message = self.messages.message_scroll;
+        self.messages.message_keep_selection_visible = false;
+        self.refresh_message_auto_follow();
     }
 
     #[cfg(test)]
@@ -944,6 +1030,23 @@ impl DashboardState {
         );
     }
 
+    fn scroll_message_viewport_down_by_rows(&mut self, rows: usize) {
+        for _ in 0..rows {
+            let before = (
+                self.messages.message_scroll,
+                self.messages.message_line_scroll,
+            );
+            self.scroll_message_viewport_down();
+            let after = (
+                self.messages.message_scroll,
+                self.messages.message_line_scroll,
+            );
+            if before == after {
+                break;
+            }
+        }
+    }
+
     fn scroll_message_viewport_up_one_row(
         &mut self,
         content_width: usize,
@@ -967,6 +1070,56 @@ impl DashboardState {
             &mut self.messages.message_line_scroll,
             previous_message_height,
         );
+    }
+
+    fn scroll_message_viewport_up_by_rows(&mut self, rows: usize) {
+        for _ in 0..rows {
+            let before = (
+                self.messages.message_scroll,
+                self.messages.message_line_scroll,
+            );
+            self.scroll_message_viewport_up();
+            let after = (
+                self.messages.message_scroll,
+                self.messages.message_line_scroll,
+            );
+            if before == after {
+                break;
+            }
+        }
+    }
+
+    fn last_visible_message_index(&self) -> Option<usize> {
+        let messages = self.messages();
+        let mut index = self.messages.message_scroll;
+        let mut remaining = self.message_content_height();
+        let mut last = messages.get(index).map(|_| index)?;
+
+        while messages.get(index).is_some() {
+            let height = self
+                .message_rendered_height_at(
+                    index,
+                    self.messages.message_content_width,
+                    self.messages.message_preview_width,
+                    self.messages.message_max_preview_height,
+                )
+                .max(1);
+            let visible_rows = if index == self.messages.message_scroll {
+                height.saturating_sub(self.messages.message_line_scroll)
+            } else {
+                height
+            }
+            .max(1);
+
+            last = index;
+            if visible_rows >= remaining {
+                break;
+            }
+            remaining = remaining.saturating_sub(visible_rows);
+            index = index.saturating_add(1);
+        }
+
+        Some(last)
     }
 
     fn normalize_message_line_scroll(
@@ -1402,6 +1555,18 @@ impl DashboardState {
         })
     }
 
+    pub fn next_older_history_command_for_half_page_up(&mut self) -> Option<AppCommand> {
+        if !self.message_pane_can_load_message_history() {
+            return None;
+        }
+        let channel_id = self.selected_message_history_channel_id()?;
+        let before = self.older_history_viewport_cursor()?;
+        Some(AppCommand::LoadMessageHistory {
+            channel_id,
+            before: Some(before),
+        })
+    }
+
     pub(super) fn select_loaded_referenced_message(
         &mut self,
         channel_id: Id<ChannelMarker>,
@@ -1433,6 +1598,19 @@ impl DashboardState {
             || self.navigation.focus != FocusPane::Messages
             || self.messages().is_empty()
             || self.selected_message() != 0
+        {
+            return None;
+        }
+
+        self.messages().first().map(|message| message.id)
+    }
+
+    fn older_history_viewport_cursor(&self) -> Option<Id<MessageMarker>> {
+        if !self.message_pane_can_load_message_history()
+            || self.navigation.focus != FocusPane::Messages
+            || self.messages().is_empty()
+            || self.messages.message_scroll != 0
+            || self.messages.message_line_scroll != 0
         {
             return None;
         }

--- a/src/tui/state/navigation.rs
+++ b/src/tui/state/navigation.rs
@@ -321,11 +321,7 @@ impl DashboardState {
             }
             FocusPane::Messages => {
                 let distance = self.message_content_height() / 2;
-                let len = self.message_pane_item_count();
-                move_index_down_by(&mut self.messages.selected_message, len, distance.max(1));
-                self.messages.message_keep_selection_visible = true;
-                self.clamp_message_viewport();
-                self.refresh_message_auto_follow();
+                self.half_page_message_down(distance);
             }
             FocusPane::Members => {
                 let distance = pane_content_height(self.navigation.member_view_height) / 2;
@@ -352,13 +348,7 @@ impl DashboardState {
             }
             FocusPane::Messages => {
                 let distance = self.message_content_height() / 2;
-                self.messages.selected_message = self
-                    .messages
-                    .selected_message
-                    .saturating_sub(distance.max(1));
-                self.messages.message_keep_selection_visible = true;
-                self.clamp_message_viewport();
-                self.refresh_message_auto_follow();
+                self.half_page_message_up(distance);
             }
             FocusPane::Members => {
                 let distance = pane_content_height(self.navigation.member_view_height) / 2;

--- a/src/tui/state/tests/message_viewport.rs
+++ b/src/tui/state/tests/message_viewport.rs
@@ -475,6 +475,30 @@ fn message_viewport_scrolls_by_rendered_line() {
 }
 
 #[test]
+fn message_half_page_scrolls_by_rendered_rows() {
+    let mut state = state_with_single_message_content("abcdefghijkl");
+    for id in 2..=5 {
+        push_text_message(&mut state, id, &format!("msg {id}"));
+    }
+    state.focus_pane(FocusPane::Messages);
+    state.set_message_view_height(5);
+    state.jump_top();
+    state.clamp_message_viewport_for_image_previews(5, 16, 3);
+
+    state.half_page_down();
+    state.clamp_message_viewport_for_image_previews(5, 16, 3);
+
+    assert_eq!(state.selected_message(), 1);
+    assert_eq!(state.message_scroll(), 0);
+    assert_eq!(state.message_line_scroll(), 2);
+
+    state.half_page_up();
+    state.clamp_message_viewport_for_image_previews(5, 16, 3);
+    assert_eq!(state.selected_message(), 0);
+    assert_eq!(state.message_line_scroll(), 0);
+}
+
+#[test]
 fn viewport_scroll_moves_to_next_message_after_current_message() {
     let mut state = state_with_single_message_content("abcdefghijkl");
     state.push_event(message_create_event(MessageCreateFixture {
@@ -820,10 +844,12 @@ fn message_half_page_up_disables_follow() {
     let mut state = state_with_messages(10);
     state.focus_pane(FocusPane::Messages);
     state.set_message_view_height(9);
+    state.clamp_message_viewport_for_image_previews(200, 16, 3);
 
     state.half_page_up();
 
-    assert_eq!(state.selected_message(), 5);
+    assert_eq!(state.selected_message(), 0);
+    assert_eq!(state.message_scroll(), 0);
     assert!(!state.message_auto_follow());
 }
 
@@ -845,19 +871,21 @@ fn message_jump_bottom_re_engages_auto_follow() {
 }
 
 #[test]
-fn message_half_page_down_re_engages_auto_follow_when_landing_on_last() {
+fn message_half_page_down_re_engages_auto_follow_after_viewport_returns_to_latest() {
     let mut state = state_with_messages(10);
     state.focus_pane(FocusPane::Messages);
     state.set_message_view_height(9);
+    state.clamp_message_viewport_for_image_previews(200, 16, 3);
 
-    state.half_page_down();
-    assert!(state.message_auto_follow());
-
-    state.move_up();
+    state.half_page_up();
     assert!(!state.message_auto_follow());
 
     state.half_page_down();
-    // Half-page-down moved the cursor back onto the latest message.
+    assert_eq!(state.selected_message(), 9);
+    assert_eq!(state.message_scroll(), 2);
+    assert!(!state.message_auto_follow());
+
+    state.half_page_down();
     assert!(state.message_auto_follow());
 }
 


### PR DESCRIPTION
<!--
Thanks for the contribution. Please keep the subject under ~72 characters
and use a semantic prefix (feat:, fix:, refactor:, docs:, chore:, test:).

By submitting this PR you agree it will be distributed under GPL-3.0-only.
-->

## Summary

<!-- What does this change do, in one or two sentences? -->

## Why

Closes #149

<!-- The motivation. Link the issue it closes, e.g. "Closes #123". -->
<!-- Feature additions must have a related issue first. Feature PRs without a related issue may be closed without review. -->

## How

<!-- Notable implementation choices and any non-obvious trade-offs. -->

## Testing

<!-- How you verified the change. Mention the OS, terminal, and graphics protocol used for manual checks. -->

- [ ] `cargo fmt --all --check`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo test --all-features`
- [ ] Manual test in a real terminal (describe below)

## Screenshots or recordings

<!-- For UI changes, attach a screenshot or asciinema/gif. Delete this section if not applicable. -->

## Checklist

- [ ] One logical change per PR.
- [ ] Link a related issue.
- [ ] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [ ] Change does not add self-bot automation, mass actions, or scraping.
- [ ] Updated `README.md`, if behavior or workflows changed.
