### PR TITLE
fix: Fix slash command invocation to preserve selected command identity

### DIFF
--- a/src/discord/application_commands.rs
+++ b/src/discord/application_commands.rs
@@ -17,7 +17,20 @@ pub struct ApplicationCommandInfo {
     pub raw: Value,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ApplicationCommandIdentity {
+    pub id: Id<ApplicationMarker>,
+    pub application_id: Id<ApplicationMarker>,
+}
+
 impl ApplicationCommandInfo {
+    pub fn identity(&self) -> ApplicationCommandIdentity {
+        ApplicationCommandIdentity {
+            id: self.id,
+            application_id: self.application_id,
+        }
+    }
+
     pub fn without_raw(mut self) -> Self {
         self.raw = Value::Null;
         self
@@ -87,6 +100,7 @@ pub struct ApplicationCommandInteraction {
 pub struct ApplicationCommandInvocation {
     pub guild_id: Option<Id<GuildMarker>>,
     pub channel_id: Id<ChannelMarker>,
+    pub command_identity: Option<ApplicationCommandIdentity>,
     pub command_name: String,
     pub content: String,
 }
@@ -115,6 +129,9 @@ pub fn application_command_interaction_from_invocation(
     invocation: &ApplicationCommandInvocation,
     command: &ApplicationCommandInfo,
 ) -> Option<ApplicationCommandInteraction> {
+    if let Some(identity) = invocation.command_identity {
+        (command.identity() == identity).then_some(())?;
+    }
     (invocation.command_name == command.name).then_some(())?;
     Some(ApplicationCommandInteraction {
         guild_id: invocation.guild_id,
@@ -524,6 +541,7 @@ mod tests {
         ApplicationCommandInvocation {
             guild_id: Some(Id::new(1)),
             channel_id: Id::new(2),
+            command_identity: None,
             command_name: command_name.to_owned(),
             content: content.to_owned(),
         }

--- a/src/discord/client.rs
+++ b/src/discord/client.rs
@@ -907,10 +907,13 @@ impl DiscordClient {
             .expect("application command cache lock is not poisoned");
         let command = commands
             .get(&invocation.guild_id)
-            .and_then(|commands| {
-                commands
+            .and_then(|commands| match invocation.command_identity {
+                Some(identity) => commands
                     .iter()
-                    .find(|command| command.name == invocation.command_name)
+                    .find(|command| command.identity() == identity),
+                None => commands
+                    .iter()
+                    .find(|command| command.name == invocation.command_name),
             })
             .ok_or_else(|| {
                 AppError::DiscordRequest(format!(

--- a/src/discord/client/tests.rs
+++ b/src/discord/client/tests.rs
@@ -465,8 +465,18 @@ fn application_command_metadata_keeps_raw_backend_owned() {
     let client = DiscordClient::new("test-token".to_owned()).expect("token is valid header");
     let guild_id = Some(Id::new(1));
     let command = application_command("echo");
+    let mut selected_command = application_command("echo");
+    selected_command.id = Id::new(101);
+    selected_command.application_id = Id::new(201);
+    selected_command.raw = json!({
+        "id": "101",
+        "application_id": "201",
+        "version": "1",
+        "name": "echo",
+    });
 
-    let tui_commands = client.record_application_commands_for_tui(guild_id, vec![command]);
+    let tui_commands = client
+        .record_application_commands_for_tui(guild_id, vec![command, selected_command.clone()]);
 
     assert_eq!(tui_commands[0].raw, Value::Null);
     let commands = client
@@ -477,6 +487,18 @@ fn application_command_metadata_keeps_raw_backend_owned() {
         commands.get(&guild_id).expect("backend cache")[0].raw["name"],
         "echo"
     );
+    drop(commands);
+
+    let interaction = client
+        .application_command_interaction(&crate::discord::ApplicationCommandInvocation {
+            guild_id,
+            channel_id: Id::new(2),
+            command_identity: Some(selected_command.identity()),
+            command_name: "echo".to_owned(),
+            content: "/echo".to_owned(),
+        })
+        .expect("selected command identity should resolve");
+    assert_eq!(interaction.command.identity(), selected_command.identity());
 }
 
 #[tokio::test]

--- a/src/discord/mod.rs
+++ b/src/discord/mod.rs
@@ -26,10 +26,11 @@ mod voice;
 pub use application_commands::{
     APPLICATION_COMMAND_CHANNEL_KIND, APPLICATION_COMMAND_MENTIONABLE_KIND,
     APPLICATION_COMMAND_ROLE_KIND, APPLICATION_COMMAND_STRING_KIND, APPLICATION_COMMAND_USER_KIND,
-    ApplicationCommandChoiceInfo, ApplicationCommandInfo, ApplicationCommandInteraction,
-    ApplicationCommandInteractionOption, ApplicationCommandInvocation,
-    ApplicationCommandOptionInfo, application_command_content_is_complete,
-    application_command_option_scope, parsed_application_command_option_names,
+    ApplicationCommandChoiceInfo, ApplicationCommandIdentity, ApplicationCommandInfo,
+    ApplicationCommandInteraction, ApplicationCommandInteractionOption,
+    ApplicationCommandInvocation, ApplicationCommandOptionInfo,
+    application_command_content_is_complete, application_command_option_scope,
+    parsed_application_command_option_names,
 };
 pub use channel::{
     ChannelInfo, ChannelRecipientInfo, PermissionOverwriteInfo, PermissionOverwriteKind,

--- a/src/tui/input/keyboard/composer.rs
+++ b/src/tui/input/keyboard/composer.rs
@@ -133,6 +133,7 @@ fn handle_command_picker_key(
     if key.code == KeyCode::Enter
         && key.modifiers == KeyModifiers::NONE
         && state.composer_command_can_submit()
+        && !state.composer_command_selected_candidate_is_top_level()
     {
         return Some(state.submit_composer());
     }

--- a/src/tui/input/tests/composer.rs
+++ b/src/tui/input/tests/composer.rs
@@ -654,28 +654,49 @@ fn enter_submits_complete_slash_command_when_optional_options_are_suggested() {
     handle_key(&mut state, key(KeyCode::Enter));
     state.push_event(AppEvent::ApplicationCommandsLoaded {
         guild_id: Some(Id::new(1)),
-        commands: vec![ApplicationCommandInfo {
-            application_id: Id::new(200),
-            version: "1".to_owned(),
-            application_name: Some("TestBot".to_owned()),
-            description: "achievements command".to_owned(),
-            options: vec![ApplicationCommandOptionInfo {
-                description: "member option".to_owned(),
-                ..ApplicationCommandOptionInfo::test(6, "member")
-            }],
-            raw: serde_json::json!({
-                "id": "100",
-                "application_id": "200",
-                "version": "1",
-                "name": "achievements",
-            }),
-            ..ApplicationCommandInfo::test(Id::new(100), "achievements")
-        }],
+        commands: vec![
+            ApplicationCommandInfo {
+                application_id: Id::new(200),
+                version: "1".to_owned(),
+                application_name: Some("WrongBot".to_owned()),
+                description: "first achievements command".to_owned(),
+                raw: serde_json::json!({
+                    "id": "100",
+                    "application_id": "200",
+                    "version": "1",
+                    "name": "achievements",
+                }),
+                ..ApplicationCommandInfo::test(Id::new(100), "achievements")
+            },
+            ApplicationCommandInfo {
+                application_id: Id::new(201),
+                version: "2".to_owned(),
+                application_name: Some("TestBot".to_owned()),
+                description: "selected achievements command".to_owned(),
+                options: vec![ApplicationCommandOptionInfo {
+                    description: "member option".to_owned(),
+                    ..ApplicationCommandOptionInfo::test(6, "member")
+                }],
+                raw: serde_json::json!({
+                    "id": "101",
+                    "application_id": "201",
+                    "version": "2",
+                    "name": "achievements",
+                }),
+                ..ApplicationCommandInfo::test(Id::new(101), "achievements")
+            },
+        ],
     });
     handle_key(&mut state, char_key('i'));
-    for ch in "/achievements ".chars() {
+    for ch in "/ach".chars() {
         handle_key(&mut state, char_key(ch));
     }
+    assert_eq!(state.composer_command_query(), Some("/ach"));
+
+    handle_key(&mut state, key(KeyCode::Down));
+    handle_key(&mut state, key(KeyCode::Enter));
+
+    assert_eq!(state.composer_input(), "/achievements ");
     assert_eq!(state.composer_command_query(), Some(""));
 
     let command = handle_key(&mut state, key(KeyCode::Enter));
@@ -685,6 +706,8 @@ fn enter_submits_complete_slash_command_when_optional_options_are_suggested() {
         Some(AppCommand::RunApplicationCommand { ref invocation })
             if invocation.command_name == "achievements"
                 && invocation.content == "/achievements"
+                && invocation.command_identity.map(|identity| (identity.id, identity.application_id))
+                    == Some((Id::new(101), Id::new(201)))
     ));
 }
 

--- a/src/tui/state/composer/completions.rs
+++ b/src/tui/state/composer/completions.rs
@@ -4,8 +4,8 @@ use crate::discord::ids::{
 };
 
 use crate::discord::{
-    ApplicationCommandInfo, ApplicationCommandOptionInfo, ChannelState, CustomEmojiInfo,
-    PresenceStatus, RoleState,
+    ApplicationCommandIdentity, ApplicationCommandInfo, ApplicationCommandOptionInfo, ChannelState,
+    CustomEmojiInfo, PresenceStatus, RoleState,
 };
 
 use super::super::{MemberEntry, emoji::custom_emoji_can_be_used_directly};
@@ -85,6 +85,7 @@ pub struct CommandPickerEntry {
     pub label: String,
     pub detail: String,
     pub replacement: String,
+    pub command_identity: Option<ApplicationCommandIdentity>,
 }
 
 pub(super) fn build_command_candidates(
@@ -112,6 +113,7 @@ pub(super) fn build_command_candidates(
                     label: format!("/{}", command.name),
                     detail: command_picker_detail(command),
                     replacement: format!("/{} ", command.name),
+                    command_identity: Some(command.identity()),
                 },
             ))
         })
@@ -142,6 +144,7 @@ pub(super) fn build_command_option_candidates(
             label: command_option_label(option),
             detail: command_option_detail(option),
             replacement: command_option_replacement(option),
+            command_identity: None,
         })
         .collect()
 }
@@ -199,6 +202,7 @@ pub(super) fn build_command_choice_candidates(
                     .map(str::to_owned)
                     .unwrap_or_else(|| choice.value.to_string())
             ),
+            command_identity: None,
         })
         .collect()
 }

--- a/src/tui/state/composer/state.rs
+++ b/src/tui/state/composer/state.rs
@@ -6,10 +6,10 @@ use crate::discord::ids::{
 };
 use crate::discord::{
     APPLICATION_COMMAND_CHANNEL_KIND, APPLICATION_COMMAND_MENTIONABLE_KIND,
-    APPLICATION_COMMAND_ROLE_KIND, APPLICATION_COMMAND_USER_KIND, ApplicationCommandInfo,
-    ApplicationCommandInvocation, MAX_UPLOAD_ATTACHMENT_COUNT, MessageAttachmentUpload,
-    application_command_content_is_complete, application_command_option_scope,
-    parsed_application_command_option_names,
+    APPLICATION_COMMAND_ROLE_KIND, APPLICATION_COMMAND_USER_KIND, ApplicationCommandIdentity,
+    ApplicationCommandInfo, ApplicationCommandInvocation, MAX_UPLOAD_ATTACHMENT_COUNT,
+    MessageAttachmentUpload, application_command_content_is_complete,
+    application_command_option_scope, parsed_application_command_option_names,
 };
 
 use super::super::{
@@ -51,6 +51,8 @@ pub(in crate::tui::state) struct ComposerUiState {
     pub(in crate::tui::state) composer_command_start: Option<usize>,
     pub(in crate::tui::state) composer_command_selected: usize,
     pub(in crate::tui::state) composer_command_candidates: Vec<CommandPickerEntry>,
+    pub(in crate::tui::state) composer_selected_command_identity:
+        Option<ApplicationCommandIdentity>,
     /// Records `@displayname` substrings that the picker inserted, so the
     /// composer can rewrite them to Discord's `<@USER_ID>` wire format on
     /// submit even though the visible text is still the friendly form.
@@ -508,6 +510,14 @@ impl DashboardState {
         self.composer.composer_command_candidates.clone()
     }
 
+    pub(in crate::tui) fn composer_command_selected_candidate_is_top_level(&self) -> bool {
+        self.composer
+            .composer_command_candidates
+            .get(self.composer.composer_command_selected)
+            .and_then(|entry| entry.command_identity)
+            .is_some()
+    }
+
     pub(in crate::tui) fn composer_command_can_submit(&self) -> bool {
         let expanded = expand_composer_completions(
             &self.composer.composer_input,
@@ -644,6 +654,9 @@ impl DashboardState {
         }
 
         self.replace_composer_range(command_start..cursor, &entry.replacement);
+        if let Some(identity) = entry.command_identity {
+            self.composer.composer_selected_command_identity = Some(identity);
+        }
         self.close_composer_command_query();
         self.refresh_active_mention_query();
         true
@@ -689,6 +702,7 @@ impl DashboardState {
         self.close_composer_command_query();
         self.composer.composer_mention_completions.clear();
         self.composer.composer_emoji_completions.clear();
+        self.composer.composer_selected_command_identity = None;
     }
 
     fn close_composer_mention_query(&mut self) {
@@ -991,6 +1005,7 @@ impl DashboardState {
                     super::completions::MentionPickerTarget::Channel(_) => "channel".to_owned(),
                 },
                 replacement: format!("{} ", entry.target.wire_format()),
+                command_identity: None,
             })
             .collect()
     }
@@ -1013,6 +1028,14 @@ impl DashboardState {
             .strip_prefix('/')?
             .split_whitespace()
             .next()?;
+        if let Some(identity) = self.composer.composer_selected_command_identity
+            && let Some(command) = self
+                .application_commands_for_selected_channel()
+                .iter()
+                .find(|command| command.identity() == identity && command.name == name)
+        {
+            return Some(command);
+        }
         self.application_commands_for_selected_channel()
             .iter()
             .find(|command| command.name == name)
@@ -1031,11 +1054,20 @@ impl DashboardState {
         else {
             return ApplicationCommandSubmit::NotCommand;
         };
-        let Some(command) = self
+        let commands = self
             .discord
             .application_commands
             .get(&guild_id)
-            .and_then(|commands| commands.iter().find(|command| command.name == command_name))
+            .map(Vec::as_slice)
+            .unwrap_or(&[]);
+        let selected_identity = self.composer.composer_selected_command_identity;
+        let Some(command) = selected_identity
+            .and_then(|identity| {
+                commands
+                    .iter()
+                    .find(|command| command.identity() == identity && command.name == command_name)
+            })
+            .or_else(|| commands.iter().find(|command| command.name == command_name))
             .cloned()
         else {
             return ApplicationCommandSubmit::NotCommand;
@@ -1046,6 +1078,7 @@ impl DashboardState {
         ApplicationCommandSubmit::Ready(ApplicationCommandInvocation {
             guild_id,
             channel_id,
+            command_identity: Some(command.identity()),
             command_name: command.name,
             content: content.to_owned(),
         })

--- a/src/tui/state/tests/composer.rs
+++ b/src/tui/state/tests/composer.rs
@@ -118,6 +118,12 @@ fn assert_slash_invocation(command: Option<AppCommand>, command_name: &str, cont
     };
     assert_eq!(invocation.guild_id, Some(Id::new(1)));
     assert_eq!(invocation.channel_id, Id::new(2));
+    assert_eq!(
+        invocation
+            .command_identity
+            .map(|identity| (identity.id, identity.application_id)),
+        Some((Id::new(100), Id::new(200)))
+    );
     assert_eq!(invocation.command_name, command_name);
     assert_eq!(invocation.content, content);
 }


### PR DESCRIPTION
<!--
Thanks for the contribution. Please keep the subject under ~72 characters
and use a semantic prefix (feat:, fix:, refactor:, docs:, chore:, test:).

By submitting this PR you agree it will be distributed under GPL-3.0-only.
-->

## Summary

<!-- What does this change do, in one or two sentences? -->

## Why
Closes #47 
<!-- The motivation. Link the issue it closes, e.g. "Closes #123". -->
<!-- Feature additions must have a related issue first. Feature PRs without a related issue may be closed without review. -->

## How

<!-- Notable implementation choices and any non-obvious trade-offs. -->

## Testing

<!-- How you verified the change. Mention the OS, terminal, and graphics protocol used for manual checks. -->

- [ ] `cargo fmt --all --check`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo test --all-features`
- [ ] Manual test in a real terminal (describe below)

## Screenshots or recordings

<!-- For UI changes, attach a screenshot or asciinema/gif. Delete this section if not applicable. -->

## Checklist

- [ ] One logical change per PR.
- [ ] Link a related issue.
- [ ] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [ ] Change does not add self-bot automation, mass actions, or scraping.
- [ ] Updated `README.md`, if behavior or workflows changed.
