### PR TITLE
fix: Fix bot badge rendering

### DIFF
--- a/src/tui/ui/message/list.rs
+++ b/src/tui/ui/message/list.rs
@@ -678,7 +678,10 @@ fn message_item_lines_with_previews(input: MessageItemLinesInput<'_>) -> Vec<Lin
     let mut lines = if show_header {
         let mut header = vec![message_avatar_span(), Span::styled(author, author_style)];
         if author_is_bot {
-            header.push(bot_badge_span());
+            header.extend([
+                Span::raw(" "),
+                bot_badge_span(),
+            ]);
         }
         header.extend([
             Span::raw(" "),
@@ -719,7 +722,7 @@ pub(in crate::tui::ui) fn message_author_style(role_color: Option<u32>) -> Style
 
 fn bot_badge_span() -> Span<'static> {
     Span::styled(
-        " [bot]",
+        "[bot]",
         Style::default()
             .fg(Color::White)
             .bg(Color::Rgb(88, 101, 242))

--- a/src/tui/ui/message/list.rs
+++ b/src/tui/ui/message/list.rs
@@ -678,10 +678,7 @@ fn message_item_lines_with_previews(input: MessageItemLinesInput<'_>) -> Vec<Lin
     let mut lines = if show_header {
         let mut header = vec![message_avatar_span(), Span::styled(author, author_style)];
         if author_is_bot {
-            header.extend([
-                Span::raw(" "),
-                bot_badge_span(),
-            ]);
+            header.extend([Span::raw(" "), bot_badge_span()]);
         }
         header.extend([
             Span::raw(" "),

--- a/src/tui/ui/tests/messages.rs
+++ b/src/tui/ui/tests/messages.rs
@@ -161,9 +161,13 @@ fn message_viewport_author_uses_resolved_role_color() {
         lines[1].spans[1].style.fg,
         Some(Color::Rgb(0x33, 0x66, 0xCC))
     );
-    assert_eq!(lines[1].spans[2].content.as_ref(), " [bot]");
-    assert_eq!(lines[1].spans[2].style.fg, Some(Color::White));
-    assert_eq!(lines[1].spans[2].style.bg, Some(Color::Rgb(88, 101, 242)));
+
+    assert_eq!(lines[1].spans[2].content.as_ref(), " ");
+    assert_eq!(lines[1].spans[2].style.fg, None);
+    assert_eq!(lines[1].spans[2].style.bg, None);
+    assert_eq!(lines[1].spans[3].content.as_ref(), "[bot]");
+    assert_eq!(lines[1].spans[3].style.fg, Some(Color::White));
+    assert_eq!(lines[1].spans[3].style.bg, Some(Color::Rgb(88, 101, 242)));
 }
 
 #[test]


### PR DESCRIPTION
<!--
Thanks for the contribution. Please keep the subject under ~72 characters
and use a semantic prefix (feat:, fix:, refactor:, docs:, chore:, test:).

By submitting this PR you agree it will be distributed under GPL-3.0-only.
-->

## Summary

<!-- What does this change do, in one or two sentences? -->

Fix bot badge rendering to make the padding render correctly.

## Why

<!-- The motivation. Link the issue it closes, e.g. "Closes #123". -->
<!-- Feature additions must have a related issue first. Feature PRs without a related issue may be closed without review. -->

It looks a bit weird.

## How

<!-- Notable implementation choices and any non-obvious trade-offs. -->

Render the padding separately with no styling.

## Testing

<!-- How you verified the change. Mention the OS, terminal, and graphics protocol used for manual checks. -->

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] Manual test in a real terminal (describe below)

## Screenshots or recordings

<!-- For UI changes, attach a screenshot or asciinema/gif. Delete this section if not applicable. -->

| Before | After |
| ---       | ---    |
| <img width="270" height="66" alt="Screenshot 2026-07-05 at 2 34 35 AM" src="https://github.com/user-attachments/assets/efd974f9-59c3-4fee-900e-c7190fca59db" /> | <img width="278" height="60" alt="Screenshot 2026-07-05 at 2 34 41 AM" src="https://github.com/user-attachments/assets/4764dd54-70c8-4630-8dc9-23f43f8f2252" /> |


## Checklist

- [x] One logical change per PR.
- [ ] Link a related issue.
- [x] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [x] Change does not add self-bot automation, mass actions, or scraping.
- [ ] Updated `README.md`, if behavior or workflows changed.
