### PR TITLE
feat: Notify for active-channel messages while the terminal is unfocused

### DIFF
--- a/src/tui/runtime/events.rs
+++ b/src/tui/runtime/events.rs
@@ -46,6 +46,8 @@ pub(super) fn handle_terminal_event(
         TerminalEvent::Paste(text) if input::handle_paste(state, &text) => {
             outcome.dirty = true;
         }
+        TerminalEvent::FocusGained => state.set_terminal_focused(true),
+        TerminalEvent::FocusLost => state.set_terminal_focused(false),
         _ => {}
     }
 

--- a/src/tui/state/discord_ui.rs
+++ b/src/tui/state/discord_ui.rs
@@ -201,7 +201,7 @@ impl DashboardState {
             return None;
         };
         if !self.desktop_notifications_enabled()
-            || self.navigation.active_channel_id == Some(*channel_id)
+            || (self.terminal_focused() && self.navigation.active_channel_id == Some(*channel_id))
         {
             return None;
         }

--- a/src/tui/state/runtime_state.rs
+++ b/src/tui/state/runtime_state.rs
@@ -30,6 +30,9 @@ pub(super) struct RuntimeUiState {
     pub(super) clipboard_paste_pending: bool,
     pub(super) copy_message_content_requested: Option<String>,
     pub(super) should_quit: bool,
+    /// Inverted so the `Default` of `false` means "focused"; terminals that
+    /// never report focus events keep the current notification behavior.
+    pub(super) terminal_focus_lost: bool,
 }
 
 impl DashboardState {
@@ -39,5 +42,13 @@ impl DashboardState {
 
     pub fn should_quit(&self) -> bool {
         self.runtime.should_quit
+    }
+
+    pub fn set_terminal_focused(&mut self, focused: bool) {
+        self.runtime.terminal_focus_lost = !focused;
+    }
+
+    pub(super) fn terminal_focused(&self) -> bool {
+        !self.runtime.terminal_focus_lost
     }
 }

--- a/src/tui/terminal.rs
+++ b/src/tui/terminal.rs
@@ -2,8 +2,9 @@ use std::io::stdout;
 
 use crossterm::{
     event::{
-        DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
-        KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+        DisableBracketedPaste, DisableFocusChange, DisableMouseCapture, EnableBracketedPaste,
+        EnableFocusChange, EnableMouseCapture, KeyboardEnhancementFlags,
+        PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
     },
     execute,
 };
@@ -14,6 +15,7 @@ pub(in crate::tui) struct TerminalRestoreGuard {
     keyboard_enhancement_enabled: bool,
     mouse_capture_enabled: bool,
     bracketed_paste_enabled: bool,
+    focus_change_enabled: bool,
 }
 
 impl TerminalRestoreGuard {
@@ -28,10 +30,12 @@ impl TerminalRestoreGuard {
         .is_ok();
         let mouse_capture_enabled = execute!(stdout(), EnableMouseCapture).is_ok();
         let bracketed_paste_enabled = execute!(stdout(), EnableBracketedPaste).is_ok();
+        let focus_change_enabled = execute!(stdout(), EnableFocusChange).is_ok();
         Ok(Self {
             keyboard_enhancement_enabled,
             mouse_capture_enabled,
             bracketed_paste_enabled,
+            focus_change_enabled,
         })
     }
 }
@@ -51,6 +55,9 @@ impl Drop for TerminalRestoreGuard {
         }
         if self.bracketed_paste_enabled {
             let _ = execute!(stdout(), DisableBracketedPaste);
+        }
+        if self.focus_change_enabled {
+            let _ = execute!(stdout(), DisableFocusChange);
         }
         ratatui::restore();
     }


### PR DESCRIPTION
Note: Slop. (But, alas, isn't it all these days?)

## Problem

Notifications are not shown for any active channel or DM one is in, even if the window is not focused. So if you remain in a DM or channel and then tab away to another app, you still receive no desktop notification for any new message, potentially missing a lot of messages unless you are actively checking.

## Change

Show notifications for the active channel if the window is not also active. (This is the normal behavior of Discord as well anyway.)

Track terminal focus via crossterm's `FocusGained`/`FocusLost` events and suppress active-channel notifications only while the terminal is actually focused:

- `TerminalRestoreGuard` enables focus reporting on startup and disables it on exit, using the same per-feature fallback pattern as mouse capture.
- A `terminal_focus_lost` flag on `RuntimeUiState` (stored inverted so `derive(Default)` means "focused" at startup).
- The suppression condition in `desktop_notification_for_event` now requires terminal focus *and* a matching active channel; all other suppression layers (mute settings, notification levels) are unchanged.
- Focus events don't mark the frame dirty, so alt-tabbing causes no redraw churn.

Terminals that don't support focus reporting degrade gracefully: the flag never flips, so behavior is identical to today.

## Notes

- Under tmux, focus events require `set -g focus-events on`.
- Known limitation (pre-existing, untouched): messages in the active channel are still auto-acked while unfocused, so unread state on other devices clears even though the desktop notification fires. Gating the ack on focus could be a follow-up.

## Testing

- Manually verified on macOS:
unfocused terminal + message in the active channel = notification fires. 
refocused terminal = silent as before; other channels unchanged in both cases.
