### PR TITLE
feat: Add underline and strikethrough support to message formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,9 +209,8 @@ Concord renders a practical subset of Discord-style Markdown in message bodies:
 - Headings: `# H1`, `## H2`, `### H3`
 - Quotes: `> quoted text`
 - Bullets: `- item` and `* item`
-- Inline styles: `**bold**`, `*italic*`, and `` `inline code` ``
-- Fenced code blocks with optional language labels, rendered as compact boxes
-  with syntax highlighting
+- Inline styles: `**bold**`, `*italic*`, `__underline__`, `~~strikethrough~~`, and `` `inline code` ``
+- Fenced code blocks with optional language labels, rendered as compact boxes with syntax highlighting
 - Raw URLs and markdown link destinations are underlined and can be opened from message actions
 
 ### Reactions & Polls

--- a/src/tui/message/format.rs
+++ b/src/tui/message/format.rs
@@ -917,7 +917,7 @@ fn parse_inline_markdown(rendered: RenderedText) -> InlineMarkdownText {
 }
 
 fn next_inline_markdown_marker(value: &str, cursor: usize) -> Option<usize> {
-    ["`", "***", "**", "*", "_"]
+    ["`", "***", "**", "*", "__", "_", "~~"]
         .into_iter()
         .filter_map(|marker| next_inline_markdown_marker_for(value, cursor, marker))
         .min()
@@ -948,8 +948,12 @@ fn inline_markdown_marker_at(value: &str, cursor: usize) -> Option<(&'static str
         Some(("**", Style::default().add_modifier(Modifier::BOLD)))
     } else if rest.starts_with('*') {
         Some(("*", Style::default().add_modifier(Modifier::ITALIC)))
+    } else if rest.starts_with("__") {
+        Some(("__", Style::default().add_modifier(Modifier::UNDERLINED)))
     } else if rest.starts_with('_') && should_open_underscore_marker(value, cursor) {
         Some(("_", Style::default().add_modifier(Modifier::ITALIC)))
+    } else if rest.starts_with("~~") {
+        Some(("~~", Style::default().add_modifier(Modifier::CROSSED_OUT)))
     } else {
         None
     }


### PR DESCRIPTION
<!--
Thanks for the contribution. Please keep the subject under ~72 characters
and use a semantic prefix (feat:, fix:, refactor:, docs:, chore:, test:).

By submitting this PR you agree it will be distributed under GPL-3.0-only.
-->

## Summary

<!-- What does this change do, in one or two sentences? -->

Add <ins>underline</ins> and ~~strikethrough~~ support to message formatting.

## Why

<!-- The motivation. Link the issue it closes, e.g. "Closes #123". -->
<!-- Feature additions must have a related issue first. Feature PRs without a related issue may be closed without review. -->

I don't really know why this isn't implemented before, perhaps for some compatibility reasons?

## How

<!-- Notable implementation choices and any non-obvious trade-offs. -->

By adding new parsing and formatting logic to `next_inline_markdown_marker()` and `inline_markdown_marker_at()` respectively.

## Testing

<!-- How you verified the change. Mention the OS, terminal, and graphics protocol used for manual checks. -->

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] Manual test in a real terminal (describe below)

## Screenshots or recordings

<!-- For UI changes, attach a screenshot or asciinema/gif. Delete this section if not applicable. -->

<img width="150" height="65" alt="Screenshot 2026-06-29 at 4 23 06 PM" src="https://github.com/user-attachments/assets/0cd5418e-ae2c-49e6-bb5a-9ab602e0c2a5" />

## Checklist

- [x] One logical change per PR.
- [ ] Link a related issue.
- [x] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [x] Change does not add self-bot automation, mass actions, or scraping.
- [x] Updated `README.md`, if behavior or workflows changed.
