### PR TITLE
feat: add syntax highlighting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,6 +428,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -766,6 +775,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "syntect",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -2723,6 +2733,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3238,6 +3254,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "onig"
+version = "6.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3700,6 +3738,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "plist"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+dependencies = [
+ "base64",
+ "indexmap",
+ "quick-xml 0.38.4",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3925,6 +3976,15 @@ name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
 ]
@@ -4845,6 +4905,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "syntect"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
+dependencies = [
+ "bincode",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "onig",
+ "plist",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror 2.0.18",
+ "walkdir",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -6315,6 +6396,15 @@ name = "y4m"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ toml = "1.1.2"
 unicode-segmentation = "1.12.0"
 unicode-width = "0.2.2"
 uuid = { version = "1.23.1", features = ["v4"] }
+syntect = "5.3.0"
 
 [features]
 default = ["voice-playback"]

--- a/src/tui/message/format.rs
+++ b/src/tui/message/format.rs
@@ -355,6 +355,7 @@ pub(in crate::tui) fn format_message_content_sections_with_loaded_custom_emoji_u
         let rendered =
             state.render_user_mentions_with_highlights(message.guild_id, &message.mentions, &value);
         lines.extend(wrap_markdown_message_lines_with_loaded_custom_emoji_urls(
+            state,
             rendered,
             width,
             Style::default(),
@@ -937,6 +938,7 @@ fn wrap_rendered_text_lines_with_styled_ranges(
 }
 
 fn wrap_markdown_message_lines_with_loaded_custom_emoji_urls(
+    state: &DashboardState,
     rendered: RenderedText,
     width: usize,
     style: Style,
@@ -961,7 +963,8 @@ fn wrap_markdown_message_lines_with_loaded_custom_emoji_urls(
                 if content_end > 0 {
                     code_block_lines.push(rendered_text_slice(&rendered_line, 0, content_end));
                 }
-                lines.extend(wrap_code_block_lines(
+                lines.extend(wrap_code_block_lines_and_highlight(
+                    state,
                     std::mem::take(&mut code_block_lines),
                     width,
                     code_block_label.take(),
@@ -990,7 +993,8 @@ fn wrap_markdown_message_lines_with_loaded_custom_emoji_urls(
                 lines.extend(wrap_markdown_inline_text(fence, width, style));
             }
         } else {
-            lines.extend(wrap_code_block_lines(
+            lines.extend(wrap_code_block_lines_and_highlight(
+                state,
                 code_block_lines,
                 width,
                 code_block_label,
@@ -1080,29 +1084,44 @@ fn wrap_markdown_inline_text_preserving_empty(
     lines
 }
 
-fn wrap_code_block_lines(
+fn wrap_code_block_lines_and_highlight(
+    state: &DashboardState,
     code_lines: Vec<RenderedText>,
     width: usize,
     label: Option<String>,
 ) -> Vec<MessageContentLine> {
     let style = markdown_code_style();
-    let inner_width = width.saturating_sub(4).max(1);
-    let mut body_texts = Vec::new();
-    for rendered in code_lines {
-        let wrapped = wrap_text_lines(&rendered.text, inner_width);
-        if wrapped.is_empty() {
-            body_texts.push(String::new());
+    let highlighted_lines = {
+        if let Some(language) = label.as_ref().filter(|l| !l.is_empty()) {
+            let text_lines = code_lines.into_iter().map(|rt| rt.text).collect::<Vec<_>>();
+            state
+                .syntax_highlight_cache
+                .highlight(&text_lines, language)
         } else {
-            body_texts.extend(wrapped);
+            code_lines
+                .into_iter()
+                .map(|rt| vec![(style, rt.text)])
+                .collect()
+        }
+    };
+
+    let inner_width = width.saturating_sub(4).max(1);
+    let mut body_lines = Vec::new();
+    for regions in highlighted_lines {
+        let wrapped = wrap_text_line_with_styles(regions, inner_width);
+        if wrapped.is_empty() {
+            body_lines.push(vec![(style, String::new())]);
+        } else {
+            body_lines.extend(wrapped);
         }
     }
-    if body_texts.is_empty() {
-        body_texts.push(String::new());
+    if body_lines.is_empty() {
+        body_lines.push(vec![(style, String::new())]);
     }
 
-    let content_width = body_texts
+    let content_width = body_lines
         .iter()
-        .map(|line| line.width())
+        .map(|line| line.iter().map(|region| region.1.width()).sum())
         .max()
         .unwrap_or(0)
         .max(4)
@@ -1115,9 +1134,9 @@ fn wrap_code_block_lines(
         label.as_deref(),
     )];
     lines.extend(
-        body_texts
+        body_lines
             .into_iter()
-            .map(|line| code_box_body_line(line, content_width, style)),
+            .map(|line| code_box_body_line(line, content_width)),
     );
     lines.push(code_box_border_line('╰', '╯', content_width, None));
     lines
@@ -1148,20 +1167,25 @@ fn code_box_border_line(
     MessageContentLine::dim(format!("{left}{inner}{right}"))
 }
 
-fn code_box_body_line(text: String, content_width: usize, style: Style) -> MessageContentLine {
-    let padding = content_width.saturating_sub(text.width());
+fn code_box_body_line(regions: Vec<(Style, String)>, content_width: usize) -> MessageContentLine {
     let mut line =
         MessageContentLine::styled_text("│ ".to_owned(), Style::default().fg(DIM), Vec::new());
     let content_start = line.text.len();
-    line.text.push_str(&text);
+    let mut width = 0usize;
+    let mut current_pos = content_start;
+    for (style, text) in regions {
+        line.text.push_str(&text);
+        line.styled_prefixes.push(StyledPrefix {
+            start: current_pos,
+            len: text.len(),
+            style,
+            patch_base: false,
+        });
+        width += text.width();
+        current_pos += text.len();
+    }
+    let padding = content_width.saturating_sub(width);
     line.text.push_str(&" ".repeat(padding));
-    let content_len = line.text.len().saturating_sub(content_start);
-    line.styled_prefixes.push(StyledPrefix {
-        start: content_start,
-        len: content_len,
-        style,
-        patch_base: false,
-    });
     line.append_styled_suffix(" │", Style::default().fg(DIM));
     line
 }
@@ -1716,6 +1740,48 @@ pub(in crate::tui) fn wrap_text_lines(value: &str, width: usize) -> Vec<String> 
             current.push_str(grapheme);
             current_width = current_width.saturating_add(grapheme_width);
         }
+        lines.push(current);
+    }
+    lines
+}
+
+fn wrap_text_line_with_styles(
+    value: Vec<(Style, String)>,
+    width: usize,
+) -> Vec<Vec<(Style, String)>> {
+    if value.is_empty() {
+        return Vec::new();
+    }
+
+    let width = width.max(1);
+    let mut lines = Vec::new();
+    let mut current = Vec::new();
+    let mut current_width = 0usize;
+    for (style, region) in value {
+        let mut current_region = String::new();
+        for grapheme in region.graphemes(true) {
+            let grapheme_width = grapheme.width();
+            if current_width > 0
+                && grapheme_width > 0
+                && current_width.saturating_add(grapheme_width) > width
+            {
+                if !current_region.is_empty() {
+                    current.push((style, current_region));
+                }
+                lines.push(current);
+                current = Vec::new();
+                current_region = String::new();
+                current_width = 0;
+            }
+
+            current_region.push_str(grapheme);
+            current_width = current_width.saturating_add(grapheme_width);
+        }
+        if !current_region.is_empty() {
+            current.push((style, current_region));
+        }
+    }
+    if !current.is_empty() {
         lines.push(current);
     }
     lines

--- a/src/tui/message/mod.rs
+++ b/src/tui/message/mod.rs
@@ -1,4 +1,5 @@
 pub(in crate::tui) mod format;
 pub(in crate::tui) mod layout;
 pub(in crate::tui) mod rows;
+pub(in crate::tui) mod syntax_highlight;
 pub(in crate::tui) mod time;

--- a/src/tui/message/syntax_highlight.rs
+++ b/src/tui/message/syntax_highlight.rs
@@ -1,0 +1,158 @@
+use std::{cell::RefCell, collections::HashMap, sync::LazyLock};
+
+use ratatui::style::{Color, Modifier, Style};
+use syntect::{
+    easy::HighlightLines,
+    highlighting::{FontStyle, ThemeSet},
+    parsing::SyntaxSet,
+};
+
+use crate::logging;
+
+static SYNTAX_SET: LazyLock<SyntaxSet> = LazyLock::new(SyntaxSet::load_defaults_nonewlines);
+static THEME_SET: LazyLock<ThemeSet> = LazyLock::new(ThemeSet::load_defaults);
+
+fn compute_key(lines: &[String], language: &str) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    lines.hash(&mut hasher);
+    language.hash(&mut hasher);
+    hasher.finish()
+}
+
+#[derive(Debug, Default)]
+pub(in crate::tui) struct SyntaxHighlightCache {
+    state: RefCell<SyntaxHighlightCacheState>,
+}
+
+#[derive(Debug, Default)]
+struct SyntaxHighlightCacheState {
+    entries: HashMap<u64, SyntaxHighlightEntry>,
+    tick: u64,
+}
+
+#[derive(Debug)]
+struct SyntaxHighlightEntry {
+    lines: Vec<Vec<(Style, String)>>,
+    last_used: u64,
+}
+
+const MAX_CACHE_ENTRIES: usize = 32;
+
+impl SyntaxHighlightCache {
+    pub(super) fn highlight(&self, lines: &[String], language: &str) -> Vec<Vec<(Style, String)>> {
+        let key = compute_key(lines, language);
+        let mut state = self.state.borrow_mut();
+        state.tick = state.tick.wrapping_add(1);
+        let next_tick = state.tick;
+
+        if let Some(entry) = state.entries.get_mut(&key) {
+            entry.last_used = next_tick;
+            return entry.lines.clone();
+        }
+
+        let highlighted_lines = do_highlight(lines, language);
+
+        if state.entries.len() >= MAX_CACHE_ENTRIES
+            && let Some(oldest) = state
+                .entries
+                .iter()
+                .min_by_key(|(_, e)| e.last_used)
+                .map(|(k, _)| *k)
+        {
+            state.entries.remove(&oldest);
+        }
+
+        state.entries.insert(
+            key,
+            SyntaxHighlightEntry {
+                lines: highlighted_lines.clone(),
+                last_used: next_tick,
+            },
+        );
+
+        highlighted_lines
+    }
+}
+
+fn syntect_style_to_ratatui(s: syntect::highlighting::Style) -> Style {
+    let mut style = Style::default().fg(Color::Rgb(s.foreground.r, s.foreground.g, s.foreground.b));
+    if s.font_style.contains(FontStyle::BOLD) {
+        style = style.add_modifier(Modifier::BOLD);
+    }
+    if s.font_style.contains(FontStyle::ITALIC) {
+        style = style.add_modifier(Modifier::ITALIC);
+    }
+    if s.font_style.contains(FontStyle::UNDERLINE) {
+        style = style.add_modifier(Modifier::UNDERLINED);
+    }
+    style
+}
+
+fn do_highlight(lines: &[String], language: &str) -> Vec<Vec<(Style, String)>> {
+    let syntax = SYNTAX_SET
+        .find_syntax_by_token(language)
+        .unwrap_or_else(|| SYNTAX_SET.find_syntax_plain_text());
+    let theme = THEME_SET
+        .themes
+        .get("base16-ocean.dark")
+        .expect("should be included default theme");
+
+    let mut h = HighlightLines::new(syntax, theme);
+    let mut result = Vec::new();
+
+    for line in lines {
+        let line = line.trim_end_matches('\n');
+        let regions = match h.highlight_line(line, &SYNTAX_SET) {
+            Ok(regions) => regions,
+            Err(error) => {
+                logging::error(
+                    "syntax_highlight",
+                    format!("There was an error while calling highlight_line: {error}"),
+                );
+                result.push(vec![(Style::default(), line.to_owned())]);
+                continue;
+            }
+        };
+        result.push(
+            regions
+                .into_iter()
+                .filter(|(_, text)| !text.is_empty())
+                .map(|(style, text)| (syntect_style_to_ratatui(style), text.to_owned()))
+                .collect(),
+        );
+    }
+
+    result
+}
+
+#[test]
+fn syntax_highlight_cache_stores_cached_elements() {
+    let cache = SyntaxHighlightCache::default();
+    let code = ["let works = true;".to_string()];
+    let language = "rust";
+    let key = compute_key(&code, language);
+    cache.highlight(&code, language);
+    assert_eq!(cache.state.borrow().tick, 1);
+    assert_eq!(cache.state.borrow().entries.len(), 1);
+    cache.highlight(&code, language);
+    assert_eq!(cache.state.borrow().tick, 2);
+    assert_eq!(cache.state.borrow().entries.len(), 1);
+    assert!(cache.state.borrow().entries.contains_key(&key));
+    cache.highlight(&code, "js");
+    assert_eq!(cache.state.borrow().tick, 3);
+    assert_eq!(cache.state.borrow().entries.len(), 2);
+}
+
+#[test]
+fn syntax_highlight_cache_no_over_limit() {
+    let cache = SyntaxHighlightCache::default();
+    for i in 0..(MAX_CACHE_ENTRIES + 5) {
+        cache.highlight(&[i.to_string()], "rust");
+    }
+    assert_eq!(cache.state.borrow().entries.len(), MAX_CACHE_ENTRIES);
+    let key_too_old = compute_key(&[4.to_string()], "rust");
+    let key_not_old = compute_key(&[5.to_string()], "rust");
+    assert!(!cache.state.borrow().entries.contains_key(&key_too_old));
+    assert!(cache.state.borrow().entries.contains_key(&key_not_old));
+}

--- a/src/tui/state/dashboard.rs
+++ b/src/tui/state/dashboard.rs
@@ -1,3 +1,5 @@
+use crate::tui::message::syntax_highlight::SyntaxHighlightCache;
+
 use super::{
     ComposerUiState, DiscordUiState, LayoutCacheState, MessageHistoryRefreshState,
     MessageViewportState, NavigationState, OptionsUiState, PopupUiState, RequestTrackingState,
@@ -16,6 +18,7 @@ pub struct DashboardState {
     pub(super) options: OptionsUiState,
     pub(super) requests: RequestTrackingState,
     pub(super) layout_cache: LayoutCacheState,
+    pub(in crate::tui) syntax_highlight_cache: SyntaxHighlightCache,
 }
 
 impl DashboardState {

--- a/src/tui/ui/tests/messages.rs
+++ b/src/tui/ui/tests/messages.rs
@@ -1,3 +1,5 @@
+use ratatui::style::Stylize;
+
 use super::*;
 
 #[test]
@@ -619,24 +621,27 @@ fn message_content_applies_supported_markdown_formatting() {
     assert_eq!(lines[13].style.fg, Some(DIM));
 
     let code_line = lines[11].spans();
-    assert_eq!(code_line[0].content.as_ref(), "│ ");
-    assert_eq!(code_line[0].style.fg, Some(DIM));
-    assert_eq!(code_line[1].content.as_ref(), "let answer = 42;    ");
-    assert_eq!(code_line[1].style.fg, Some(Color::White));
-    assert_eq!(code_line[1].style.bg, None);
-    assert_eq!(code_line[2].content.as_ref(), " │");
-    assert_eq!(code_line[2].style.fg, Some(DIM));
+    assert_eq!(
+        code_line,
+        vec![
+            ratatui::text::Span::from("│ ").fg(DIM),
+            ratatui::text::Span::from("let").fg(Color::Rgb(180, 142, 173)),
+            ratatui::text::Span::from(" answer ").fg(Color::Rgb(192, 197, 206)),
+            ratatui::text::Span::from("=").fg(Color::Rgb(192, 197, 206)),
+            ratatui::text::Span::from(" ").fg(Color::Rgb(192, 197, 206)),
+            ratatui::text::Span::from("42").fg(Color::Rgb(208, 135, 112)),
+            ratatui::text::Span::from(";").fg(Color::Rgb(192, 197, 206)),
+            ratatui::text::Span::from("    ").dark_gray(),
+            ratatui::text::Span::from(" │").fg(DIM)
+        ]
+    );
 
     let literal_code_line = lines[12].spans();
-    assert_eq!(
-        literal_code_line[1].content.as_ref(),
-        "**not bold in code**"
-    );
+    assert_eq!(literal_code_line[1].content.as_ref(), "*");
     assert!(
-        !literal_code_line[1]
-            .style
-            .add_modifier
-            .contains(Modifier::BOLD)
+        !literal_code_line
+            .iter()
+            .any(|span| span.style.add_modifier.contains(Modifier::BOLD))
     );
 
     let mut quote = message_with_content(Some("> hello <@10>".to_owned()));


### PR DESCRIPTION
<!--
Thanks for the contribution. Please keep the subject under ~72 characters
and use a semantic prefix (feat:, fix:, refactor:, docs:, chore:, test:).

By submitting this PR you agree it will be distributed under GPL-3.0-only.
-->

## Summary

<!-- What does this change do, in one or two sentences? -->
This PR adds syntax highlighting for various languages when the syntax-highlighting feature, which is in the default feature set, is enabled.

## Why

<!-- The motivation. Link the issue it closes, e.g. "Closes #123". -->
<!-- Feature additions must have a related issue first. Feature PRs without a related issue may be closed without review. -->
Part of the suggestions in #29 , it doesn't close the issue though because of other feature suggestions in there.

## How

<!-- Notable implementation choices and any non-obvious trade-offs. -->
It uses the `syntect` crate and its default memory dumped supported syntaxes and themes.
It uses a `LazyLock` to load them into memory when they are first needed. This may take a small amount of time.

It adds a cache to keep the last 32 used highlightings, so that highlighting the message on every re-render is not necessary.

The increase in binary size is less than a megabyte and the increase in memory usage doesn't seem to be significantly noticeable.

## Testing

<!-- How you verified the change. Mention the OS, terminal, and graphics protocol used for manual checks. -->

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] Manual test in a real terminal (describe below)

OS: NixOS
Terminal: Kitty
Graphics Protocol: Kitty

## Screenshots or recordings

<!-- For UI changes, attach a screenshot or asciinema/gif. Delete this section if not applicable. -->
<img width="1519" height="956" alt="image" src="https://github.com/user-attachments/assets/b17c2fbc-5d0d-4de5-8880-aa779171d0e4" />

## Checklist

- [x] One logical change per PR.
- [x] Link a related issue.
- [x] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [x] Change does not add self-bot automation, mass actions, or scraping.
- [x] Updated `README.md`, if behavior or workflows changed.
