### PR TITLE
feat(discord): lock DM composer until the conversation is established

### DIFF
--- a/src/app/command_dispatch.rs
+++ b/src/app/command_dispatch.rs
@@ -57,7 +57,8 @@ impl CommandDispatcher {
             | AppCommand::LoadForumPosts { .. }
             | AppCommand::LoadInboxMentions { .. }
             | AppCommand::LoadInboxChannelHistory { .. }
-            | AppCommand::SearchMessages { .. }) => {
+            | AppCommand::SearchMessages { .. }
+            | AppCommand::VerifyDmEstablished { .. }) => {
                 history_commands::handle(self.client.clone(), command).await;
             }
             command @ (AppCommand::LoadGuildMembers { .. }

--- a/src/app/history_commands.rs
+++ b/src/app/history_commands.rs
@@ -10,12 +10,18 @@ use crate::{
 };
 
 const MESSAGE_HISTORY_LIMIT: u16 = 50;
+/// Mirrors the composer's `DM_ESTABLISHED_MESSAGE_THRESHOLD`. Keep them in sync.
+const DM_ESTABLISHED_MESSAGE_THRESHOLD: usize = 5;
+const DM_ESTABLISHED_SCAN_PAGES: usize = 2;
 const THREAD_PREVIEW_LIMIT: u16 = 1;
 const INBOX_MENTIONS_LIMIT: u16 = 25;
 const INBOX_CHANNEL_HISTORY_LIMIT: u16 = 5;
 
 pub(super) async fn handle(client: DiscordClient, command: AppCommand) {
     match command {
+        AppCommand::VerifyDmEstablished { channel_id } => {
+            verify_dm_established(&client, channel_id).await;
+        }
         AppCommand::LoadMessageHistory { channel_id, before } => {
             if let Some(before) = before
                 && !client.begin_older_message_history_request(channel_id, before)
@@ -389,6 +395,56 @@ pub(super) async fn handle(client: DiscordClient, command: AppCommand) {
             }
         }
         _ => unreachable!("non-history command routed to history handler"),
+    }
+}
+
+/// Best-effort background check off a DM open: a history load failure is logged
+/// and retried on the next open rather than surfaced to the user.
+async fn verify_dm_established(client: &DiscordClient, channel_id: Id<ChannelMarker>) {
+    let Some(current_user_id) = client.current_user_id() else {
+        return;
+    };
+
+    let mut sent = 0usize;
+    let mut before: Option<Id<MessageMarker>> = None;
+    for _ in 0..DM_ESTABLISHED_SCAN_PAGES {
+        let messages = match client
+            .load_message_history(channel_id, before, MESSAGE_HISTORY_LIMIT)
+            .await
+        {
+            Ok(messages) => messages,
+            Err(error) => {
+                logging::debug(
+                    "history",
+                    format!("verify dm established load failed: {error}"),
+                );
+                return;
+            }
+        };
+
+        sent += messages
+            .iter()
+            .filter(|message| message.author_id == current_user_id)
+            .count();
+        if sent >= DM_ESTABLISHED_MESSAGE_THRESHOLD {
+            break;
+        }
+
+        // A short page means we reached the start of the DM, so there is no
+        // older history left to scan.
+        let Some(oldest) = messages.iter().map(|message| message.message_id).min() else {
+            break;
+        };
+        if messages.len() < MESSAGE_HISTORY_LIMIT as usize {
+            break;
+        }
+        before = Some(oldest);
+    }
+
+    if sent >= DM_ESTABLISHED_MESSAGE_THRESHOLD {
+        client
+            .publish_event(AppEvent::DmEstablished { channel_id })
+            .await;
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -239,6 +239,9 @@ pub struct UiStateOptions {
     pub collapsed_channel_categories: Vec<Id<ChannelMarker>>,
     pub collapsed_server_folder_ids: Vec<u64>,
     pub collapsed_server_folder_guilds: Vec<Vec<Id<GuildMarker>>>,
+    /// DMs confirmed to hold enough of our own messages, persisted so the
+    /// composer skips re-scanning history on every open.
+    pub established_dms: Vec<Id<ChannelMarker>>,
 }
 
 impl Default for UiStateOptions {
@@ -253,6 +256,7 @@ impl Default for UiStateOptions {
             collapsed_channel_categories: Vec::new(),
             collapsed_server_folder_ids: Vec::new(),
             collapsed_server_folder_guilds: Vec::new(),
+            established_dms: Vec::new(),
         }
     }
 }

--- a/src/discord/commands.rs
+++ b/src/discord/commands.rs
@@ -477,6 +477,9 @@ pub enum AppCommand {
     TriggerTyping {
         channel_id: Id<ChannelMarker>,
     },
+    VerifyDmEstablished {
+        channel_id: Id<ChannelMarker>,
+    },
     SubscribeDirectMessage {
         channel_id: Id<ChannelMarker>,
     },

--- a/src/discord/events.rs
+++ b/src/discord/events.rs
@@ -143,6 +143,9 @@ pub enum AppEvent {
         user_id: Option<Id<UserMarker>>,
     },
     SignedOut,
+    DmEstablished {
+        channel_id: Id<ChannelMarker>,
+    },
     CurrentUserCapabilities {
         premium_tier: PremiumTier,
     },
@@ -572,6 +575,7 @@ define_app_event_kinds! {
     GatewayDispatchReceived: AppEvent::GatewayDispatchReceived { .. },
     Ready: AppEvent::Ready { .. },
     SignedOut: AppEvent::SignedOut,
+    DmEstablished: AppEvent::DmEstablished { .. },
     CurrentUserCapabilities: AppEvent::CurrentUserCapabilities { .. },
     UserIdentityUpdate: AppEvent::UserIdentityUpdate { .. },
     ApplicationCommandsLoaded: AppEvent::ApplicationCommandsLoaded { .. },
@@ -1637,7 +1641,8 @@ impl AppEventKind {
             | AppEventKind::RichPresenceDetected
             | AppEventKind::GatewayResumed
             | AppEventKind::GatewayReidentified
-            | AppEventKind::GatewayClosed => AppEventMetadata::effect_only(),
+            | AppEventKind::GatewayClosed
+            | AppEventKind::DmEstablished => AppEventMetadata::effect_only(),
 
             AppEventKind::VoiceServerUpdate => AppEventMetadata::inert(),
 

--- a/src/discord/state.rs
+++ b/src/discord/state.rs
@@ -1005,7 +1005,8 @@ impl DiscordState {
             | AppEvent::ActivateChannel { .. }
             | AppEvent::GatewayResumed
             | AppEvent::GatewayReidentified
-            | AppEvent::GatewayClosed => {}
+            | AppEvent::GatewayClosed
+            | AppEvent::DmEstablished { .. } => {}
         }
     }
 

--- a/src/tui/state/channels.rs
+++ b/src/tui/state/channels.rs
@@ -1197,6 +1197,10 @@ impl DashboardState {
         }
 
         self.refresh_composer_emoji_candidates_for_current_query();
+
+        if self.selected_dm_needs_establishment_verification() {
+            self.enqueue_pending_command(AppCommand::VerifyDmEstablished { channel_id });
+        }
     }
 
     fn record_message_channel_view_transition(

--- a/src/tui/state/composer/state.rs
+++ b/src/tui/state/composer/state.rs
@@ -42,14 +42,30 @@ use crate::tui::text_input::TextInputState;
 pub enum DmComposerLock {
     Spam,
     MessageRequest,
-    /// No locally known message authored by us, so the first send would hit the
-    /// CAPTCHA gate.
-    NeverMessaged,
+    /// The DM is too new or holds too few of our own messages, where an early
+    /// send would trip Discord's CAPTCHA / spam gate.
+    NotEstablished,
 }
 
 /// Discord keeps a typing indicator alive for about ten seconds, so resend a
 /// little sooner while the user keeps typing.
 const COMPOSER_TYPING_INTERVAL: Duration = Duration::from_secs(8);
+
+const DM_ESTABLISHED_MESSAGE_THRESHOLD: usize = 5;
+const DM_ESTABLISHED_MIN_AGE_MS: u64 = 24 * 60 * 60 * 1000;
+
+const DISCORD_EPOCH_MS: u64 = 1_420_070_400_000;
+
+fn snowflake_created_ms<T>(id: Id<T>) -> u64 {
+    (id.get() >> 22) + DISCORD_EPOCH_MS
+}
+
+fn current_unix_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_millis() as u64)
+        .unwrap_or(0)
+}
 
 #[derive(Debug, Default)]
 pub(in crate::tui::state) struct ComposerUiState {
@@ -343,16 +359,11 @@ impl DashboardState {
         }
     }
 
-    /// Why the composer is locked in the selected one-to-one DM, or `None` when
-    /// sending is allowed (or the selection is not a DM). Sending the first
-    /// message into such a DM is what triggers Discord's CAPTCHA gate, which a
-    /// terminal cannot solve, so we lock first (issue #218).
-    ///
-    /// The `NeverMessaged` case trusts locally cached history. A dormant DM whose
-    /// latest page holds only the other side's messages reads as locked until one
-    /// of our own messages pages back in. That is the safe failure: a temporary
-    /// read-only composer rather than an unintended send.
     pub fn dm_composer_lock(&self) -> Option<DmComposerLock> {
+        self.dm_composer_lock_at(current_unix_ms())
+    }
+
+    pub(in crate::tui::state) fn dm_composer_lock_at(&self, now_ms: u64) -> Option<DmComposerLock> {
         let channel = self.selected_channel_state()?;
         if !channel.is_dm() {
             return None;
@@ -363,16 +374,52 @@ impl DashboardState {
         if channel.is_message_request == Some(true) {
             return Some(DmComposerLock::MessageRequest);
         }
-        // Without our own id we cannot prove we have written here, so defer to
-        // the flags above and otherwise allow sending.
+        let aged =
+            now_ms.saturating_sub(snowflake_created_ms(channel.id)) >= DM_ESTABLISHED_MIN_AGE_MS;
+        // Without our own id we cannot count our messages, so allow sending.
+        let has_enough_messages = self
+            .navigation
+            .channels
+            .established_dms
+            .contains(&channel.id)
+            || self.dm_own_message_count(channel.id)? >= DM_ESTABLISHED_MESSAGE_THRESHOLD;
+        (!(aged && has_enough_messages)).then_some(DmComposerLock::NotEstablished)
+    }
+
+    fn dm_own_message_count(&self, channel_id: Id<ChannelMarker>) -> Option<usize> {
         let current_user_id = self.current_user_id()?;
-        let has_sent = self
-            .discord
-            .cache
-            .messages_for_channel(channel.id)
-            .iter()
-            .any(|message| message.author_id == current_user_id);
-        (!has_sent).then_some(DmComposerLock::NeverMessaged)
+        Some(
+            self.discord
+                .cache
+                .messages_for_channel(channel_id)
+                .iter()
+                .filter(|message| message.author_id == current_user_id)
+                .count(),
+        )
+    }
+
+    pub(in crate::tui::state) fn record_dm_established(&mut self, channel_id: Id<ChannelMarker>) {
+        if self.navigation.channels.established_dms.insert(channel_id) {
+            self.options.ui_state_save_pending = true;
+        }
+    }
+
+    pub(in crate::tui::state) fn selected_dm_needs_establishment_verification(&self) -> bool {
+        let Some(channel) = self.selected_channel_state() else {
+            return false;
+        };
+        if self
+            .navigation
+            .channels
+            .established_dms
+            .contains(&channel.id)
+        {
+            return false;
+        }
+        matches!(
+            self.dm_composer_lock(),
+            Some(DmComposerLock::NotEstablished)
+        )
     }
 
     fn can_send_tts_in_selected_channel(&self) -> bool {

--- a/src/tui/state/events.rs
+++ b/src/tui/state/events.rs
@@ -167,6 +167,9 @@ impl DashboardState {
             AppEvent::CurrentUserCapabilities { premium_tier } => {
                 self.discord.current_user_premium_tier = Some(*premium_tier);
             }
+            AppEvent::DmEstablished { channel_id } => {
+                self.record_dm_established(*channel_id);
+            }
             AppEvent::ApplicationCommandsLoaded { guild_id, commands } => {
                 self.discord
                     .application_commands

--- a/src/tui/state/navigation.rs
+++ b/src/tui/state/navigation.rs
@@ -71,6 +71,7 @@ pub(super) struct ChannelPaneNavigationState {
     pub(super) visible: bool,
     pub(super) width: u16,
     pub(super) collapsed_channel_categories: HashSet<Id<ChannelMarker>>,
+    pub(super) established_dms: HashSet<Id<ChannelMarker>>,
 }
 
 #[derive(Debug)]
@@ -247,6 +248,7 @@ impl Default for ChannelPaneNavigationState {
             visible: true,
             width: DEFAULT_CHANNEL_LIST_WIDTH,
             collapsed_channel_categories: HashSet::new(),
+            established_dms: HashSet::new(),
         }
     }
 }

--- a/src/tui/state/options.rs
+++ b/src/tui/state/options.rs
@@ -152,6 +152,7 @@ impl DashboardState {
         }
         self.navigation.channels.collapsed_channel_categories =
             options.collapsed_channel_categories.into_iter().collect();
+        self.navigation.channels.established_dms = options.established_dms.into_iter().collect();
         self.navigation.guilds.collapsed_folders = options
             .collapsed_server_folder_ids
             .into_iter()
@@ -174,6 +175,15 @@ impl DashboardState {
             .copied()
             .collect();
         collapsed_channel_categories.sort_by_key(|id| id.get());
+
+        let mut established_dms: Vec<_> = self
+            .navigation
+            .channels
+            .established_dms
+            .iter()
+            .copied()
+            .collect();
+        established_dms.sort_by_key(|id| id.get());
 
         let mut collapsed_server_folder_ids = Vec::new();
         let mut collapsed_server_folder_guilds = Vec::new();
@@ -200,6 +210,7 @@ impl DashboardState {
             collapsed_channel_categories,
             collapsed_server_folder_ids,
             collapsed_server_folder_guilds,
+            established_dms,
         }
     }
 

--- a/src/tui/state/tests/direct_messages.rs
+++ b/src/tui/state/tests/direct_messages.rs
@@ -84,7 +84,7 @@ fn restoring_discord_snapshot_recovers_missed_guilds_and_direct_messages() {
 }
 
 #[test]
-fn dm_composer_locks_until_current_user_has_sent_a_message() {
+fn dm_composer_locks_until_conversation_is_established() {
     let mut state = DashboardState::new();
     state.push_event(AppEvent::Ready {
         user: "me".to_owned(),
@@ -109,17 +109,31 @@ fn dm_composer_locks_until_current_user_has_sent_a_message() {
     }));
     assert_eq!(
         state.dm_composer_lock(),
-        Some(DmComposerLock::NeverMessaged)
+        Some(DmComposerLock::NotEstablished)
     );
     assert!(!state.can_send_in_selected_channel());
+
+    for message_id in 201..205 {
+        state.push_event(message_create_event(MessageCreateFixture {
+            guild_id: None,
+            channel_id: Id::new(20),
+            message_id: Id::new(message_id),
+            author_id: Id::new(1),
+            content: Some("hey".to_owned()),
+            ..guild_message_create_fixture()
+        }));
+    }
+    assert_eq!(
+        state.dm_composer_lock(),
+        Some(DmComposerLock::NotEstablished)
+    );
     state.start_composer();
     assert!(!state.is_composing());
 
-    // Once one of our own messages syncs in, the composer unlocks.
     state.push_event(message_create_event(MessageCreateFixture {
         guild_id: None,
         channel_id: Id::new(20),
-        message_id: Id::new(201),
+        message_id: Id::new(205),
         author_id: Id::new(1),
         content: Some("hey".to_owned()),
         ..guild_message_create_fixture()
@@ -128,6 +142,95 @@ fn dm_composer_locks_until_current_user_has_sent_a_message() {
     assert!(state.can_send_in_selected_channel());
     state.start_composer();
     assert!(state.is_composing());
+}
+
+#[test]
+fn dm_composer_locks_fresh_dm_until_a_day_has_passed() {
+    let mut state = DashboardState::new();
+    state.push_event(AppEvent::Ready {
+        user: "me".to_owned(),
+        user_id: Some(Id::new(1)),
+    });
+    let created_ms = 1_700_000_000_000u64;
+    let channel_id = Id::new((created_ms - 1_420_070_400_000) << 22);
+    state.push_event(AppEvent::ChannelUpsert(dm_channel_info(
+        channel_id, "alice",
+    )));
+    state.confirm_selected_guild();
+    state.confirm_selected_channel();
+
+    for message_id in 201..206 {
+        state.push_event(message_create_event(MessageCreateFixture {
+            guild_id: None,
+            channel_id,
+            message_id: Id::new(message_id),
+            author_id: Id::new(1),
+            content: Some("hey".to_owned()),
+            ..guild_message_create_fixture()
+        }));
+    }
+
+    let same_day = created_ms + 60 * 60 * 1000;
+    assert_eq!(
+        state.dm_composer_lock_at(same_day),
+        Some(DmComposerLock::NotEstablished)
+    );
+
+    let next_day = created_ms + 25 * 60 * 60 * 1000;
+    assert_eq!(state.dm_composer_lock_at(next_day), None);
+}
+
+#[test]
+fn recording_dm_established_unlocks_composer_and_persists() {
+    let mut state = DashboardState::new();
+    state.push_event(AppEvent::Ready {
+        user: "me".to_owned(),
+        user_id: Some(Id::new(1)),
+    });
+    state.push_event(AppEvent::ChannelUpsert(dm_channel_info(
+        Id::new(20),
+        "alice",
+    )));
+    state.confirm_selected_guild();
+    state.confirm_selected_channel();
+    assert_eq!(
+        state.dm_composer_lock(),
+        Some(DmComposerLock::NotEstablished)
+    );
+
+    state.push_event(AppEvent::DmEstablished {
+        channel_id: Id::new(20),
+    });
+    assert_eq!(state.dm_composer_lock(), None);
+    assert!(state.can_send_in_selected_channel());
+
+    let saved = state
+        .take_ui_state_save_request()
+        .expect("establishing a DM requests a save");
+    assert!(saved.established_dms.contains(&Id::new(20)));
+}
+
+#[test]
+fn opening_a_fresh_dm_enqueues_an_establishment_check() {
+    let mut state = DashboardState::new();
+    state.push_event(AppEvent::Ready {
+        user: "me".to_owned(),
+        user_id: Some(Id::new(1)),
+    });
+    state.push_event(AppEvent::ChannelUpsert(dm_channel_info(
+        Id::new(20),
+        "alice",
+    )));
+    state.confirm_selected_guild();
+    state.confirm_selected_channel();
+
+    assert!(
+        state
+            .drain_pending_commands()
+            .contains(&AppCommand::VerifyDmEstablished {
+                channel_id: Id::new(20),
+            })
+    );
 }
 
 #[test]

--- a/src/tui/ui/panes/composer.rs
+++ b/src/tui/ui/panes/composer.rs
@@ -911,9 +911,9 @@ pub(in crate::tui::ui) fn composer_text(state: &DashboardState, width: u16) -> S
                         "read-only · {label} is a message request. accept it in the official app first"
                     )
                 }
-                DmComposerLock::NeverMessaged => {
+                DmComposerLock::NotEstablished => {
                     format!(
-                        "read-only · no past messages with {label}. send the first one from the official app"
+                        "read-only · {label} is a new conversation. send at least 5 messages from the official app and wait a day before sending here"
                     )
                 }
             };


### PR DESCRIPTION
<!--
Thanks for the contribution. Please keep the subject under ~72 characters
and use a semantic prefix (feat:, fix:, refactor:, docs:, chore:, test:).

By submitting this PR you agree it will be distributed under GPL-3.0-only.
-->

## Summary

<!-- What does this change do, in one or two sentences? -->

## Why

Closes #244 

<!-- The motivation. Link the issue it closes, e.g. "Closes #123". -->
<!-- Feature additions must have a related issue first. Feature PRs without a related issue may be closed without review. -->

## How

<!-- Notable implementation choices and any non-obvious trade-offs. -->

## Testing

<!-- How you verified the change. Mention the OS, terminal, and graphics protocol used for manual checks. -->

- [ ] `cargo fmt --all --check`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo test --all-features`
- [ ] Manual test in a real terminal (describe below)

## Screenshots or recordings

<!-- For UI changes, attach a screenshot or asciinema/gif. Delete this section if not applicable. -->

## Checklist

- [ ] One logical change per PR.
- [ ] Link a related issue.
- [ ] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [ ] Change does not add self-bot automation, mass actions, or scraping.
- [ ] Updated `README.md`, if behavior or workflows changed.
