### PR TITLE
feat: Add built-in discord commands

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -739,6 +739,20 @@ fn start_command_loop(
                                 .await;
                         }
                     },
+                    AppCommand::SendTtsMessage {
+                        channel_id,
+                        content,
+                    } => match client.send_tts_message(channel_id, &content).await {
+                        Ok(message) => client.publish_event(message_create_event(message)).await,
+                        Err(error) => {
+                            log_app_error("send tts message failed", &error);
+                            client
+                                .publish_event(AppEvent::GatewayError {
+                                    message: format!("send tts message failed: {error}"),
+                                })
+                                .await;
+                        }
+                    },
                     AppCommand::LoadApplicationCommands { guild_id } => {
                         match client.load_application_commands(guild_id).await {
                             Ok(Some(commands)) => {

--- a/src/discord/builtin_commands.rs
+++ b/src/discord/builtin_commands.rs
@@ -1,0 +1,189 @@
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BuiltinSlashCommand {
+    Gif,
+    Tenor,
+    Tts,
+    Me,
+    Tableflip,
+    Unflip,
+    Shrug,
+    Spoiler,
+    Nick,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct BuiltinSlashCommandInfo {
+    pub kind: BuiltinSlashCommand,
+    pub name: &'static str,
+    pub description: &'static str,
+    pub replacement: &'static str,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum BuiltinSlashCommandSubmit {
+    Message { content: String, tts: bool },
+    Nickname { nickname: String },
+    Unsupported { message: String },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum BuiltinSlashCommandParse {
+    Ready(BuiltinSlashCommandSubmit),
+    Incomplete,
+    NotBuiltin,
+}
+
+const BUILTIN_SLASH_COMMANDS: &[BuiltinSlashCommandInfo] = &[
+    BuiltinSlashCommandInfo {
+        kind: BuiltinSlashCommand::Gif,
+        name: "gif",
+        description: "Search for a GIF",
+        replacement: "/gif ",
+    },
+    BuiltinSlashCommandInfo {
+        kind: BuiltinSlashCommand::Tenor,
+        name: "tenor",
+        description: "Search Tenor GIFs",
+        replacement: "/tenor ",
+    },
+    BuiltinSlashCommandInfo {
+        kind: BuiltinSlashCommand::Tts,
+        name: "tts",
+        description: "Send a text-to-speech message",
+        replacement: "/tts ",
+    },
+    BuiltinSlashCommandInfo {
+        kind: BuiltinSlashCommand::Me,
+        name: "me",
+        description: "Send an italic action message",
+        replacement: "/me ",
+    },
+    BuiltinSlashCommandInfo {
+        kind: BuiltinSlashCommand::Tableflip,
+        name: "tableflip",
+        description: "Add a table flip face ((╯°□°）╯︵ ┻━┻)",
+        replacement: "/tableflip ",
+    },
+    BuiltinSlashCommandInfo {
+        kind: BuiltinSlashCommand::Unflip,
+        name: "unflip",
+        description: "Add a table unflip face (┬─┬ ノ( ゜-゜ノ))",
+        replacement: "/unflip ",
+    },
+    BuiltinSlashCommandInfo {
+        kind: BuiltinSlashCommand::Shrug,
+        name: "shrug",
+        description: r"Add a shrug face (¯\_(ツ)_/¯)",
+        replacement: "/shrug ",
+    },
+    BuiltinSlashCommandInfo {
+        kind: BuiltinSlashCommand::Spoiler,
+        name: "spoiler",
+        description: "Send spoiler text",
+        replacement: "/spoiler ",
+    },
+    BuiltinSlashCommandInfo {
+        kind: BuiltinSlashCommand::Nick,
+        name: "nick",
+        description: "Change or clear your server nickname",
+        replacement: "/nick ",
+    },
+];
+
+pub fn builtin_slash_commands() -> &'static [BuiltinSlashCommandInfo] {
+    BUILTIN_SLASH_COMMANDS
+}
+
+pub fn parse_builtin_slash_command(content: &str) -> BuiltinSlashCommandParse {
+    let Some(rest) = content.strip_prefix('/') else {
+        return BuiltinSlashCommandParse::NotBuiltin;
+    };
+    let Some((name, argument)) = split_command_name(rest) else {
+        return BuiltinSlashCommandParse::NotBuiltin;
+    };
+    let Some(command) = BUILTIN_SLASH_COMMANDS
+        .iter()
+        .find(|command| command.name == name)
+    else {
+        return BuiltinSlashCommandParse::NotBuiltin;
+    };
+
+    match command.kind {
+        BuiltinSlashCommand::Gif | BuiltinSlashCommand::Tenor => required_argument(argument)
+            .map_or(BuiltinSlashCommandParse::Incomplete, |_| {
+                BuiltinSlashCommandParse::Ready(BuiltinSlashCommandSubmit::Unsupported {
+                    message: "GIF slash commands are not supported in Concord yet".to_owned(),
+                })
+            }),
+        BuiltinSlashCommand::Tts => {
+            required_argument(argument).map_or(BuiltinSlashCommandParse::Incomplete, |message| {
+                BuiltinSlashCommandParse::Ready(BuiltinSlashCommandSubmit::Message {
+                    content: message.to_owned(),
+                    tts: true,
+                })
+            })
+        }
+        BuiltinSlashCommand::Me => {
+            required_argument(argument).map_or(BuiltinSlashCommandParse::Incomplete, |message| {
+                BuiltinSlashCommandParse::Ready(BuiltinSlashCommandSubmit::Message {
+                    content: format!("_{message}_"),
+                    tts: false,
+                })
+            })
+        }
+        BuiltinSlashCommand::Tableflip => {
+            BuiltinSlashCommandParse::Ready(BuiltinSlashCommandSubmit::Message {
+                content: append_optional_message(argument, "(╯°□°）╯︵ ┻━┻"),
+                tts: false,
+            })
+        }
+        BuiltinSlashCommand::Unflip => {
+            BuiltinSlashCommandParse::Ready(BuiltinSlashCommandSubmit::Message {
+                content: append_optional_message(argument, "┬─┬ ノ( ゜-゜ノ)"),
+                tts: false,
+            })
+        }
+        BuiltinSlashCommand::Shrug => {
+            BuiltinSlashCommandParse::Ready(BuiltinSlashCommandSubmit::Message {
+                content: append_optional_message(argument, r"¯\_(ツ)_/¯"),
+                tts: false,
+            })
+        }
+        BuiltinSlashCommand::Spoiler => {
+            required_argument(argument).map_or(BuiltinSlashCommandParse::Incomplete, |message| {
+                BuiltinSlashCommandParse::Ready(BuiltinSlashCommandSubmit::Message {
+                    content: format!("||{message}||"),
+                    tts: false,
+                })
+            })
+        }
+        BuiltinSlashCommand::Nick => {
+            BuiltinSlashCommandParse::Ready(BuiltinSlashCommandSubmit::Nickname {
+                nickname: argument.to_owned(),
+            })
+        }
+    }
+}
+
+fn split_command_name(input: &str) -> Option<(&str, &str)> {
+    let trimmed = input.trim_start();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let name_end = trimmed.find(char::is_whitespace).unwrap_or(trimmed.len());
+    let name = &trimmed[..name_end];
+    let argument = trimmed[name_end..].trim_start();
+    Some((name, argument))
+}
+
+fn required_argument(argument: &str) -> Option<&str> {
+    (!argument.trim().is_empty()).then_some(argument)
+}
+
+fn append_optional_message(message: &str, suffix: &str) -> String {
+    if message.is_empty() {
+        suffix.to_owned()
+    } else {
+        format!("{message} {suffix}")
+    }
+}

--- a/src/discord/client.rs
+++ b/src/discord/client.rs
@@ -38,6 +38,8 @@ use super::{
 const MEMBER_SEARCH_MIN_QUERY_CHARS: usize = 2;
 const MEMBER_SEARCH_MAX_QUERY_CHARS: usize = 64;
 const MEMBER_SEARCH_MAX_LIMIT: u16 = 10;
+const OFFICIAL_WORDLE_APPLICATION_ID: u64 = 1_211_781_489_931_452_447;
+const DISCORD_LOCAL_APPLICATION_ID: &str = "-1";
 
 type ApplicationCommandCache = HashMap<Option<Id<GuildMarker>>, Vec<ApplicationCommandInfo>>;
 type MemberListRange = (u32, u32);
@@ -862,6 +864,15 @@ impl DiscordClient {
             .await
     }
 
+    pub async fn send_tts_message(
+        &self,
+        channel_id: Id<ChannelMarker>,
+        content: &str,
+    ) -> Result<MessageInfo> {
+        self.ensure_can_send_tts_message(channel_id)?;
+        self.rest.send_tts_message(channel_id, content).await
+    }
+
     fn ensure_can_send_message(
         &self,
         channel_id: Id<ChannelMarker>,
@@ -882,6 +893,22 @@ impl DiscordClient {
         if !attachments.is_empty() && !state.can_attach_in_channel(channel) {
             return Err(AppError::DiscordRequest(
                 "cannot attach files in channel".to_owned(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn ensure_can_send_tts_message(&self, channel_id: Id<ChannelMarker>) -> Result<()> {
+        let state = self
+            .state
+            .read()
+            .expect("discord state lock is not poisoned");
+        let Some(channel) = state.channel(channel_id) else {
+            return Ok(());
+        };
+        if !state.can_send_tts_in_channel(channel) {
+            return Err(AppError::DiscordRequest(
+                "cannot send text-to-speech messages in channel".to_owned(),
             ));
         }
         Ok(())
@@ -1313,6 +1340,10 @@ impl DiscordClient {
         guild_id: Option<Id<GuildMarker>>,
         commands: Vec<ApplicationCommandInfo>,
     ) -> Vec<ApplicationCommandInfo> {
+        let commands = commands
+            .into_iter()
+            .filter(|command| !is_hidden_default_application_command(command))
+            .collect::<Vec<_>>();
         self.record_application_commands(guild_id, commands.clone());
         commands
             .into_iter()
@@ -1326,6 +1357,26 @@ impl DiscordClient {
             .expect("application command request lock is not poisoned")
             .remove(&guild_id);
     }
+}
+
+fn is_hidden_default_application_command(command: &ApplicationCommandInfo) -> bool {
+    match command.name.as_str() {
+        "giphy" | "msg" | "play" => is_discord_default_application(command),
+        "wordle" => command.application_id.get() == OFFICIAL_WORDLE_APPLICATION_ID,
+        _ => false,
+    }
+}
+
+fn is_discord_default_application(command: &ApplicationCommandInfo) -> bool {
+    command
+        .raw
+        .get("application_id")
+        .and_then(|value| value.as_str())
+        .is_some_and(|id| id == DISCORD_LOCAL_APPLICATION_ID)
+        || command
+            .application_name
+            .as_deref()
+            .is_some_and(|name| name.eq_ignore_ascii_case("Discord"))
 }
 
 #[cfg(test)]

--- a/src/discord/client/tests.rs
+++ b/src/discord/client/tests.rs
@@ -17,7 +17,8 @@ use crate::{
 use serde_json::{Value, json};
 
 use super::{
-    DiscordClient, MEMBER_SEARCH_MAX_LIMIT, MEMBER_SEARCH_MAX_QUERY_CHARS, validate_token_header,
+    DiscordClient, MEMBER_SEARCH_MAX_LIMIT, MEMBER_SEARCH_MAX_QUERY_CHARS,
+    OFFICIAL_WORDLE_APPLICATION_ID, validate_token_header,
 };
 
 #[tokio::test]
@@ -489,27 +490,49 @@ fn application_command_metadata_keeps_raw_backend_owned() {
     let client = DiscordClient::new("test-token".to_owned()).expect("token is valid header");
     let guild_id = Some(Id::new(1));
     let command = application_command("echo");
-    let mut selected_command = application_command("echo");
-    selected_command.id = Id::new(101);
-    selected_command.application_id = Id::new(201);
-    selected_command.raw = json!({
-        "id": "101",
-        "application_id": "201",
-        "version": "1",
-        "name": "echo",
-    });
+    let selected_command = application_command_with_ids("echo", "TestBot", 101, 201);
+    let third_party_play = application_command_with_ids("play", "MusicBot", 102, 202);
+    let third_party_wordle = application_command_with_ids("wordle", "WordleBot", 103, 203);
+    let discord_play = application_command_with_ids("play", "Discord", 104, 204);
+    let official_wordle =
+        application_command_with_ids("wordle", "Wordle", 105, OFFICIAL_WORDLE_APPLICATION_ID);
 
-    let tui_commands = client
-        .record_application_commands_for_tui(guild_id, vec![command, selected_command.clone()]);
+    let tui_commands = client.record_application_commands_for_tui(
+        guild_id,
+        vec![
+            command,
+            selected_command.clone(),
+            third_party_play,
+            third_party_wordle,
+            discord_play,
+            official_wordle,
+        ],
+    );
 
     assert_eq!(tui_commands[0].raw, Value::Null);
+    assert_eq!(
+        command_sources(&tui_commands),
+        vec![
+            ("echo", Some("TestBot")),
+            ("echo", Some("TestBot")),
+            ("play", Some("MusicBot")),
+            ("wordle", Some("WordleBot")),
+        ]
+    );
     let commands = client
         .application_commands
         .lock()
         .expect("application command cache lock is not poisoned");
+    let cached_commands = commands.get(&guild_id).expect("backend cache");
+    assert_eq!(cached_commands[0].raw["name"], "echo");
     assert_eq!(
-        commands.get(&guild_id).expect("backend cache")[0].raw["name"],
-        "echo"
+        command_sources(cached_commands),
+        vec![
+            ("echo", Some("TestBot")),
+            ("echo", Some("TestBot")),
+            ("play", Some("MusicBot")),
+            ("wordle", Some("WordleBot")),
+        ]
     );
     drop(commands);
 
@@ -814,19 +837,44 @@ fn user_profile(user_id: Id<UserMarker>) -> UserProfileInfo {
 }
 
 fn application_command(name: &str) -> crate::discord::ApplicationCommandInfo {
+    application_command_with_app_name(name, "TestBot")
+}
+
+fn application_command_with_app_name(
+    name: &str,
+    application_name: &str,
+) -> crate::discord::ApplicationCommandInfo {
+    application_command_with_ids(name, application_name, 100, 200)
+}
+
+fn application_command_with_ids(
+    name: &str,
+    application_name: &str,
+    command_id: u64,
+    application_id: u64,
+) -> crate::discord::ApplicationCommandInfo {
     crate::discord::ApplicationCommandInfo {
-        application_id: Id::new(200),
+        application_id: Id::new(application_id),
         version: "1".to_owned(),
-        application_name: Some("TestBot".to_owned()),
+        application_name: Some(application_name.to_owned()),
         description: format!("{name} command"),
         raw: json!({
-            "id": "100",
-            "application_id": "200",
+            "id": command_id.to_string(),
+            "application_id": application_id.to_string(),
             "version": "1",
             "name": name,
         }),
-        ..crate::discord::ApplicationCommandInfo::test(Id::new(100), name)
+        ..crate::discord::ApplicationCommandInfo::test(Id::new(command_id), name)
     }
+}
+
+fn command_sources(
+    commands: &[crate::discord::ApplicationCommandInfo],
+) -> Vec<(&str, Option<&str>)> {
+    commands
+        .iter()
+        .map(|command| (command.name.as_str(), command.application_name.as_deref()))
+        .collect()
 }
 
 fn channel_upsert_event() -> AppEvent {

--- a/src/discord/commands.rs
+++ b/src/discord/commands.rs
@@ -484,6 +484,10 @@ pub enum AppCommand {
         reply_to: Option<Id<MessageMarker>>,
         attachments: Vec<MessageAttachmentUpload>,
     },
+    SendTtsMessage {
+        channel_id: Id<ChannelMarker>,
+        content: String,
+    },
     LoadApplicationCommands {
         guild_id: Option<Id<GuildMarker>>,
     },

--- a/src/discord/mod.rs
+++ b/src/discord/mod.rs
@@ -1,5 +1,6 @@
 mod application_commands;
 mod auth_http;
+mod builtin_commands;
 mod channel;
 mod client;
 mod commands;
@@ -32,6 +33,10 @@ pub use application_commands::{
     ApplicationCommandInvocation, ApplicationCommandOptionInfo,
     application_command_content_is_complete, application_command_option_scope,
     parsed_application_command_option_names,
+};
+pub use builtin_commands::{
+    BuiltinSlashCommandInfo, BuiltinSlashCommandParse, BuiltinSlashCommandSubmit,
+    builtin_slash_commands, parse_builtin_slash_command,
 };
 pub use channel::{
     ChannelInfo, ChannelRecipientInfo, PermissionOverwriteInfo, PermissionOverwriteKind,

--- a/src/discord/permission/state.rs
+++ b/src/discord/permission/state.rs
@@ -11,6 +11,7 @@ use crate::discord::state::{ChannelState, DiscordState};
 /// does not need to depend on twilight's bitflags.
 const PERMISSION_VIEW_CHANNEL: u64 = 0x0000_0000_0000_0400;
 const PERMISSION_SEND_MESSAGES: u64 = 0x0000_0000_0000_0800;
+const PERMISSION_SEND_TTS_MESSAGES: u64 = 0x0000_0000_0000_1000;
 const PERMISSION_MANAGE_MESSAGES: u64 = 0x0000_0000_0000_2000;
 const PERMISSION_ATTACH_FILES: u64 = 0x0000_0000_0000_8000;
 const PERMISSION_READ_MESSAGE_HISTORY: u64 = 0x0000_0000_0001_0000;
@@ -48,6 +49,15 @@ impl DiscordState {
         let permissions = self.effective_permissions_for_channel(channel);
         permission_set(permissions, PERMISSION_VIEW_CHANNEL)
             && permission_set(permissions, PERMISSION_SEND_MESSAGES)
+    }
+
+    /// Whether the user can send Discord text-to-speech messages in `channel`.
+    /// Discord treats TTS as its own permission in addition to normal sending.
+    pub fn can_send_tts_in_channel(&self, channel: &ChannelState) -> bool {
+        let permissions = self.effective_permissions_for_channel(channel);
+        permission_set(permissions, PERMISSION_VIEW_CHANNEL)
+            && permission_set(permissions, PERMISSION_SEND_MESSAGES)
+            && permission_set(permissions, PERMISSION_SEND_TTS_MESSAGES)
     }
 
     /// Whether the user can upload attachments in `channel`. Same fall-back

--- a/src/discord/rest.rs
+++ b/src/discord/rest.rs
@@ -97,6 +97,26 @@ impl DiscordRest {
         validate_message_payload(content, attachments)?;
         let body = message_request_body(content, reply_to, attachments);
 
+        self.send_message_body(channel_id, body, attachments).await
+    }
+
+    pub async fn send_tts_message(
+        &self,
+        channel_id: Id<ChannelMarker>,
+        content: &str,
+    ) -> Result<MessageInfo> {
+        validate_message_content(content)?;
+        let body = message_request_body_with_tts(content, None, &[], true);
+
+        self.send_message_body(channel_id, body, &[]).await
+    }
+
+    async fn send_message_body(
+        &self,
+        channel_id: Id<ChannelMarker>,
+        body: Value,
+        attachments: &[MessageAttachmentUpload],
+    ) -> Result<MessageInfo> {
         let request = self
             .raw_http
             .post(format!(
@@ -1541,7 +1561,19 @@ fn message_request_body(
     reply_to: Option<Id<MessageMarker>>,
     attachments: &[MessageAttachmentUpload],
 ) -> Value {
+    message_request_body_with_tts(content, reply_to, attachments, false)
+}
+
+fn message_request_body_with_tts(
+    content: &str,
+    reply_to: Option<Id<MessageMarker>>,
+    attachments: &[MessageAttachmentUpload],
+    tts: bool,
+) -> Value {
     let mut body = json!({ "content": content });
+    if tts {
+        body["tts"] = Value::Bool(true);
+    }
     if let Some(message_id) = reply_to {
         body["message_reference"] = json!({ "message_id": message_id.to_string() });
     }

--- a/src/discord/rest/tests.rs
+++ b/src/discord/rest/tests.rs
@@ -17,11 +17,12 @@ use crate::{
             ForumPostPage, ForumSearchSort, REACTION_USERS_MAX_PAGES,
             application_command_interaction_body, application_command_option_body,
             is_search_index_warming, merge_forum_pages, message_multipart_form,
-            message_request_body, message_search_date_snowflake_bounds,
-            message_search_query_params, mute_request_body, next_reaction_users_after,
-            parse_application_command_index, parse_forum_first_messages, parse_forum_threads,
-            parse_user_profile_response, poll_vote_request_body, reaction_route_component,
-            upload_content_type, validate_message_content, validate_message_payload,
+            message_request_body, message_request_body_with_tts,
+            message_search_date_snowflake_bounds, message_search_query_params, mute_request_body,
+            next_reaction_users_after, parse_application_command_index, parse_forum_first_messages,
+            parse_forum_threads, parse_user_profile_response, poll_vote_request_body,
+            reaction_route_component, upload_content_type, validate_message_content,
+            validate_message_payload,
         },
     },
 };
@@ -51,6 +52,12 @@ fn validates_attachment_only_message_payload() {
     assert_eq!(body["message_reference"]["message_id"], "44");
     assert_eq!(body["attachments"][0]["id"], 0);
     assert_eq!(body["attachments"][0]["filename"], "cat.png");
+}
+
+#[test]
+fn message_request_body_sets_tts_only_when_requested() {
+    let tts = message_request_body_with_tts("hello", None, &[], true);
+    assert_eq!(tts["tts"], true);
 }
 
 #[test]

--- a/src/discord/state/tests/permissions.rs
+++ b/src/discord/state/tests/permissions.rs
@@ -4,6 +4,7 @@ use super::*;
 // verify Discord's documented bit values instead of reusing the code under test.
 const VIEW_CHANNEL: u64 = 0x0000_0000_0000_0400;
 const SEND_MESSAGES: u64 = 0x0000_0000_0000_0800;
+const SEND_TTS_MESSAGES: u64 = 0x0000_0000_0000_1000;
 const MANAGE_MESSAGES: u64 = 0x0000_0000_0000_2000;
 const ATTACH_FILES: u64 = 0x0000_0000_0000_8000;
 const READ_MESSAGE_HISTORY: u64 = 0x0000_0000_0001_0000;
@@ -507,6 +508,29 @@ fn cannot_attach_when_role_overwrite_denies_attach_files() {
     let ch = state.channel(channel).expect("channel");
     assert!(state.can_send_in_channel(ch));
     assert!(!state.can_attach_in_channel(ch));
+}
+
+#[test]
+fn cannot_send_tts_when_role_overwrite_denies_send_tts_messages() {
+    let me = Id::new(10);
+    let owner = Id::new(11);
+    let guild = Id::new(1);
+    let channel = Id::new(2);
+    let state = guild_with_permissions(
+        owner,
+        me,
+        guild,
+        channel,
+        vec![],
+        vec![RoleInfo {
+            permissions: VIEW_CHANNEL | SEND_MESSAGES | SEND_TTS_MESSAGES,
+            ..RoleInfo::test(Id::new(guild.get()), "@everyone")
+        }],
+        vec![perm_role(guild.get(), 0, SEND_TTS_MESSAGES)],
+    );
+    let ch = state.channel(channel).expect("channel");
+    assert!(state.can_send_in_channel(ch));
+    assert!(!state.can_send_tts_in_channel(ch));
 }
 
 #[test]

--- a/src/tui/message/format.rs
+++ b/src/tui/message/format.rs
@@ -1358,14 +1358,22 @@ fn parse_inline_markdown(rendered: RenderedText) -> InlineMarkdownText {
 }
 
 fn next_inline_markdown_marker(value: &str, cursor: usize) -> Option<usize> {
-    ["`", "***", "**", "*"]
+    ["`", "***", "**", "*", "_"]
         .into_iter()
-        .filter_map(|marker| {
-            value[cursor..]
-                .find(marker)
-                .map(|relative| cursor.saturating_add(relative))
-        })
+        .filter_map(|marker| next_inline_markdown_marker_for(value, cursor, marker))
         .min()
+}
+
+fn next_inline_markdown_marker_for(value: &str, cursor: usize, marker: &str) -> Option<usize> {
+    let mut search_start = cursor;
+    while let Some(relative) = value[search_start..].find(marker) {
+        let index = search_start.saturating_add(relative);
+        if marker != "_" || should_open_underscore_marker(value, index) {
+            return Some(index);
+        }
+        search_start = index.saturating_add(marker.len());
+    }
+    None
 }
 
 fn inline_markdown_marker_at(value: &str, cursor: usize) -> Option<(&'static str, Style)> {
@@ -1381,17 +1389,23 @@ fn inline_markdown_marker_at(value: &str, cursor: usize) -> Option<(&'static str
         Some(("**", Style::default().add_modifier(Modifier::BOLD)))
     } else if rest.starts_with('*') {
         Some(("*", Style::default().add_modifier(Modifier::ITALIC)))
+    } else if rest.starts_with('_') && should_open_underscore_marker(value, cursor) {
+        Some(("_", Style::default().add_modifier(Modifier::ITALIC)))
     } else {
         None
     }
 }
 
 fn find_inline_markdown_closer(value: &str, start: usize, marker: &str) -> Option<usize> {
-    if marker == "*" {
+    if matches!(marker, "*" | "_") {
         let mut search_start = start;
-        while let Some(relative) = value[search_start..].find('*') {
+        while let Some(relative) = value[search_start..].find(marker) {
             let index = search_start.saturating_add(relative);
-            if !value[index..].starts_with("**") {
+            if marker == "_" && !should_close_underscore_marker(value, index) {
+                search_start = index.saturating_add(1);
+                continue;
+            }
+            if marker == "_" || !value[index..].starts_with("**") {
                 return (start < index).then_some(index);
             }
             search_start = index.saturating_add(1);
@@ -1403,6 +1417,24 @@ fn find_inline_markdown_closer(value: &str, start: usize, marker: &str) -> Optio
             .map(|relative| start.saturating_add(relative))
             .filter(|index| start < *index)
     }
+}
+
+fn should_open_underscore_marker(value: &str, index: usize) -> bool {
+    let previous = value[..index].chars().next_back();
+    let next = value[index + '_'.len_utf8()..].chars().next();
+    previous.is_none_or(|value| !is_inline_markdown_word_char(value))
+        && next.is_some_and(|value| !value.is_whitespace())
+}
+
+fn should_close_underscore_marker(value: &str, index: usize) -> bool {
+    let previous = value[..index].chars().next_back();
+    let next = value[index + '_'.len_utf8()..].chars().next();
+    previous.is_some_and(|value| !value.is_whitespace())
+        && next.is_none_or(|value| !is_inline_markdown_word_char(value))
+}
+
+fn is_inline_markdown_word_char(value: char) -> bool {
+    value.is_alphanumeric()
 }
 
 fn push_source_segment(

--- a/src/tui/state/composer/completions.rs
+++ b/src/tui/state/composer/completions.rs
@@ -5,7 +5,7 @@ use crate::discord::ids::{
 
 use crate::discord::{
     ApplicationCommandIdentity, ApplicationCommandInfo, ApplicationCommandOptionInfo, ChannelState,
-    CustomEmojiInfo, PresenceStatus, RoleState,
+    CustomEmojiInfo, PresenceStatus, RoleState, builtin_slash_commands,
 };
 
 use super::super::{MemberEntry, emoji::custom_emoji_can_be_used_directly};
@@ -85,7 +85,23 @@ pub struct CommandPickerEntry {
     pub label: String,
     pub detail: String,
     pub replacement: String,
+    pub top_level: bool,
     pub command_identity: Option<ApplicationCommandIdentity>,
+}
+
+pub(super) fn build_builtin_command_candidates(query: &str) -> Vec<CommandPickerEntry> {
+    let needle = query.to_ascii_lowercase();
+    builtin_slash_commands()
+        .iter()
+        .filter(|command| needle.is_empty() || command.name.starts_with(&needle))
+        .map(|command| CommandPickerEntry {
+            label: format!("/{}", command.name),
+            detail: command.description.to_owned(),
+            replacement: command.replacement.to_owned(),
+            top_level: true,
+            command_identity: None,
+        })
+        .collect()
 }
 
 pub(super) fn build_command_candidates(
@@ -113,6 +129,7 @@ pub(super) fn build_command_candidates(
                     label: format!("/{}", command.name),
                     detail: command_picker_detail(command),
                     replacement: format!("/{} ", command.name),
+                    top_level: true,
                     command_identity: Some(command.identity()),
                 },
             ))
@@ -144,6 +161,7 @@ pub(super) fn build_command_option_candidates(
             label: command_option_label(option),
             detail: command_option_detail(option),
             replacement: command_option_replacement(option),
+            top_level: false,
             command_identity: None,
         })
         .collect()
@@ -202,6 +220,7 @@ pub(super) fn build_command_choice_candidates(
                     .map(str::to_owned)
                     .unwrap_or_else(|| choice.value.to_string())
             ),
+            top_level: false,
             command_identity: None,
         })
         .collect()

--- a/src/tui/state/composer/state.rs
+++ b/src/tui/state/composer/state.rs
@@ -7,9 +7,11 @@ use crate::discord::ids::{
 use crate::discord::{
     APPLICATION_COMMAND_CHANNEL_KIND, APPLICATION_COMMAND_MENTIONABLE_KIND,
     APPLICATION_COMMAND_ROLE_KIND, APPLICATION_COMMAND_USER_KIND, ApplicationCommandIdentity,
-    ApplicationCommandInfo, ApplicationCommandInvocation, MAX_UPLOAD_ATTACHMENT_COUNT,
-    MessageAttachmentUpload, application_command_content_is_complete,
-    application_command_option_scope, parsed_application_command_option_names,
+    ApplicationCommandInfo, ApplicationCommandInvocation, BuiltinSlashCommandParse,
+    BuiltinSlashCommandSubmit, GlobalUserProfileUpdate, GuildUserProfileUpdate,
+    MAX_UPLOAD_ATTACHMENT_COUNT, MessageAttachmentUpload, UserProfileUpdate,
+    application_command_content_is_complete, application_command_option_scope,
+    parse_builtin_slash_command, parsed_application_command_option_names,
 };
 
 use super::super::{
@@ -18,10 +20,10 @@ use super::super::{
 };
 use super::completions::{
     ComposerEmojiImageCompletion, EmojiCompletion, MentionCompletion,
-    build_channel_mention_candidates, build_command_candidates, build_command_choice_candidates,
-    build_command_option_candidates, build_emoji_candidates, build_mention_candidates,
-    expand_composer_completions, expand_emoji_shortcodes, is_command_query_char,
-    is_emoji_query_char, is_mention_query_char, move_picker_selection,
+    build_builtin_command_candidates, build_channel_mention_candidates, build_command_candidates,
+    build_command_choice_candidates, build_command_option_candidates, build_emoji_candidates,
+    build_mention_candidates, expand_composer_completions, expand_emoji_shortcodes,
+    is_command_query_char, is_emoji_query_char, is_mention_query_char, move_picker_selection,
     should_start_completion_query,
 };
 use crate::discord::AppCommand;
@@ -180,6 +182,14 @@ impl DashboardState {
         match self.selected_channel_state() {
             Some(channel) if channel.is_forum() => false,
             Some(channel) => self.discord.cache.can_send_in_channel(channel),
+            None => true,
+        }
+    }
+
+    fn can_send_tts_in_selected_channel(&self) -> bool {
+        match self.selected_channel_state() {
+            Some(channel) if channel.is_forum() => false,
+            Some(channel) => self.discord.cache.can_send_tts_in_channel(channel),
             None => true,
         }
     }
@@ -392,6 +402,20 @@ impl DashboardState {
         }
 
         if !has_attachments && self.composer.reply_target_message_id.is_none() {
+            match self.builtin_slash_command_submit_for_content(&content, channel_id) {
+                BuiltinCommandSubmit::Ready(command) => {
+                    self.clear_submitted_composer_text();
+                    self.composer.reply_target_message_id = None;
+                    self.composer.pending_composer_attachments.clear();
+                    return Some(command);
+                }
+                BuiltinCommandSubmit::Incomplete => return None,
+                BuiltinCommandSubmit::Error(message) => {
+                    self.show_error_toast(message, std::time::Instant::now());
+                    return None;
+                }
+                BuiltinCommandSubmit::NotCommand => {}
+            }
             match self.application_command_submit_for_content(&content) {
                 ApplicationCommandSubmit::Ready(interaction) => {
                     self.clear_submitted_composer_text();
@@ -518,8 +542,7 @@ impl DashboardState {
         self.composer
             .composer_command_candidates
             .get(self.composer.composer_command_selected)
-            .and_then(|entry| entry.command_identity)
-            .is_some()
+            .is_some_and(|entry| entry.top_level)
     }
 
     pub(in crate::tui) fn composer_command_can_submit(&self) -> bool {
@@ -658,8 +681,8 @@ impl DashboardState {
         }
 
         self.replace_composer_range(command_start..cursor, &entry.replacement);
-        if let Some(identity) = entry.command_identity {
-            self.composer.composer_selected_command_identity = Some(identity);
+        if entry.top_level {
+            self.composer.composer_selected_command_identity = entry.command_identity;
         }
         self.close_composer_command_query();
         self.refresh_active_mention_query();
@@ -928,7 +951,9 @@ impl DashboardState {
         if token_start == 0 {
             let query = token.strip_prefix('/')?;
             if query.chars().all(is_command_query_char) {
-                return Some((0, build_command_candidates(query, commands)));
+                let mut candidates = build_builtin_command_candidates(query);
+                candidates.extend(build_command_candidates(query, commands));
+                return Some((0, candidates));
             }
             return None;
         }
@@ -1009,6 +1034,7 @@ impl DashboardState {
                     super::completions::MentionPickerTarget::Channel(_) => "channel".to_owned(),
                 },
                 replacement: format!("{} ", entry.target.wire_format()),
+                top_level: false,
                 command_identity: None,
             })
             .collect()
@@ -1043,6 +1069,71 @@ impl DashboardState {
         self.application_commands_for_selected_channel()
             .iter()
             .find(|command| command.name == name)
+    }
+
+    fn builtin_slash_command_submit_for_content(
+        &self,
+        content: &str,
+        channel_id: Id<ChannelMarker>,
+    ) -> BuiltinCommandSubmit {
+        match parse_builtin_slash_command(content) {
+            BuiltinSlashCommandParse::Ready(BuiltinSlashCommandSubmit::Message {
+                content,
+                tts,
+            }) => {
+                if tts {
+                    if !self.can_send_tts_in_selected_channel() {
+                        return BuiltinCommandSubmit::Error(
+                            "Cannot send text-to-speech messages in this channel".to_owned(),
+                        );
+                    }
+                    BuiltinCommandSubmit::Ready(AppCommand::SendTtsMessage {
+                        channel_id,
+                        content,
+                    })
+                } else {
+                    BuiltinCommandSubmit::Ready(AppCommand::SendMessage {
+                        channel_id,
+                        content,
+                        reply_to: None,
+                        attachments: Vec::new(),
+                    })
+                }
+            }
+            BuiltinSlashCommandParse::Ready(BuiltinSlashCommandSubmit::Nickname { nickname }) => {
+                let Some(user_id) = self.current_user_id() else {
+                    return BuiltinCommandSubmit::Error(
+                        "Cannot change nickname before the current user is loaded".to_owned(),
+                    );
+                };
+                let Some(guild_id) = self
+                    .selected_channel_state()
+                    .and_then(|channel| channel.guild_id)
+                else {
+                    return BuiltinCommandSubmit::Error(
+                        "/nick can only be used in a server channel".to_owned(),
+                    );
+                };
+
+                BuiltinCommandSubmit::Ready(AppCommand::UpdateUserProfile {
+                    update: UserProfileUpdate {
+                        user_id,
+                        guild_id: Some(guild_id),
+                        global: GlobalUserProfileUpdate::default(),
+                        guild: Some(GuildUserProfileUpdate {
+                            guild_id,
+                            nickname: Some(nickname),
+                            pronouns: None,
+                        }),
+                    },
+                })
+            }
+            BuiltinSlashCommandParse::Ready(BuiltinSlashCommandSubmit::Unsupported { message }) => {
+                BuiltinCommandSubmit::Error(message)
+            }
+            BuiltinSlashCommandParse::Incomplete => BuiltinCommandSubmit::Incomplete,
+            BuiltinSlashCommandParse::NotBuiltin => BuiltinCommandSubmit::NotCommand,
+        }
     }
 
     fn application_command_submit_for_content(&self, content: &str) -> ApplicationCommandSubmit {
@@ -1163,6 +1254,13 @@ impl DashboardState {
 enum ApplicationCommandSubmit {
     Ready(ApplicationCommandInvocation),
     Incomplete,
+    NotCommand,
+}
+
+enum BuiltinCommandSubmit {
+    Ready(AppCommand),
+    Incomplete,
+    Error(String),
     NotCommand,
 }
 

--- a/src/tui/state/tests/composer.rs
+++ b/src/tui/state/tests/composer.rs
@@ -47,6 +47,15 @@ fn state_with_application_command(command: ApplicationCommandInfo) -> DashboardS
     state
 }
 
+fn submit_composer_text(input: &str) -> Option<AppCommand> {
+    let mut state = state_with_writable_channel();
+    state.start_composer();
+    for value in input.chars() {
+        state.push_composer_char(value);
+    }
+    state.submit_composer()
+}
+
 fn state_with_command_mentions(command: ApplicationCommandInfo) -> DashboardState {
     let me: Id<UserMarker> = Id::new(10);
     let guild: Id<GuildMarker> = Id::new(1);
@@ -208,6 +217,71 @@ fn debug_channel_visibility_reports_active_guild_counts() {
             visible: 0,
             hidden: 1,
         }
+    );
+}
+
+#[test]
+fn submit_builtin_text_slash_commands_as_messages() {
+    for (input, expected) in [
+        ("/me waves", "_waves_"),
+        ("/spoiler secret words", "||secret words||"),
+        ("/shrug hello", r"hello ¯\_(ツ)_/¯"),
+    ] {
+        assert_eq!(
+            submit_composer_text(input),
+            Some(AppCommand::SendMessage {
+                channel_id: Id::new(2),
+                content: expected.to_owned(),
+                reply_to: None,
+                attachments: Vec::new(),
+            }),
+            "{input:?} should send transformed content",
+        );
+    }
+}
+
+#[test]
+fn submit_builtin_tts_and_nick_commands_use_specific_app_commands() {
+    assert_eq!(
+        submit_composer_text("/tts hello there"),
+        Some(AppCommand::SendTtsMessage {
+            channel_id: Id::new(2),
+            content: "hello there".to_owned(),
+        })
+    );
+
+    for (input, expected_nick) in [("/nick Neo Prime", "Neo Prime"), ("/nick", "")] {
+        let Some(AppCommand::UpdateUserProfile { update }) = submit_composer_text(input) else {
+            panic!("{input:?} should update the current user's guild nickname");
+        };
+        assert_eq!(update.user_id, Id::new(10));
+        assert_eq!(update.guild_id, Some(Id::new(1)));
+        assert_eq!(
+            update.guild.and_then(|guild| guild.nickname),
+            Some(expected_nick.to_owned())
+        );
+    }
+}
+
+#[test]
+fn builtin_command_picker_precedes_app_commands_and_blocks_gif_send() {
+    let mut state = state_with_application_command(application_command("gif", Vec::new()));
+    type_composer_text(&mut state, "/gi");
+    let labels = state
+        .composer_command_candidates()
+        .into_iter()
+        .map(|entry| entry.label)
+        .collect::<Vec<_>>();
+
+    assert_eq!(labels.first().map(String::as_str), Some("/gif"));
+
+    state.clear_composer_input();
+    type_composer_text(&mut state, "/gif cats");
+
+    assert_eq!(state.submit_composer(), None);
+    assert_eq!(
+        state.toast_message().map(|toast| toast.text),
+        Some("GIF slash commands are not supported in Concord yet")
     );
 }
 

--- a/src/tui/state/tests/fixtures.rs
+++ b/src/tui/state/tests/fixtures.rs
@@ -16,6 +16,8 @@ use crate::discord::{
 
 pub(super) const PERM_ADD_REACTIONS: u64 = 0x0000_0000_0000_0040;
 pub(super) const PERM_VIEW_CHANNEL: u64 = 0x0000_0000_0000_0400;
+pub(super) const PERM_SEND_MESSAGES: u64 = 0x0000_0000_0000_0800;
+pub(super) const PERM_SEND_TTS_MESSAGES: u64 = 0x0000_0000_0000_1000;
 pub(super) const PERM_MANAGE_MESSAGES: u64 = 0x0000_0000_0000_2000;
 pub(super) const PERM_READ_MESSAGE_HISTORY: u64 = 0x0000_0000_0001_0000;
 pub(super) const PERM_PIN_MESSAGES: u64 = 0x0008_0000_0000_0000;
@@ -226,7 +228,7 @@ pub(super) fn state_with_view_denied_channel() -> DashboardState {
     }])
 }
 
-/// Build a guild with a single channel where @everyone has VIEW + SEND
+/// Build a guild with a single channel where @everyone has VIEW + SEND + TTS
 /// (no overwrites), so the composer should open and submit normally.
 pub(super) fn state_with_writable_channel() -> DashboardState {
     guild_state_with_overwrites(Vec::new())
@@ -349,7 +351,11 @@ pub(super) fn guild_state_with_overwrites(
         }],
         members: vec![member_info(me, "me")],
         presences: Vec::new(),
-        roles: vec![role_info(Id::new(guild.get()), "@everyone", 0x400 | 0x800)], // VIEW + SEND
+        roles: vec![role_info(
+            Id::new(guild.get()),
+            "@everyone",
+            PERM_VIEW_CHANNEL | PERM_SEND_MESSAGES | PERM_SEND_TTS_MESSAGES,
+        )],
         emojis: Vec::new(),
     });
     state.activate_guild(ActiveGuildScope::Guild(guild));
@@ -387,7 +393,11 @@ pub(super) fn state_with_writable_channel_and_members() -> DashboardState {
             (Id::new(22), PresenceStatus::Online),
             (Id::new(23), PresenceStatus::Online),
         ],
-        roles: vec![role_info(Id::new(guild.get()), "@everyone", 0x400 | 0x800)],
+        roles: vec![role_info(
+            Id::new(guild.get()),
+            "@everyone",
+            PERM_VIEW_CHANNEL | PERM_SEND_MESSAGES | PERM_SEND_TTS_MESSAGES,
+        )],
         emojis: Vec::new(),
     });
     state.activate_guild(ActiveGuildScope::Guild(guild));

--- a/src/tui/ui/tests/messages.rs
+++ b/src/tui/ui/tests/messages.rs
@@ -521,7 +521,7 @@ fn message_content_preserves_explicit_newlines() {
 #[test]
 fn message_content_applies_supported_markdown_formatting() {
     let message = message_with_content(Some(
-            "# Project Update\n## Highlights\n### Detail\nMessage body\n> Keep the layout calm\n>\nNext paragraph\n- First action\n* Alternate action\nUse **bold**, *italic*, ***both***, and `code` text\n```rust\nlet answer = 42;\n**not bold in code**\n```\nAfter\n```css\nTEST```\n\n```cs\nsadfasdf\n```\n\n```css\nzdasfffaewfewf\n\n```"
+            "# Project Update\n## Highlights\n### Detail\nMessage body\n> Keep the layout calm\n>\nNext paragraph\n- First action\n* Alternate action\nUse **bold**, *italic*, _under italic_, ***both***, `code`, and snake_case text\n```rust\nlet answer = 42;\n**not bold in code**\n```\nAfter\n```css\nTEST```\n\n```cs\nsadfasdf\n```\n\n```css\nzdasfffaewfewf\n\n```"
             .to_owned(),
     ));
 
@@ -539,7 +539,7 @@ fn message_content_applies_supported_markdown_formatting() {
             "Next paragraph",
             "• First action",
             "• Alternate action",
-            "Use bold, italic, both, and code text",
+            "Use bold, italic, under italic, both, code, and snake_case text",
             "╭─ rust ───────────────╮",
             "│ let answer = 42;     │",
             "│ **not bold in code** │",
@@ -602,6 +602,12 @@ fn message_content_applies_supported_markdown_formatting() {
         .find(|span| span.content == "italic")
         .expect("italic span should be present");
     assert!(italic.style.add_modifier.contains(Modifier::ITALIC));
+
+    let under_italic = inline_spans
+        .iter()
+        .find(|span| span.content == "under italic")
+        .expect("underscore italic span should be present");
+    assert!(under_italic.style.add_modifier.contains(Modifier::ITALIC));
 
     let bold_italic = inline_spans
         .iter()


### PR DESCRIPTION
<!--
Thanks for the contribution. Please keep the subject under ~72 characters
and use a semantic prefix (feat:, fix:, refactor:, docs:, chore:, test:).

By submitting this PR you agree it will be distributed under GPL-3.0-only.
-->

## Summary

<!-- What does this change do, in one or two sentences? -->

## Why

<!-- The motivation. Link the issue it closes, e.g. "Closes #123". -->
<!-- Feature additions must have a related issue first. Feature PRs without a related issue may be closed without review. -->

## How

<!-- Notable implementation choices and any non-obvious trade-offs. -->

## Testing

<!-- How you verified the change. Mention the OS, terminal, and graphics protocol used for manual checks. -->

- [ ] `cargo fmt --all --check`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo test --all-features`
- [ ] Manual test in a real terminal (describe below)

## Screenshots or recordings

<!-- For UI changes, attach a screenshot or asciinema/gif. Delete this section if not applicable. -->

## Checklist

- [ ] One logical change per PR.
- [ ] Link a related issue.
- [ ] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [ ] Change does not add self-bot automation, mass actions, or scraping.
- [ ] Updated `README.md`, if behavior or workflows changed.
