### PR TITLE
fix: Hide empty channel categories if user doesn't have permission

### DIFF
--- a/src/discord/permission/state.rs
+++ b/src/discord/permission/state.rs
@@ -10,6 +10,8 @@ use crate::discord::state::{ChannelState, DiscordState};
 /// Discord's permission bits, kept inline so the state crate
 /// does not need to depend on twilight's bitflags.
 const PERMISSION_VIEW_CHANNEL: u64 = 0x0000_0000_0000_0400;
+const PERMISSION_MANAGE_CHANNELS: u64 = 0x0000_0000_0000_0010;
+const PERMISSION_MANAGE_GUILD: u64 = 0x0000_0000_0000_0020;
 const PERMISSION_SEND_MESSAGES: u64 = 0x0000_0000_0000_0800;
 const PERMISSION_SEND_TTS_MESSAGES: u64 = 0x0000_0000_0000_1000;
 const PERMISSION_MANAGE_MESSAGES: u64 = 0x0000_0000_0000_2000;
@@ -120,6 +122,22 @@ impl DiscordState {
         let permissions = self.effective_permissions_for_channel(channel);
         permission_set(permissions, PERMISSION_VIEW_CHANNEL)
             && permission_set(permissions, PERMISSION_CONNECT)
+    }
+
+    /// Whether the user can manage guild/channel structure around `channel`.
+    /// Empty categories are only useful to users who can configure the server
+    /// or channel tree, so this check is intentionally pessimistic while
+    /// permission state is still hydrating.
+    pub fn can_manage_channel_structure_in_channel(&self, channel: &ChannelState) -> bool {
+        if channel.guild_id.is_none() {
+            return false;
+        }
+        let permissions = self.effective_permissions_for_channel(channel);
+        if permissions == PERMISSIONS_UNKNOWN {
+            return false;
+        }
+        permission_set(permissions, PERMISSION_MANAGE_CHANNELS)
+            || permission_set(permissions, PERMISSION_MANAGE_GUILD)
     }
 
     /// Compute the effective Discord permission bitfield for the

--- a/src/discord/state/tests/permissions.rs
+++ b/src/discord/state/tests/permissions.rs
@@ -3,6 +3,8 @@ use super::*;
 // Keep these literals separate from the implementation constants so the tests
 // verify Discord's documented bit values instead of reusing the code under test.
 const VIEW_CHANNEL: u64 = 0x0000_0000_0000_0400;
+const MANAGE_CHANNELS: u64 = 0x0000_0000_0000_0010;
+const MANAGE_GUILD: u64 = 0x0000_0000_0000_0020;
 const SEND_MESSAGES: u64 = 0x0000_0000_0000_0800;
 const SEND_TTS_MESSAGES: u64 = 0x0000_0000_0000_1000;
 const MANAGE_MESSAGES: u64 = 0x0000_0000_0000_2000;
@@ -120,6 +122,52 @@ fn administrator_role_bypasses_channel_overwrites() {
     );
     let ch = state.channel(channel).expect("channel");
     assert!(state.can_view_channel(ch));
+}
+
+#[test]
+fn manage_channels_or_guild_can_manage_channel_structure() {
+    let me = Id::new(10);
+    let owner = Id::new(11);
+    let guild = Id::new(1);
+    let channel = Id::new(2);
+    let manager_role = Id::new(50);
+
+    for permissions in [MANAGE_CHANNELS, MANAGE_GUILD] {
+        let state = guild_with_permissions(
+            owner,
+            me,
+            guild,
+            channel,
+            vec![manager_role],
+            vec![
+                role_info(Id::new(guild.get()), "@everyone", VIEW_CHANNEL),
+                role_info(manager_role, "Manager", permissions),
+            ],
+            Vec::new(),
+        );
+        let ch = state.channel(channel).expect("channel");
+        assert!(state.can_manage_channel_structure_in_channel(ch));
+    }
+}
+
+#[test]
+fn plain_member_cannot_manage_channel_structure() {
+    let me = Id::new(10);
+    let owner = Id::new(11);
+    let guild = Id::new(1);
+    let channel = Id::new(2);
+    let state = guild_with_permissions(
+        owner,
+        me,
+        guild,
+        channel,
+        vec![],
+        vec![role_info(Id::new(guild.get()), "@everyone", VIEW_CHANNEL)],
+        Vec::new(),
+    );
+    let ch = state.channel(channel).expect("channel");
+
+    assert!(!state.can_manage_channel_structure_in_channel(ch));
 }
 
 #[test]

--- a/src/tui/state/channels.rs
+++ b/src/tui/state/channels.rs
@@ -462,6 +462,16 @@ impl DashboardState {
                 continue;
             }
 
