### PR TITLE
Add auto label github action for gh-cli created issues

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,5 @@
+# .github/labeler.yml
+enhancement:
+  - '/feat.*/'
+bug:
+  - '/bug.*/'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,5 @@
 # .github/labeler.yml
 enhancement:
-  - '/^feat/i'
+  - '/^feat:/i'
 bug:
-  - '/^bug/i'
+  - '/^bug:/i'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,5 @@
 # .github/labeler.yml
 enhancement:
-  - '/feat.*/'
+  - '/^feat/i'
 bug:
-  - '/bug.*/'
+  - '/^bug/i'

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,21 @@
+# .github/workflows/issue-labeler.yml
+name: "Issue Labeler"
+on: 
+  issues:
+    types: [opened, created, edited]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: github/issue-labeler@v3.4
+        with:
+          configuration-path: .github/labeler.yml
+          enable-versioned-regex: 0
+          sync-labels: 1
+          include-title: 1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -16,6 +16,5 @@ jobs:
         with:
           configuration-path: .github/labeler.yml
           enable-versioned-regex: 0
-          sync-labels: 1
           include-title: 1
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -2,7 +2,7 @@
 name: "Issue Labeler"
 on: 
   issues:
-    types: [opened, created, edited]
+    types: [opened, edited]
 
 permissions:
   issues: write


### PR DESCRIPTION
<!--
Thanks for the contribution. Please keep the subject under ~72 characters
and use a semantic prefix (feat:, fix:, refactor:, docs:, chore:, test:).

By submitting this PR you agree it will be distributed under GPL-3.0-only.
-->

## Summary

<!-- What does this change do, in one or two sentences? -->
This adds a github action for auto-labeling new bug or enhancement issues
created with gh-cli.

## Why
gh-cli created issues bypass the preset templates in a repo and do not get
auto-labeled. This slip can create more tedious work for the devs.

This PR would close #201

<!-- The motivation. Link the issue it closes, e.g. "Closes #123". -->
<!-- Feature additions must have a related issue first. Feature PRs without a related issue may be closed without review. -->

## How
This PR adds two files:
`.github/labeler.yml`
`.github/workflows/issue-labeler.yml`

The first file acts as a configuration for the second. This is the relevant
project:
https://github.com/github/issue-labeler

<!-- Notable implementation choices and any non-obvious trade-offs. -->

## Testing

<!-- How you verified the change. Mention the OS, terminal, and graphics protocol used for manual checks. -->

- [X] `cargo fmt --all --check`
- [X] `cargo clippy --all-targets --all-features -- -D warnings`
- [X] `cargo test --all-features`
- [X] Manual test in a real terminal (describe below)

This was tested by pushing issues to my fork of the repository via gh-cli. No
changes to the source were made.

## Screenshots or recordings

<!-- For UI changes, attach a screenshot or asciinema/gif. Delete this section if not applicable. -->

## Checklist

- [X] One logical change per PR.
- [X] Link a related issue.
- [X] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [X] Change does not add self-bot automation, mass actions, or scraping.
- [X] Updated `README.md`, if behavior or workflows changed.
