### PR TITLE
fix: show macOS notifications on terminals that don't set TERM_PROGRAM

### DIFF
--- a/src/tui/runtime/effects.rs
+++ b/src/tui/runtime/effects.rs
@@ -248,12 +248,12 @@ fn deliver_notify_rust_notification(
 fn init_macos_notification_identity() {
     static INIT: Once = Once::new();
     INIT.call_once(|| {
-        let Some(app_name) = std::env::var("TERM_PROGRAM")
+        // macOS needs a real app bundle, so fall back to Terminal for terminals
+        // we can't identify (e.g. kitty, tmux) -- otherwise notifications vanish.
+        let app_name = std::env::var("TERM_PROGRAM")
             .ok()
             .and_then(|program| macos_terminal_app_name(&program))
-        else {
-            return;
-        };
+            .unwrap_or("Terminal");
         let bundle_id = notify_rust::get_bundle_identifier_or_default(app_name);
         if bundle_id != "com.apple.Finder" {
             let _ = notify_rust::set_application(&bundle_id);


### PR DESCRIPTION
NOTE: This is slop. But I heavily went through this issue to figure out what exactly was happening, and I made the fix as small as humanly possible so you could grok it at a glance.

## Summary

On macOS, use Terminal as fallback when TERM_PROGRAM isn't set. Kitty doesn't set it (probably some other terminals don't as well), and if you set it with an environment variable, it doesn't pass through to tmux. This makes notifications work regardless.

## Why

Regression from `23737a8` ("fix: remove macos notification fallback", v2.1.8). Before that, macOS used afplay to play a notification sound and fell back to `osascript`/`terminal-notifier` for the visual notification. Those don't need a MacOS bundle identity. That masked a latent bug: `init_macos_notification_identity` has silently set  no identity whenever `TERM_PROGRAM` isn't a recognized terminal (kitty doesn't set it and tmux sets an unmapped value), going all the way back to the original notification feature (#5).

Once the fallback was removed and macOS collapsed onto the plain `notify-rust` path, that latent bug surfaced: with no identity registered, `notify-rust` posts under no app bundle and the notification never appears, with no audible/visual fallback. Result on kitty/tmux is total silence. (In the past, the visual notifications didn't work, but the audio still played.)

## How

Replace the early return on an unrecognized `TERM_PROGRAM` with `.unwrap_or("Terminal")`. `Terminal` always resolves to a valid bundle id (`com.apple.Terminal`), so `set_application` succeeds and the native notification (banner + sound) pops up regardless of which terminal is being used. Recognized terminals (iterm, wezterm, etc) still post under their own identity.

## Testing

macOS, kitty (both inside and outside of tmux)

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` (1325 passed)
- [x] Manual: ran Concord in kitty alone and inside tmux. Desktop notifications now work.

## Checklist

- [x] One logical change per PR.
- [ ] Link a related issue.
- [x] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [x] Change does not add self-bot automation, mass actions, or scraping.
- [ ] Updated `README.md`, if behavior or workflows changed. (n/a — no workflow change)