+            let mut children = channel_tree::sorted_category_children(&channels, root.id);
+            if children.is_empty()
+                && !self
+                    .discord
+                    .cache
+                    .can_manage_channel_structure_in_channel(root)
+            {
+                continue;
+            }
+
             let collapsed = self
                 .navigation
                 .collapsed_channel_categories
@@ -471,7 +481,6 @@ impl DashboardState {
                 collapsed,
             });
 
-            let mut children = channel_tree::sorted_category_children(&channels, root.id);
             if collapsed {
                 children.retain(|child| self.collapsed_category_child_visible(child));
             }

--- a/src/tui/state/tests/fixtures.rs
+++ b/src/tui/state/tests/fixtures.rs
@@ -15,6 +15,7 @@ use crate::discord::{
 };
 
 pub(super) const PERM_ADD_REACTIONS: u64 = 0x0000_0000_0000_0040;
+pub(super) const PERM_MANAGE_CHANNELS: u64 = 0x0000_0000_0000_0010;
 pub(super) const PERM_VIEW_CHANNEL: u64 = 0x0000_0000_0000_0400;
 pub(super) const PERM_SEND_MESSAGES: u64 = 0x0000_0000_0000_0800;
 pub(super) const PERM_SEND_TTS_MESSAGES: u64 = 0x0000_0000_0000_1000;

--- a/src/tui/state/tests/panes.rs
+++ b/src/tui/state/tests/panes.rs
@@ -188,15 +188,24 @@ fn half_page_scrolls_all_list_panes() {
 
 #[test]
 fn channel_tree_groups_category_children() {
-    let state = state_with_channel_tree();
+    let mut state = state_with_channel_tree();
+    state.push_event(AppEvent::ChannelUpsert(category_channel_info(
+        Id::new(1),
+        Id::new(13),
+        "Empty Category",
+        2,
+    )));
+
     let entries = state.channel_pane_entries();
 
+    assert_eq!(entries.len(), 3);
     assert!(matches!(
         &entries[0],
         ChannelPaneEntry::CategoryHeader {
+            state,
             collapsed: false,
             ..
-        }
+        } if state.id == Id::new(10)
     ));
     assert!(matches!(
         &entries[1],
@@ -211,6 +220,47 @@ fn channel_tree_groups_category_children() {
             branch: ChannelBranch::Last,
             ..
         }
+    ));
+}
+
+#[test]
+fn channel_tree_keeps_empty_categories_for_channel_managers() {
+    let current_user_id = Id::new(99);
+    let manager_role_id = Id::new(50);
+    let mut state = state_with_channel_tree();
+    state.push_event(AppEvent::Ready {
+        user: "me".to_owned(),
+        user_id: Some(current_user_id),
+    });
+    state.push_event(AppEvent::GuildRoleUpsert {
+        guild_id: Id::new(1),
+        role: role_info(
+            manager_role_id,
+            "Manager",
+            PERM_VIEW_CHANNEL | PERM_MANAGE_CHANNELS,
+        ),
+    });
+    state.push_event(AppEvent::GuildMemberUpsert {
+        guild_id: Id::new(1),
+        member: member_with_roles(current_user_id, "me", vec![manager_role_id]),
+    });
+    state.push_event(AppEvent::ChannelUpsert(category_channel_info(
+        Id::new(1),
+        Id::new(13),
+        "Empty Category",
+        2,
+    )));
+
+    let entries = state.channel_pane_entries();
+
+    assert_eq!(entries.len(), 4);
+    assert!(matches!(
+        &entries[3],
+        ChannelPaneEntry::CategoryHeader {
+            state,
+            collapsed: false,
+            ..
+        } if state.id == Id::new(13)
     ));
 }
 


### PR DESCRIPTION
<!--
Thanks for the contribution. Please keep the subject under ~72 characters
and use a semantic prefix (feat:, fix:, refactor:, docs:, chore:, test:).

By submitting this PR you agree it will be distributed under GPL-3.0-only.
-->

## Summary

<!-- What does this change do, in one or two sentences? -->

## Why

Fixes #197 
<!-- The motivation. Link the issue it closes, e.g. "Closes #123". -->
<!-- Feature additions must have a related issue first. Feature PRs without a related issue may be closed without review. -->

## How

<!-- Notable implementation choices and any non-obvious trade-offs. -->

## Testing

<!-- How you verified the change. Mention the OS, terminal, and graphics protocol used for manual checks. -->

- [ ] `cargo fmt --all --check`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo test --all-features`
- [ ] Manual test in a real terminal (describe below)

## Screenshots or recordings

<!-- For UI changes, attach a screenshot or asciinema/gif. Delete this section if not applicable. -->

## Checklist

- [ ] One logical change per PR.
- [ ] Link a related issue.
- [ ] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [ ] Change does not add self-bot automation, mass actions, or scraping.
- [ ] Updated `README.md`, if behavior or workflows changed.
