### PR TITLE
feat: Allow file drop without needing to already be composing (#212)

### DIFF
--- a/src/tui/input/keyboard/paste.rs
+++ b/src/tui/input/keyboard/paste.rs
@@ -34,11 +34,11 @@ pub fn handle_paste(state: &mut DashboardState, text: &str) -> bool {
     }
 
     if !state.is_composing() {
-        if pasted_file_attachments(text).is_none() {
-            return false;
+        if state.composer_accepts_attachments() && pasted_file_attachments(text).is_some() {
+            state.start_composer();
+            return handle_pasted_file_attachments(state, text);
         }
-        state.start_composer();
-        return handle_pasted_file_attachments(state, text);
+        return false;
     }
 
     if handle_pasted_file_attachments(state, text) {

--- a/src/tui/input/keyboard/paste.rs
+++ b/src/tui/input/keyboard/paste.rs
@@ -34,15 +34,12 @@ pub fn handle_paste(state: &mut DashboardState, text: &str) -> bool {
     }
 
     if !state.is_composing() {
-        let Some(attachments) = pasted_file_attachments(text) else {
-            return false;
-        };
-        state.start_composer();
-        if !state.is_composing() {
-            return false;
-        }
-        state.add_pending_composer_attachments(attachments);
-        return true;
+           if pasted_file_attachments(text).is_none() {
+              return false;
+           }
+           state.start_composer();
+           return handle_pasted_file_attachments(state, text);
+       }
     }
 
     if handle_pasted_file_attachments(state, text) {

--- a/src/tui/input/keyboard/paste.rs
+++ b/src/tui/input/keyboard/paste.rs
@@ -34,7 +34,15 @@ pub fn handle_paste(state: &mut DashboardState, text: &str) -> bool {
     }
 
     if !state.is_composing() {
-        return false;
+        let Some(attachments) = pasted_file_attachments(text) else {
+            return false;
+        };
+        state.start_composer();
+        if !state.is_composing() {
+            return false;
+        }
+        state.add_pending_composer_attachments(attachments);
+        return true;
     }
 
     if handle_pasted_file_attachments(state, text) {

--- a/src/tui/input/keyboard/paste.rs
+++ b/src/tui/input/keyboard/paste.rs
@@ -34,12 +34,11 @@ pub fn handle_paste(state: &mut DashboardState, text: &str) -> bool {
     }
 
     if !state.is_composing() {
-           if pasted_file_attachments(text).is_none() {
-              return false;
-           }
-           state.start_composer();
-           return handle_pasted_file_attachments(state, text);
-       }
+        if pasted_file_attachments(text).is_none() {
+            return false;
+        }
+        state.start_composer();
+        return handle_pasted_file_attachments(state, text);
     }
 
     if handle_pasted_file_attachments(state, text) {


### PR DESCRIPTION
<!--
Thanks for the contribution. Please keep the subject under ~72 characters
and use a semantic prefix (feat:, fix:, refactor:, docs:, chore:, test:).

By submitting this PR you agree it will be distributed under GPL-3.0-only.
-->

## Summary

<!-- What does this change do, in one or two sentences? -->

Allow the user to drop file without needing to be in "input mode".

## Why

<!-- The motivation. Link the issue it closes, e.g. "Closes #123". -->
<!-- Feature additions must have a related issue first. Feature PRs without a related issue may be closed without review. -->

Closes #212.

## How

<!-- Notable implementation choices and any non-obvious trade-offs. -->

If `!state.is_composing()` it tries to parse the input to see if any attachments are included. If so, try start composing and add the attachments.

## Testing

<!-- How you verified the change. Mention the OS, terminal, and graphics protocol used for manual checks. -->

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] Manual test in a real terminal (describe below)

## Screenshots or recordings

<!-- For UI changes, attach a screenshot or asciinema/gif. Delete this section if not applicable. -->

<img width="2048" height="982" alt="Recording at 2026-06-29 15 27 52 (Cropped in 2026-06-29 15 28 34)" src="https://github.com/user-attachments/assets/7b722858-1b06-46eb-ac6c-98aaba4f87de" />

## Checklist

- [x] One logical change per PR.
- [x] Link a related issue.
- [x] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [x] Change does not add self-bot automation, mass actions, or scraping.
- [x] Updated `README.md`, if behavior or workflows changed.
