### PR TITLE
feat: support CONCORD_TOKEN env var in Auto credential mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ aplay -D pulse /usr/share/sounds/alsa/Front_Center.wav
 - **Token** : paste an existing Discord token.
 - **Email / Password** : login with credentials. MFA (TOTP, SMS) is fully supported.
 - **QR Code** : scan the code from the Discord mobile app.
-- **CONCORD_TOKEN env var** : set `CONCORD_TOKEN=your-token` before launching Concord. Takes precedence over the plaintext credential file when `credentials.store = "auto"`, but the keychain is checked first.
+- **CONCORD_TOKEN env var** : set `CONCORD_TOKEN=your-token` before launching Concord. It overrides every `credentials.store` mode (`auto`, `keychain`, `plain`).
 
 Email and QR code logins may trigger a CAPTCHA challenge on Discord's side. We cannot solve that, so I strongly recommend using token authentication.
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ aplay -D pulse /usr/share/sounds/alsa/Front_Center.wav
 - **Token** : paste an existing Discord token.
 - **Email / Password** : login with credentials. MFA (TOTP, SMS) is fully supported.
 - **QR Code** : scan the code from the Discord mobile app.
+- **CONCORD_TOKEN env var** : set `CONCORD_TOKEN=your-token` before launching Concord. Takes precedence over the plaintext credential file when `credentials.store = "auto"`, but the keychain is checked first.
 
 Email and QR code logins may trigger a CAPTCHA challenge on Discord's side. We cannot solve that, so I strongly recommend using token authentication.
 
@@ -751,6 +752,7 @@ No. If Discord requires a CAPTCHA during login, use token login instead.
 
 - By default, tokens are stored in the system keychain when available.
 - On Linux, keychain storage uses Secret Service when a compatible service is available.
+- The `CONCORD_TOKEN` environment variable lets you provide a token without writing it to disk. This avoids leaving plaintext on disk, but the token is visible in `/proc/<pid>/environ` and in process listings while Concord is running.
 - In `credentials.store = "auto"`, Concord falls back to **plain text** credentials under Concord's state directory when keychain storage is unavailable. In `keychain` mode, Concord does not fall back to plain storage. Keep fallback credential files secure and do not share them. You can use a token from that file to log in to the official Discord client, so treat it like a password.
 - On Unix, the fallback credential's parent directory is created with `0700` and the credential file with `0600` permissions.
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -87,7 +87,13 @@ impl App {
             shutdown_gateway(&client, gateway_task).await;
             match result? {
                 tui::DashboardExit::Quit => return Ok(()),
-                tui::DashboardExit::SignOut => {}
+                // Sign-out of an env-token session quits: re-resolving would
+                // read the same CONCORD_TOKEN and log straight back in.
+                tui::DashboardExit::SignOut => {
+                    if crate::token_store::env_token().is_some() {
+                        return Ok(());
+                    }
+                }
             }
         }
     }

