### PR TITLE
feat: Add support for playing audio attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ If your terminal does not support any graphics protocol, images will be rendered
 
 You can toggle image viewing on or off in the configuration file. When image viewing is off, attachments and emojis will be shown as text placeholders.
 
-Video playback uses [mpv](https://mpv.io/). Make sure `mpv` is installed and in your PATH.
+Video and audio playback uses [mpv](https://mpv.io/). Make sure `mpv` is installed and in your PATH.
 YouTube playback depends on your local `mpv` setup, such as `yt-dlp` support.
 External media playback is off by default. You can enable it with
 `media_playback = true` under `[display]`, or toggle it from the in-app Display
@@ -349,7 +349,7 @@ Message shortcuts:
 | `d`      | Delete              | Open a delete confirmation before deleting the message      |
 | `e`      | Edit                | Start editing the selected message when editing is allowed  |
 | `o`      | Open URL            | Open the selected message URL, or choose from multiple URLs |
-| `x`      | Play media          | Play selected video media in an external player             |
+| `x`      | Play media          | Play selected video or audio media in an external player    |
 | `v`      | View attachment     | Open the selected message's attachment viewer               |
 
 Message action menu shortcuts:
@@ -363,7 +363,7 @@ Message action menu shortcuts:
 | `e`      | Edit                        | Start editing the selected message when editing is allowed  |
 | `o`      | Open URL                    | Open the selected message URL, or choose from multiple URLs |
 | `D`      | Remove embeds               | Remove embeds from the selected message                     |
-| `x`      | Play media                  | Play selected video media in an external player             |
+| `x`      | Play media                  | Play selected video or audio media in an external player    |
 | `v`      | View attachment             | Open the selected message's attachment viewer               |
 | `g`      | Go to referenced message    | Go to the replied or forwarded message                      |
 | `p`      | show message sender profile | Open the selected message author's profile                  |
@@ -372,7 +372,7 @@ Message action menu shortcuts:
 | `u`      | Show reacted users          | Show users who reacted to the selected message              |
 | `c`      | Choose poll votes           | Choose poll votes for the selected message                  |
 
-When the attachment viewer is open, press `x` to play the current video attachment
+When the attachment viewer is open, press `x` to play the current video or audio attachment
 in an external player, or `d` to download the current attachment directly.
 
 Server actions:
@@ -491,7 +491,7 @@ show_avatars = true
 # Render inline image previews for attachments and embeds.
 show_images = true
 
-# Allow video media to open in an external player.
+# Allow video and audio media to open in an external player.
 media_playback = false
 
 # Preview quality: efficient, balanced, high, or original.

--- a/src/app/media_adapters.rs
+++ b/src/app/media_adapters.rs
@@ -376,7 +376,7 @@ fn media_player_command_spec_for_url_with_ipc(
     let url = normalize_openable_url(url).ok_or_else(|| {
         io::Error::new(io::ErrorKind::InvalidInput, "unsupported media URL scheme")
     })?;
-    let mut args = vec!["--no-terminal".to_owned()];
+    let mut args = vec!["--no-terminal".to_owned(), "--force-window".to_owned()];
     if let Some(ipc_server) = ipc_server {
         args.push(format!("--input-ipc-server={ipc_server}"));
     }
@@ -696,6 +696,7 @@ mod tests {
             spec.args,
             vec![
                 "--no-terminal".to_owned(),
+                "--force-window".to_owned(),
                 "--".to_owned(),
                 "https://example.com/video.mp4?x=1&y=2".to_owned(),
             ]
@@ -715,6 +716,7 @@ mod tests {
             spec.args,
             vec![
                 "--no-terminal".to_owned(),
+                "--force-window".to_owned(),
                 "--input-ipc-server=/tmp/concord-mpv.sock".to_owned(),
                 "--".to_owned(),
                 "https://example.com/video.mp4".to_owned(),

--- a/src/discord/events.rs
+++ b/src/discord/events.rs
@@ -1725,15 +1725,14 @@ fn poll_result_info_from_fields<'a>(
 
 #[cfg(test)]
 mod tests {
-    use crate::discord::AttachmentInfo;
+    use crate::discord::{AttachmentInfo, AttachmentMediaType};
 
     use super::*;
 
     #[test]
     fn attachment_media_classification_controls_inline_preview() {
         let video = attachment_info("clip.mp4", Some("video/mp4"));
-        assert!(!video.is_image());
-        assert!(video.is_video());
+        assert!(video.media_type() == Some(AttachmentMediaType::Video));
         assert_eq!(video.inline_preview_url(), None);
         assert_eq!(
             video.inline_preview_info().map(|info| (
@@ -1749,8 +1748,7 @@ mod tests {
         );
 
         let image = attachment_info("cat.png", Some("image/png"));
-        assert!(image.is_image());
-        assert!(!image.is_video());
+        assert!(image.media_type() == Some(AttachmentMediaType::Image));
         assert_eq!(
             image.inline_preview_url(),
             Some("https://cdn.discordapp.com/cat.png")
@@ -1760,8 +1758,11 @@ mod tests {
             Some("https://media.discordapp.net/cat.png")
         );
 
-        assert!(attachment_info("CAT.PNG", None).is_image());
-        assert!(attachment_info("CLIP.MP4", None).is_video());
+        assert!(attachment_info("CAT.PNG", None).media_type() == Some(AttachmentMediaType::Image));
+        assert!(attachment_info("CLIP.MP4", None).media_type() == Some(AttachmentMediaType::Video));
+        assert!(
+            attachment_info("MUSIC.MP3", None).media_type() == Some(AttachmentMediaType::Audio)
+        );
     }
 
     #[test]

--- a/src/discord/message.rs
+++ b/src/discord/message.rs
@@ -2,10 +2,10 @@ mod info;
 mod state;
 
 pub use info::{
-    AttachmentInfo, AttachmentUpdate, EmbedFieldInfo, EmbedInfo, InlinePreviewInfo,
-    MESSAGE_FLAG_SUPPRESS_EMBEDS, MentionInfo, MessageInfo, MessageInteractionInfo, MessageKind,
-    MessageReferenceInfo, MessageSnapshotInfo, PollAnswerInfo, PollInfo, ReactionInfo,
-    ReactionUserInfo, ReplyInfo,
+    AttachmentInfo, AttachmentMediaType, AttachmentUpdate, EmbedFieldInfo, EmbedInfo,
+    InlinePreviewInfo, MESSAGE_FLAG_SUPPRESS_EMBEDS, MentionInfo, MessageInfo,
+    MessageInteractionInfo, MessageKind, MessageReferenceInfo, MessageSnapshotInfo, PollAnswerInfo,
+    PollInfo, ReactionInfo, ReactionUserInfo, ReplyInfo,
 };
 pub(in crate::discord) use state::{MessageAuthorRoleIds, MessageHistoryGap, MessageUpdateFields};
 pub use state::{MessageCapabilities, MessageState};

--- a/src/discord/message/info.rs
+++ b/src/discord/message/info.rs
@@ -1,9 +1,8 @@
+use crate::discord::commands::ReactionEmoji;
 use crate::discord::ids::{
     Id,
     marker::{AttachmentMarker, ChannelMarker, GuildMarker, MessageMarker, RoleMarker, UserMarker},
 };
-
-use crate::discord::commands::ReactionEmoji;
 
 pub const MESSAGE_FLAG_SUPPRESS_EMBEDS: u64 = 1 << 2;
 
@@ -41,6 +40,13 @@ pub struct AttachmentInfo {
     pub width: Option<u64>,
     pub height: Option<u64>,
     pub description: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AttachmentMediaType {
+    Image,
+    Video,
+    Audio,
 }
 
 #[cfg(test)]
@@ -477,31 +483,43 @@ impl AttachmentInfo {
         }
     }
 
-    pub fn is_image(&self) -> bool {
+    pub fn media_type(&self) -> Option<AttachmentMediaType> {
         if let Some(content_type) = self.content_type.as_deref() {
-            return content_type.starts_with("image/");
+            if content_type.starts_with("image/") {
+                return Some(AttachmentMediaType::Image);
+            } else if content_type.starts_with("video/") {
+                return Some(AttachmentMediaType::Video);
+            } else if content_type.starts_with("audio/") {
+                return Some(AttachmentMediaType::Audio);
+            }
         }
 
-        filename_has_extension(
+        if filename_has_extension(
             &self.filename,
             &["avif", "gif", "jpeg", "jpg", "png", "webp"],
-        )
-    }
-
-    pub fn is_video(&self) -> bool {
-        if let Some(content_type) = self.content_type.as_deref() {
-            return content_type.starts_with("video/");
+        ) {
+            return Some(AttachmentMediaType::Image);
         }
-
-        filename_has_extension(&self.filename, &["m4v", "mov", "mp4", "webm"])
+        if filename_has_extension(&self.filename, &["m4v", "mov", "mp4", "webm"]) {
+            return Some(AttachmentMediaType::Video);
+        }
+        if filename_has_extension(
+            &self.filename,
+            &["mp3", "m4a", "opus", "ogg", "flac", "wav", "aiff"],
+        ) {
+            return Some(AttachmentMediaType::Audio);
+        }
+        None
     }
 
     pub fn inline_preview_url(&self) -> Option<&str> {
-        self.is_image().then(|| self.preferred_url()).flatten()
+        self.media_type()
+            .filter(|t| *t == AttachmentMediaType::Image)
+            .and_then(|_| self.preferred_url())
     }
 
     pub fn inline_preview_info(&self) -> Option<InlinePreviewInfo<'_>> {
-        if self.is_video() && !self.proxy_url.is_empty() {
+        if self.media_type() == Some(AttachmentMediaType::Video) && !self.proxy_url.is_empty() {
             return Some(InlinePreviewInfo {
                 url: self.proxy_url.as_str(),
                 proxy_url: Some(self.proxy_url.as_str()),

--- a/src/discord/message/state.rs
+++ b/src/discord/message/state.rs
@@ -5,11 +5,10 @@ use crate::discord::ids::{
     marker::{ChannelMarker, GuildMarker, MessageMarker, RoleMarker, UserMarker},
 };
 use crate::discord::{
-    AttachmentInfo, EmbedInfo, InlinePreviewInfo, MemberInfo, MentionInfo, MessageInfo,
-    MessageInteractionInfo, MessageKind, MessageReferenceInfo, MessageSnapshotInfo,
+    AttachmentInfo, AttachmentMediaType, EmbedInfo, InlinePreviewInfo, MemberInfo, MentionInfo,
+    MessageInfo, MessageInteractionInfo, MessageKind, MessageReferenceInfo, MessageSnapshotInfo,
     MessageUpdateEventFields, PollInfo, ReactionEmoji, ReactionInfo, ReplyInfo,
 };
-
 use crate::discord::{
     member::{selected_member_role_color, selected_role_ids_color},
     profile::UserProfileCacheKey,
@@ -82,6 +81,7 @@ pub struct MessageCapabilities {
     pub has_poll: bool,
     pub has_image: bool,
     pub has_video: bool,
+    pub has_audio: bool,
     pub has_file: bool,
 }
 
@@ -155,13 +155,15 @@ impl MessageState {
 
         capabilities.has_poll = self.poll.is_some();
         for attachment in self.attachments_in_display_order() {
-            if attachment.is_image() && attachment.preferred_url().is_some() {
-                capabilities.has_image = true;
-            } else if attachment.is_video() {
-                capabilities.has_video = true;
+            if let Some(media_type) = attachment.media_type() {
+                match media_type {
+                    AttachmentMediaType::Image => capabilities.has_image = true,
+                    AttachmentMediaType::Video => capabilities.has_video = true,
+                    AttachmentMediaType::Audio => capabilities.has_audio = true,
+                };
             } else {
                 capabilities.has_file = true;
-            }
+            };
         }
         if self.first_inline_preview().is_some() {
             capabilities.has_image = true;

--- a/src/discord/mod.rs
+++ b/src/discord/mod.rs
@@ -76,10 +76,10 @@ pub use guild::{CustomEmojiInfo, GuildFolder};
 pub use ids::{Id, marker};
 pub use member::{MemberInfo, RoleInfo};
 pub use message::{
-    AttachmentInfo, AttachmentUpdate, EmbedFieldInfo, EmbedInfo, InlinePreviewInfo,
-    MESSAGE_FLAG_SUPPRESS_EMBEDS, MentionInfo, MessageInfo, MessageInteractionInfo, MessageKind,
-    MessageReferenceInfo, MessageSnapshotInfo, PollAnswerInfo, PollInfo, ReactionInfo,
-    ReactionUserInfo, ReplyInfo,
+    AttachmentInfo, AttachmentMediaType, AttachmentUpdate, EmbedFieldInfo, EmbedInfo,
+    InlinePreviewInfo, MESSAGE_FLAG_SUPPRESS_EMBEDS, MentionInfo, MessageInfo,
+    MessageInteractionInfo, MessageKind, MessageReferenceInfo, MessageSnapshotInfo, PollAnswerInfo,
+    PollInfo, ReactionInfo, ReactionUserInfo, ReplyInfo,
 };
 pub use notification::{
     ChannelNotificationOverrideInfo, GuildNotificationSettingsInfo, NotificationLevel,

--- a/src/tui/message/format/attachments.rs
+++ b/src/tui/message/format/attachments.rs
@@ -1,4 +1,4 @@
-use crate::discord::AttachmentInfo;
+use crate::discord::{AttachmentInfo, AttachmentMediaType};
 
 pub(in crate::tui) fn format_attachment_summary(attachments: &[AttachmentInfo]) -> String {
     format_attachment_summary_lines(attachments).join(" | ")
@@ -9,13 +9,14 @@ pub(super) fn format_attachment_summary_lines(attachments: &[AttachmentInfo]) ->
 }
 
 fn format_attachment(attachment: &AttachmentInfo) -> String {
-    let kind = if attachment.is_image() {
-        "image"
-    } else if attachment.is_video() {
-        "video"
-    } else {
-        "file"
-    };
+    let kind = attachment
+        .media_type()
+        .map_or("file", |media_type| match media_type {
+            AttachmentMediaType::Image => "image",
+            AttachmentMediaType::Video => "video",
+            AttachmentMediaType::Audio => "audio",
+        });
+
     let dimensions = match (attachment.width, attachment.height) {
         (Some(width), Some(height)) => format!(" {width}x{height}"),
         _ => String::new(),

--- a/src/tui/state/model.rs
+++ b/src/tui/state/model.rs
@@ -1,13 +1,10 @@
-use crate::discord::AttachmentDownloadId;
 use crate::discord::ids::{
     Id,
     marker::{ChannelMarker, GuildMarker, MessageMarker, UserMarker},
 };
-
-use crate::discord::PresenceStatus;
 use crate::discord::{
-    ChannelState, ChannelUnreadState, GuildFolder, GuildState, MuteDuration, ReactionEmoji,
-    ReactionInfo, VoiceParticipantState,
+    AttachmentDownloadId, AttachmentMediaType, ChannelState, ChannelUnreadState, GuildFolder,
+    GuildState, MuteDuration, PresenceStatus, ReactionEmoji, ReactionInfo, VoiceParticipantState,
 };
 use ratatui_image::protocol::Protocol;
 
@@ -309,8 +306,7 @@ pub struct AttachmentViewerItem {
     pub filename: String,
     pub url: Option<String>,
     pub size_bytes: u64,
-    pub is_image: bool,
-    pub is_video: bool,
+    pub media_type: Option<AttachmentMediaType>,
 }
 
 #[cfg(test)]
@@ -323,8 +319,7 @@ impl AttachmentViewerItem {
             filename: String::new(),
             url: None,
             size_bytes: 0,
-            is_image: false,
-            is_video: false,
+            media_type: None,
         }
     }
 }

--- a/src/tui/state/popups/attachment_viewer.rs
+++ b/src/tui/state/popups/attachment_viewer.rs
@@ -1,6 +1,6 @@
 use crate::discord::{
-    AppCommand, AttachmentInfo, DownloadAttachmentSource, InlinePreviewInfo, MediaPlaybackSource,
-    MediaPlaybackTarget,
+    AppCommand, AttachmentInfo, AttachmentMediaType, DownloadAttachmentSource, InlinePreviewInfo,
+    MediaPlaybackSource, MediaPlaybackTarget,
     ids::{Id, marker::MessageMarker},
 };
 
@@ -100,8 +100,7 @@ impl DashboardState {
             filename: selected.attachment.filename.clone(),
             url: selected.attachment.preferred_url().map(str::to_owned),
             size_bytes: selected.attachment.size,
-            is_image: selected.attachment.is_image(),
-            is_video: selected.attachment.is_video(),
+            media_type: selected.attachment.media_type(),
         })
     }
 
@@ -131,7 +130,10 @@ impl DashboardState {
             return None;
         }
         let item = self.selected_attachment_viewer_item()?;
-        if !item.is_video {
+        if !matches!(
+            item.media_type,
+            Some(AttachmentMediaType::Video | AttachmentMediaType::Audio)
+        ) {
             return None;
         }
         Some(AppCommand::PlayMedia {

--- a/src/tui/state/popups/message_actions.rs
+++ b/src/tui/state/popups/message_actions.rs
@@ -3,8 +3,8 @@ use crate::discord::ids::{
     marker::{ChannelMarker, MessageMarker},
 };
 use crate::discord::{
-    AppCommand, EmbedInfo, MESSAGE_FLAG_SUPPRESS_EMBEDS, MediaPlaybackSource, MediaPlaybackTarget,
-    MessageState, ReactionEmoji,
+    AppCommand, AttachmentMediaType, EmbedInfo, MESSAGE_FLAG_SUPPRESS_EMBEDS, MediaPlaybackSource,
+    MediaPlaybackTarget, MessageState, ReactionEmoji,
 };
 use crate::tui::format::detected_urls;
 use crate::tui::keybindings::KeyChord;
@@ -670,7 +670,11 @@ fn message_url_items(message: &MessageState) -> Vec<MessageUrlItem> {
 fn message_media_playback_items(message: &MessageState) -> Vec<MediaPlaybackTarget> {
     let mut targets = message
         .attachments_in_display_order()
-        .filter(|attachment| attachment.is_video())
+        .filter(|attachment| {
+            attachment.media_type().is_some_and(|media_type| {
+                media_type == AttachmentMediaType::Video || media_type == AttachmentMediaType::Audio
+            })
+        })
         .filter_map(|attachment| {
             Some(MediaPlaybackTarget {
                 url: attachment.preferred_url()?.to_owned(),

--- a/src/tui/state/tests/message_actions.rs
+++ b/src/tui/state/tests/message_actions.rs
@@ -6,8 +6,8 @@ use crate::discord::test_builders::{
     attachment_download_progress_event, attachment_download_started_event,
 };
 use crate::discord::{
-    AppCommand, AttachmentDownloadId, MESSAGE_FLAG_SUPPRESS_EMBEDS, MediaPlaybackSource,
-    MediaPlaybackTarget,
+    AppCommand, AttachmentDownloadId, AttachmentMediaType, MESSAGE_FLAG_SUPPRESS_EMBEDS,
+    MediaPlaybackSource, MediaPlaybackTarget,
 };
 
 fn message_action(actions: &[MessageActionItem], kind: MessageActionKind) -> &MessageActionItem {
@@ -156,8 +156,7 @@ fn direct_attachment_message_action_opens_attachment_viewer() {
             filename: "image-10.png".to_owned(),
             url: Some("https://cdn.discordapp.com/image-10.png".to_owned()),
             size_bytes: 2048,
-            is_image: true,
-            is_video: false,
+            media_type: Some(AttachmentMediaType::Image),
         })
     );
 }
@@ -637,8 +636,7 @@ fn reply_attachment_action_can_open_attachment_viewer() {
             filename: "image-1.png".to_owned(),
             url: Some("https://cdn.discordapp.com/image-1.png".to_owned()),
             size_bytes: 2048,
-            is_image: true,
-            is_video: false,
+            media_type: Some(AttachmentMediaType::Image),
         })
     );
 }

--- a/src/tui/ui/popups/attachment_viewer.rs
+++ b/src/tui/ui/popups/attachment_viewer.rs
@@ -1,3 +1,5 @@
+use crate::discord::AttachmentMediaType;
+
 use super::*;
 
 pub(in crate::tui::ui) fn render_attachment_viewer(
@@ -32,8 +34,10 @@ pub(in crate::tui::ui) fn render_attachment_viewer(
         height: hint_height,
         ..inner
     });
-
-    let can_preview = item.is_image || item.is_video;
+    let can_preview = matches!(
+        item.media_type,
+        Some(AttachmentMediaType::Image | AttachmentMediaType::Video)
+    );
     if can_preview
         && state.show_images()
         && let Some(image_preview) = image_preview


### PR DESCRIPTION
<!--
Thanks for the contribution. Please keep the subject under ~72 characters
and use a semantic prefix (feat:, fix:, refactor:, docs:, chore:, test:).

By submitting this PR you agree it will be distributed under GPL-3.0-only.
-->

## Summary

<!-- What does this change do, in one or two sentences? -->

Add support for playing audio attachment, also refactored some code for handling media type for attachments.

## Why

<!-- The motivation. Link the issue it closes, e.g. "Closes #123". -->
<!-- Feature additions must have a related issue first. Feature PRs without a related issue may be closed without review. -->

MPV supports playing audio files, so it should also be possible to do it in concord.

## How

<!-- Notable implementation choices and any non-obvious trade-offs. -->

Make the attachments with `media_type == AttachmentMediaType::Audio` playable. And force MPV to always show a window (headless by default when playing audio, so the `--force-window` flag is needed).

## Testing

<!-- How you verified the change. Mention the OS, terminal, and graphics protocol used for manual checks. -->

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] Manual test in a real terminal (describe below)

## Screenshots or recordings

<!-- For UI changes, attach a screenshot or asciinema/gif. Delete this section if not applicable. -->

<img width="1480" height="174" alt="Recording at 2026-07-03 12 23 13" src="https://github.com/user-attachments/assets/76e23588-b059-4c4e-bd25-fc0a8aa0542b" />

## Checklist

- [x] One logical change per PR.
- [ ] Link a related issue.
- [x] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [x] Change does not add self-bot automation, mass actions, or scraping.
- [x] Updated `README.md`, if behavior or workflows changed.