--- a/src/app/credentials.rs
+++ b/src/app/credentials.rs
@@ -10,6 +10,20 @@ pub(super) struct ResolvedToken {
 
 pub(super) async fn resolve_token() -> Result<ResolvedToken> {
     let mut warnings = Vec::new();
+
+    if let Some(token) = token_store::env_token() {
+        validate_token_header(&token)?;
+        if let Err(error) = validate_token_with_discord(&token).await {
+            match error {
+                AppError::DiscordTokenRejected => return Err(AppError::DiscordTokenRejected),
+                error => warnings.push(format!(
+                    "CONCORD_TOKEN could not be verified: {error}; continuing with it for this session"
+                )),
+            }
+        }
+        return Ok(ResolvedToken { token, warnings });
+    }
+
     let credential_store = match config::load_options() {
         Ok(options) => options.credentials.store,
         Err(error) => {

--- a/src/app/session_commands.rs
+++ b/src/app/session_commands.rs
@@ -18,6 +18,11 @@ pub(super) async fn handle(client: DiscordClient, command: AppCommand) {
 }
 
 async fn delete_saved_credentials() -> Result<()> {
+    // An env-token session has nothing stored to delete
+    if token_store::env_token().is_some() {
+        return Ok(());
+    }
+
     let credential_store = match config::load_options() {
         Ok(options) => options.credentials.store,
         Err(error) => {

--- a/src/support/token_store.rs
+++ b/src/support/token_store.rs
@@ -21,7 +21,10 @@ pub fn load_token(store: CredentialStoreMode) -> Result<Option<String>> {
     match store {
         CredentialStoreMode::Auto => match load_keychain_token(&account_id) {
             Ok(Some(token)) => Ok(Some(token)),
-            Ok(None) | Err(_) => load_fallback_token(&account_id),
+            Ok(None) | Err(_) => match std::env::var("CONCORD_TOKEN") {
+                Ok(token) => Ok(Some(normalize_token(&token)?)),
+                Err(_) => load_fallback_token(&account_id),
+            },
         },
         CredentialStoreMode::Keychain => load_keychain_token(&account_id),
         CredentialStoreMode::Plain => load_fallback_token(&account_id),

--- a/src/support/token_store.rs
+++ b/src/support/token_store.rs
@@ -8,11 +8,24 @@ use crate::{AppError, Result, config::CredentialStoreMode, paths, support::priva
 const KEYCHAIN_SERVICE: &str = "io.github.chojs23.concord.discord-token.v1";
 const DEFAULT_ACCOUNT_ID: &str = "default";
 const KEYCHAIN_ACCOUNT_PREFIX: &str = "account:";
+const ENV_TOKEN_VAR: &str = "CONCORD_TOKEN";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum TokenSaveLocation {
     Keychain,
     PlaintextFile,
+}
+
+/// A token from the `CONCORD_TOKEN` environment variable. An empty or
+/// whitespace-only value is treated as unset, so a blank env var falls through
+/// to the configured store.
+pub fn env_token() -> Option<String> {
+    let token = std::env::var(ENV_TOKEN_VAR).ok()?;
+    let token = token.trim();
+    if token.is_empty() {
+        return None;
+    }
+    Some(token.to_owned())
 }
 
 pub fn load_token(store: CredentialStoreMode) -> Result<Option<String>> {
@@ -21,10 +34,7 @@ pub fn load_token(store: CredentialStoreMode) -> Result<Option<String>> {
     match store {
         CredentialStoreMode::Auto => match load_keychain_token(&account_id) {
             Ok(Some(token)) => Ok(Some(token)),
-            Ok(None) | Err(_) => match std::env::var("CONCORD_TOKEN") {
-                Ok(token) => Ok(Some(normalize_token(&token)?)),
-                Err(_) => load_fallback_token(&account_id),
-            },
+            Ok(None) | Err(_) => load_fallback_token(&account_id),
         },
         CredentialStoreMode::Keychain => load_keychain_token(&account_id),
         CredentialStoreMode::Plain => load_fallback_token(&account_id),


### PR DESCRIPTION
<!--
Thanks for the contribution. Please keep the subject under ~72 characters
and use a semantic prefix (feat:, fix:, refactor:, docs:, chore:, test:).

By submitting this PR you agree it will be distributed under GPL-3.0-only.
-->

## Summary

<!-- What does this change do, in one or two sentences? -->
allow auth via `CONCORD_TOKEN`

## Why

<!-- The motivation. Link the issue it closes, e.g. "Closes #123". -->
<!-- Feature additions must have a related issue first. Feature PRs without a related issue may be closed without review. -->

i don't know how to unlock the kde keyring without launching a graphical session, and i prefer not to leave credentials lying around in plain text

## How

<!-- Notable implementation choices and any non-obvious trade-offs. -->
just added a check for `CONCORD_TOKEN` if the keyring check fails

## Testing

<!-- How you verified the change. Mention the OS, terminal, and graphics protocol used for manual checks. -->

- [ ] `cargo fmt --all --check`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo test --all-features`
- [x] Manual test in a real terminal (describe below)

tested with this, with kmscon

```nix
concord = inputs.concord.packages.${pkgs.system}.default.overrideAttrs (old: {
  patches =
    (old.patches or [])
    ++ [
      ./patch/0001-feat-support-CONCORD_TOKEN-env-var-in-Auto-credentia.patch
    ];
});

concord-wrapped = pkgs.writeShellScriptBin "concord" ''
  export CONCORD_TOKEN=$(< ${config.age.secrets.discord.path})
  exec ${concord}/bin/concord
'';
```

## Screenshots or recordings

<!-- For UI changes, attach a screenshot or asciinema/gif. Delete this section if not applicable. -->

## Checklist

- [x] One logical change per PR.
- [ ] Link a related issue.
- [ ] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [x] Change does not add self-bot automation, mass actions, or scraping.
- [x] Updated `README.md`, if behavior or workflows changed.