### PR TITLE
Show direct message user activity

### DIFF
--- a/src/tui/media/targets.rs
+++ b/src/tui/media/targets.rs
@@ -730,6 +730,11 @@ pub(in crate::tui) fn visible_emoji_image_targets(state: &DashboardState) -> Vec
             &mut targets,
         );
     }
+    for row in state.visible_channel_pane_rows() {
+        if let Some(activity) = row.activity() {
+            push_activity_emoji_targets(std::iter::once(activity), &mut seen, &mut targets);
+        }
+    }
 
     targets
 }

--- a/src/tui/media/tests.rs
+++ b/src/tui/media/tests.rs
@@ -12,8 +12,9 @@ use crate::{
     config::{DisplayOptions, ImagePreviewQualityPreset},
     discord::{
         ActivityEmoji, ActivityInfo, ActivityKind, AppCommand, AppEvent, AttachmentInfo,
-        ChannelInfo, CustomEmojiInfo, EmbedInfo, MessageInfo, MessageSnapshotInfo,
-        PresenceEventFields, ProfileAvatarUpload, ReactionEmoji, ReactionInfo, UserProfileInfo,
+        ChannelInfo, ChannelRecipientInfo, CustomEmojiInfo, EmbedInfo, MessageInfo,
+        MessageSnapshotInfo, PresenceEventFields, PresenceStatus, ProfileAvatarUpload,
+        ReactionEmoji, ReactionInfo, UserProfileInfo,
     },
     tui::{
         message::time::test_message_id_for_unix_millis,
@@ -1692,6 +1693,54 @@ fn emoji_image_targets_keep_profile_popup_activity_emoji_while_modal_is_open() {
         targets,
         vec![EmojiImageTarget {
             url: "https://cdn.discordapp.com/emojis/60.png".to_owned(),
+        }]
+    );
+}
+
+#[test]
+fn emoji_image_targets_include_visible_non_selected_dm_activity() {
+    let alice = Id::new(10);
+    let bob = Id::new(20);
+    let mut state = DashboardState::new();
+    for (channel_id, user_id, name, last_message_id) in [
+        (Id::new(100), alice, "alice", Id::new(200)),
+        (Id::new(101), bob, "bob", Id::new(100)),
+    ] {
+        state.push_event(AppEvent::ChannelUpsert(ChannelInfo {
+            last_message_id: Some(last_message_id),
+            recipients: Some(vec![ChannelRecipientInfo {
+                status: Some(PresenceStatus::Online),
+                ..ChannelRecipientInfo::test(user_id, name)
+            }]),
+            ..ChannelInfo::test(channel_id, "dm")
+        }));
+    }
+    state.push_event(AppEvent::PresenceUpdate {
+        guild_id: None,
+        presence: PresenceEventFields {
+            user_id: bob,
+            status: PresenceStatus::Online,
+            activities: vec![ActivityInfo {
+                emoji: Some(ActivityEmoji {
+                    name: "coffee".to_owned(),
+                    id: Some(Id::new(70)),
+                    animated: false,
+                }),
+                state: Some("Taking a break".to_owned()),
+                ..ActivityInfo::test(ActivityKind::Custom, "Custom Status")
+            }],
+        },
+    });
+    state.confirm_selected_guild();
+    state.confirm_selected_channel();
+    state.set_channel_view_height(10);
+
+    let targets = visible_emoji_image_targets(&state);
+
+    assert_eq!(
+        targets,
+        vec![EmojiImageTarget {
+            url: "https://cdn.discordapp.com/emojis/70.png".to_owned(),
         }]
     );
 }

--- a/src/tui/runtime/redraw_gate.rs
+++ b/src/tui/runtime/redraw_gate.rs
@@ -18,7 +18,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::fmt::{self, Write as _};
 use std::hash::{Hash as _, Hasher as _};
 
-use crate::tui::state::{DashboardState, NotificationInboxTab};
+use crate::tui::state::{ChannelPaneRow, DashboardState, NotificationInboxTab};
 
 /// Hash a value's `Debug` output into the running hasher. Lets us fingerprint
 /// view state without requiring every involved type to implement `Hash`.
@@ -68,13 +68,25 @@ pub(super) fn view_signature(state: &DashboardState) -> u64 {
     }
 
     // Channel sidebar with its unread badges.
-    for entry in state.visible_channel_pane_entries() {
-        hash_dbg(&mut hasher, &entry);
-        if let Some(channel) = entry.channel_state() {
-            hash_dbg(&mut hasher, &state.channel_unread(channel.id));
-            state
-                .channel_unread_message_count(channel.id)
-                .hash(&mut hasher);
+    for row in state.visible_channel_pane_rows() {
+        match row {
+            ChannelPaneRow::Entry { entry, .. } => {
+                hash_dbg(&mut hasher, &entry);
+                if let Some(channel) = entry.channel_state() {
+                    hash_dbg(&mut hasher, &state.channel_unread(channel.id));
+                    state
+                        .channel_unread_message_count(channel.id)
+                        .hash(&mut hasher);
+                }
+            }
+            ChannelPaneRow::Activity {
+                owner_entry_index,
+                recipient_id,
+                activity,
+                ..
+            } => {
+                hash_dbg(&mut hasher, &(owner_entry_index, recipient_id, activity));
+            }
         }
     }
 
@@ -140,7 +152,10 @@ pub(super) fn view_signature(state: &DashboardState) -> u64 {
 mod tests {
     use super::view_signature;
     use crate::discord::ids::Id;
-    use crate::discord::{AppEvent, ChannelInfo, MessageHistoryLoadTarget};
+    use crate::discord::{
+        ActivityInfo, ActivityKind, AppEvent, ChannelInfo, ChannelRecipientInfo,
+        MessageHistoryLoadTarget, PresenceEventFields, PresenceStatus,
+    };
     use crate::tui::state::DashboardState;
 
     #[test]
@@ -184,5 +199,41 @@ mod tests {
             message: "offline".to_owned(),
         });
         assert_ne!(loaded, view_signature(&state));
+    }
+
+    #[test]
+    fn view_signature_tracks_visible_dm_activity_changes() {
+        let user_id = Id::new(10);
+        let mut state = DashboardState::new();
+        state.push_event(AppEvent::ChannelUpsert(ChannelInfo {
+            recipients: Some(vec![ChannelRecipientInfo {
+                status: Some(PresenceStatus::Online),
+                ..ChannelRecipientInfo::test(user_id, "alice")
+            }]),
+            ..ChannelInfo::test(Id::new(20), "dm")
+        }));
+        state.confirm_selected_guild();
+        state.set_channel_view_height(4);
+
+        state.push_event(AppEvent::PresenceUpdate {
+            guild_id: None,
+            presence: PresenceEventFields {
+                user_id,
+                status: PresenceStatus::Online,
+                activities: vec![ActivityInfo::test(ActivityKind::Playing, "Game A")],
+            },
+        });
+        let game_a = view_signature(&state);
+
+        state.push_event(AppEvent::PresenceUpdate {
+            guild_id: None,
+            presence: PresenceEventFields {
+                user_id,
+                status: PresenceStatus::Online,
+                activities: vec![ActivityInfo::test(ActivityKind::Playing, "Game B")],
+            },
+        });
+
+        assert_ne!(game_a, view_signature(&state));
     }
 }

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -5,6 +5,7 @@ use crate::discord::ids::marker::{GuildMarker, UserMarker};
 use crate::discord::{
     AppCommand, AppEvent, ForumPostArchiveState, MentionInfo, MessageSnapshotInfo,
 };
+mod channel_rows;
 mod channel_tree;
 mod channels;
 mod composer;
@@ -57,6 +58,7 @@ use scroll::clamp_selected_index;
 
 pub(in crate::tui) const MINIMUM_ESTABLISHED_DM_MESSAGES: usize = 5;
 
+pub(in crate::tui) use channel_rows::ChannelPaneRow;
 pub use composer::{
     CommandPickerEntry, ComposerLock, EmojiPickerEntry, MAX_MENTION_PICKER_VISIBLE,
     MentionPickerEntry, MentionPickerTarget,
@@ -91,6 +93,7 @@ pub use popups::{
     PollVotePickerState, ReactionUsersEntry, ReactionUsersPopupState, UserProfileSettingsField,
     UserProfileSettingsTab,
 };
+pub(in crate::tui) use presentation::primary_compact_activity;
 pub use presentation::{
     apply_discord_foreground, discord_role_mention_background, folder_style, normal_text_style,
     presence_marker, presence_style,

--- a/src/tui/state/channel_rows.rs
+++ b/src/tui/state/channel_rows.rs
@@ -1,0 +1,109 @@
+use crate::discord::ids::{Id, marker::UserMarker};
+use crate::discord::{ActivityInfo, PresenceStatus};
+
+use super::model::ChannelPaneEntry;
+use super::{DashboardState, primary_compact_activity};
+
+/// One visual line in the channel pane.
+///
+/// Activity rows keep their parent's entry index so navigation can resolve the
+/// line without giving the activity an independent cursor.
+#[derive(Clone, Debug)]
+pub(in crate::tui) enum ChannelPaneRow<'a> {
+    Entry {
+        entry_index: usize,
+        entry: ChannelPaneEntry<'a>,
+    },
+    Activity {
+        owner_entry_index: usize,
+        entry: ChannelPaneEntry<'a>,
+        recipient_id: Id<UserMarker>,
+        activity: &'a ActivityInfo,
+    },
+}
+
+impl<'a> ChannelPaneRow<'a> {
+    pub(in crate::tui) fn entry_index(&self) -> usize {
+        match self {
+            Self::Entry { entry_index, .. } => *entry_index,
+            Self::Activity {
+                owner_entry_index, ..
+            } => *owner_entry_index,
+        }
+    }
+
+    pub(in crate::tui) fn entry(&self) -> &ChannelPaneEntry<'a> {
+        match self {
+            Self::Entry { entry, .. } | Self::Activity { entry, .. } => entry,
+        }
+    }
+
+    pub(in crate::tui) fn activity(&self) -> Option<&'a ActivityInfo> {
+        match self {
+            Self::Activity { activity, .. } => Some(activity),
+            Self::Entry { .. } => None,
+        }
+    }
+
+    pub(in crate::tui) fn is_entry(&self) -> bool {
+        matches!(self, Self::Entry { .. })
+    }
+}
+
+impl DashboardState {
+    pub(in crate::tui) fn channel_pane_rows(&self) -> Vec<ChannelPaneRow<'_>> {
+        let entries = self.channel_pane_filtered_entries();
+        self.channel_pane_rows_from_entries(&entries)
+    }
+
+    pub(in crate::tui) fn channel_pane_rows_from_entries<'a>(
+        &'a self,
+        entries: &[ChannelPaneEntry<'a>],
+    ) -> Vec<ChannelPaneRow<'a>> {
+        let mut rows = Vec::with_capacity(entries.len().saturating_mul(2));
+
+        for (entry_index, entry) in entries.iter().enumerate() {
+            rows.push(ChannelPaneRow::Entry {
+                entry_index,
+                entry: entry.clone(),
+            });
+
+            let ChannelPaneEntry::Channel { state: channel, .. } = entry else {
+                continue;
+            };
+            if !channel.is_dm() {
+                continue;
+            }
+            let Some(recipient) = channel.recipients.first() else {
+                continue;
+            };
+            if matches!(
+                recipient.status,
+                PresenceStatus::Offline | PresenceStatus::Unknown
+            ) {
+                continue;
+            }
+            let Some(activity) = primary_compact_activity(self.user_activities(recipient.user_id))
+            else {
+                continue;
+            };
+
+            rows.push(ChannelPaneRow::Activity {
+                owner_entry_index: entry_index,
+                entry: entry.clone(),
+                recipient_id: recipient.user_id,
+                activity,
+            });
+        }
+
+        rows
+    }
+
+    pub(in crate::tui) fn visible_channel_pane_rows(&self) -> Vec<ChannelPaneRow<'_>> {
+        self.channel_pane_rows()
+            .into_iter()
+            .skip(self.channel_scroll())
+            .take(self.channel_content_height())
+            .collect()
+    }
+}

--- a/src/tui/state/channels.rs
+++ b/src/tui/state/channels.rs
@@ -787,20 +787,6 @@ impl DashboardState {
         self.clamp_channel_viewport();
     }
 
-    pub(super) fn move_channel_selection_down_by(&mut self, distance: usize) {
-        let selected = self.selected_channel();
-        self.select_channel_entry_near(selected.saturating_add(distance), true);
-        self.navigation.channels.list.keep_selection_visible();
-        self.clamp_channel_viewport();
-    }
-
-    pub(super) fn move_channel_selection_up_by(&mut self, distance: usize) {
-        let selected = self.selected_channel();
-        self.select_channel_entry_near(selected.saturating_sub(distance), false);
-        self.navigation.channels.list.keep_selection_visible();
-        self.clamp_channel_viewport();
-    }
-
     pub(super) fn jump_channel_selection_top(&mut self) {
         self.select_channel_entry_near(0, true);
         self.navigation.channels.list.keep_selection_visible();
@@ -829,25 +815,33 @@ impl DashboardState {
             .map(ChannelPaneEntry::cursor)
     }
 
-    pub fn channel_scroll(&self) -> usize {
-        self.navigation.channels.list.scroll
-    }
-
     pub fn visible_channel_pane_entries(&self) -> Vec<ChannelPaneEntry<'_>> {
-        self.channel_pane_filtered_entries()
-            .into_iter()
-            .skip(self.navigation.channels.list.scroll)
-            .take(self.navigation.channels.list.content_height())
-            .collect()
+        let scroll = self.navigation.channels.list.scroll;
+        let height = self.navigation.channels.list.content_height();
+        let visible_end = scroll.saturating_add(height);
+        let entries = self.channel_pane_filtered_entries();
+        let mut result = Vec::new();
+        let mut line_index = 0usize;
+        for entry in entries {
+            let entry_lines = 1 + usize::from(self.channel_entry_has_activity_row(&entry));
+            if line_index >= visible_end {
+                break;
+            }
+            if line_index + entry_lines > scroll {
+                result.push(entry);
+            }
+            line_index += entry_lines;
+        }
+        result
     }
 
     pub fn set_channel_view_height(&mut self, height: usize) {
-        let len = self.channel_pane_filtered_entries().len();
-        let selected = self.navigation.channels.list.selected;
+        let selected_line = self.selected_channel_line_from_entries();
+        let len = self.count_channel_lines();
         self.navigation
             .channels
             .list
-            .set_view_height_and_clamp(height, selected, len);
+            .set_view_height_and_clamp(height, selected_line, len);
     }
 
     pub(super) fn restore_channel_cursor(&mut self, channel_id: Option<Id<ChannelMarker>>) {

--- a/src/tui/state/channels.rs
+++ b/src/tui/state/channels.rs
@@ -815,22 +815,16 @@ impl DashboardState {
             .map(ChannelPaneEntry::cursor)
     }
 
+    #[cfg(test)]
     pub fn visible_channel_pane_entries(&self) -> Vec<ChannelPaneEntry<'_>> {
-        let scroll = self.navigation.channels.list.scroll;
-        let height = self.navigation.channels.list.content_height();
-        let visible_end = scroll.saturating_add(height);
-        let entries = self.channel_pane_filtered_entries();
         let mut result = Vec::new();
-        let mut line_index = 0usize;
-        for entry in entries {
-            let entry_lines = 1 + usize::from(self.channel_entry_has_activity_row(&entry));
-            if line_index >= visible_end {
-                break;
+        let mut previous_entry_index = None;
+        for row in self.visible_channel_pane_rows() {
+            let entry_index = row.entry_index();
+            if previous_entry_index != Some(entry_index) {
+                result.push(row.entry().clone());
+                previous_entry_index = Some(entry_index);
             }
-            if line_index + entry_lines > scroll {
-                result.push(entry);
-            }
-            line_index += entry_lines;
         }
         result
     }

--- a/src/tui/state/navigation.rs
+++ b/src/tui/state/navigation.rs
@@ -901,20 +901,28 @@ impl DashboardState {
 
     pub fn channel_entry_has_activity_row(&self, entry: &ChannelPaneEntry<'_>) -> bool {
         match entry {
-            ChannelPaneEntry::Channel { state, .. } if state.is_dm() && !state.recipients.is_empty() => {
+            ChannelPaneEntry::Channel { state, .. }
+                if state.is_dm() && !state.recipients.is_empty() =>
+            {
                 let recipient = &state.recipients[0];
-                !matches!(recipient.status, PresenceStatus::Offline | PresenceStatus::Unknown)
-                    && !self.user_activities(recipient.user_id).is_empty()
+                !matches!(
+                    recipient.status,
+                    PresenceStatus::Offline | PresenceStatus::Unknown
+                ) && !self.user_activities(recipient.user_id).is_empty()
             }
             _ => false,
         }
     }
 
     pub(super) fn selected_channel_line(&self, entries: &[ChannelPaneEntry<'_>]) -> Option<usize> {
-        let selected_channel = self.navigation.channels.list.selected.min(entries.len().saturating_sub(1));
-        let mut channel_index = 0usize;
+        let selected_channel = self
+            .navigation
+            .channels
+            .list
+            .selected
+            .min(entries.len().saturating_sub(1));
         let mut line_index = 0usize;
-        for entry in entries {
+        for (channel_index, entry) in entries.iter().enumerate() {
             if channel_index == selected_channel {
                 return Some(line_index);
             }
@@ -922,7 +930,6 @@ impl DashboardState {
             if self.channel_entry_has_activity_row(entry) {
                 line_index += 1;
             }
-            channel_index += 1;
         }
         None
     }
@@ -949,11 +956,9 @@ impl DashboardState {
     fn channel_line_indices(&self) -> Vec<(usize, usize)> {
         let entries = self.channel_pane_filtered_entries();
         let mut indices = Vec::new();
-        let mut entry_index = 0usize;
         let mut line_index = 0usize;
-        for entry in &entries {
+        for (entry_index, entry) in entries.iter().enumerate() {
             indices.push((entry_index, line_index));
-            entry_index += 1;
             line_index += 1;
             if self.channel_entry_has_activity_row(entry) {
                 line_index += 1;

--- a/src/tui/state/navigation.rs
+++ b/src/tui/state/navigation.rs
@@ -13,7 +13,8 @@ use super::scroll::{
     move_index_up, move_index_up_by, pane_content_height, scroll_list_down, scroll_list_up,
 };
 use super::{
-    ChannelPaneEntry, DashboardState, FocusPane, MemberEntry, MemberGroup, PaneFilterState,
+    ChannelPaneEntry, ChannelPaneRow, DashboardState, FocusPane, MemberEntry, MemberGroup,
+    PaneFilterState,
 };
 use crate::tui::text_input::TextInputState;
 
@@ -39,6 +40,12 @@ enum FocusedNavigationAction {
     ScrollViewportUp,
     ScrollHorizontalRight,
     ScrollHorizontalLeft,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ChannelLineDirection {
+    Forward,
+    Backward,
 }
 
 #[derive(Debug)]
@@ -545,14 +552,20 @@ impl DashboardState {
             FocusedNavigationAction::HalfPageDown => {
                 let distance = self.navigation.channels.list.content_height() / 2;
                 let selected_line = self.selected_channel_line_from_entries();
-                self.select_channel_near_line(selected_line.saturating_add(distance.max(1)));
+                self.select_channel_near_line(
+                    selected_line.saturating_add(distance.max(1)),
+                    ChannelLineDirection::Forward,
+                );
                 self.navigation.channels.list.keep_selection_visible();
                 self.clamp_channel_viewport();
             }
             FocusedNavigationAction::HalfPageUp => {
                 let distance = self.navigation.channels.list.content_height() / 2;
                 let selected_line = self.selected_channel_line_from_entries();
-                self.select_channel_near_line(selected_line.saturating_sub(distance.max(1)));
+                self.select_channel_near_line(
+                    selected_line.saturating_sub(distance.max(1)),
+                    ChannelLineDirection::Backward,
+                );
                 self.navigation.channels.list.keep_selection_visible();
                 self.clamp_channel_viewport();
             }
@@ -758,21 +771,17 @@ impl DashboardState {
 
     fn select_visible_channel_row(&mut self, row: usize) -> bool {
         let target_line = self.navigation.channels.list.scroll.saturating_add(row);
-        let entries = self.channel_pane_filtered_entries();
-        for (entry_index, line_index) in self.channel_line_indices() {
-            if line_index == target_line {
-                if entries
-                    .get(entry_index)
-                    .is_some_and(ChannelPaneEntry::is_selectable)
-                {
-                    self.navigation.channels.list.selected = entry_index;
-                    self.navigation.channels.list.keep_selection_visible();
-                    return true;
-                }
-                return false;
-            }
+        let rows = self.channel_pane_rows();
+        let Some(ChannelPaneRow::Entry { entry_index, entry }) = rows.get(target_line) else {
+            return false;
+        };
+        if !entry.is_selectable() {
+            return false;
         }
-        false
+
+        self.navigation.channels.list.selected = *entry_index;
+        self.navigation.channels.list.keep_selection_visible();
+        true
     }
 
     fn select_visible_member_line(&mut self, row: usize) -> bool {
@@ -899,21 +908,6 @@ impl DashboardState {
             .clamp_viewport(selected_line, len);
     }
 
-    pub fn channel_entry_has_activity_row(&self, entry: &ChannelPaneEntry<'_>) -> bool {
-        match entry {
-            ChannelPaneEntry::Channel { state, .. }
-                if state.is_dm() && !state.recipients.is_empty() =>
-            {
-                let recipient = &state.recipients[0];
-                !matches!(
-                    recipient.status,
-                    PresenceStatus::Offline | PresenceStatus::Unknown
-                ) && !self.user_activities(recipient.user_id).is_empty()
-            }
-            _ => false,
-        }
-    }
-
     pub(super) fn selected_channel_line(&self, entries: &[ChannelPaneEntry<'_>]) -> Option<usize> {
         let selected_channel = self
             .navigation
@@ -921,17 +915,9 @@ impl DashboardState {
             .list
             .selected
             .min(entries.len().saturating_sub(1));
-        let mut line_index = 0usize;
-        for (channel_index, entry) in entries.iter().enumerate() {
-            if channel_index == selected_channel {
-                return Some(line_index);
-            }
-            line_index += 1;
-            if self.channel_entry_has_activity_row(entry) {
-                line_index += 1;
-            }
-        }
-        None
+        self.channel_pane_rows_from_entries(entries)
+            .iter()
+            .position(|row| row.is_entry() && row.entry_index() == selected_channel)
     }
 
     pub(super) fn selected_channel_line_from_entries(&self) -> usize {
@@ -939,55 +925,31 @@ impl DashboardState {
         self.selected_channel_line(&entries).unwrap_or_default()
     }
 
-    pub fn channel_entry_line_count(&self, entries: &[ChannelPaneEntry<'_>]) -> usize {
-        entries
-            .iter()
-            .map(|e| 1 + usize::from(self.channel_entry_has_activity_row(e)))
-            .sum()
-    }
-
     pub(super) fn count_channel_lines(&self) -> usize {
-        self.channel_pane_filtered_entries()
-            .iter()
-            .map(|e| 1 + usize::from(self.channel_entry_has_activity_row(e)))
-            .sum()
+        self.channel_pane_rows().len()
     }
 
-    fn channel_line_indices(&self) -> Vec<(usize, usize)> {
-        let entries = self.channel_pane_filtered_entries();
-        let mut indices = Vec::new();
-        let mut line_index = 0usize;
-        for (entry_index, entry) in entries.iter().enumerate() {
-            indices.push((entry_index, line_index));
-            line_index += 1;
-            if self.channel_entry_has_activity_row(entry) {
-                line_index += 1;
-            }
-        }
-        indices
-    }
+    fn select_channel_near_line(&mut self, target_line: usize, direction: ChannelLineDirection) {
+        let rows = self.channel_pane_rows();
+        let candidate = match direction {
+            ChannelLineDirection::Forward => rows
+                .iter()
+                .skip(target_line)
+                .find(|row| row.is_entry() && row.entry().is_selectable())
+                .or_else(|| {
+                    rows.iter()
+                        .rev()
+                        .find(|row| row.is_entry() && row.entry().is_selectable())
+                }),
+            ChannelLineDirection::Backward => rows
+                .iter()
+                .take(target_line.saturating_add(1))
+                .rev()
+                .find(|row| row.entry().is_selectable()),
+        };
 
-    fn select_channel_near_line(&mut self, target_line: usize) {
-        let entries = self.channel_pane_filtered_entries();
-        let mut last_selectable_entry = None;
-        for (entry_index, line_index) in self.channel_line_indices() {
-            if line_index >= target_line {
-                if entries
-                    .get(entry_index)
-                    .is_some_and(ChannelPaneEntry::is_selectable)
-                {
-                    self.navigation.channels.list.selected = entry_index;
-                }
-                return;
-            }
-            if entries
-                .get(entry_index)
-                .is_some_and(ChannelPaneEntry::is_selectable)
-            {
-                last_selectable_entry = Some(entry_index);
-            }
-        }
-        if let Some(entry_index) = last_selectable_entry {
+        if let Some(row) = candidate {
+            let entry_index = row.entry_index();
             self.navigation.channels.list.selected = entry_index;
         }
     }

--- a/src/tui/state/navigation.rs
+++ b/src/tui/state/navigation.rs
@@ -352,6 +352,16 @@ impl DashboardState {
 }
 
 impl DashboardState {
+    pub fn focused_channel_selection_line(
+        &self,
+        entries: &[ChannelPaneEntry<'_>],
+    ) -> Option<usize> {
+        if self.navigation.focus != FocusPane::Channels {
+            return None;
+        }
+        self.selected_channel_line(entries)
+    }
+
     pub fn selected_member(&self) -> usize {
         clamp_selected_index(
             self.navigation.members.list.selected,
@@ -382,6 +392,10 @@ impl DashboardState {
         }
     }
 
+    pub fn channel_scroll(&self) -> usize {
+        self.navigation.channels.list.scroll
+    }
+
     pub fn member_scroll(&self) -> usize {
         self.navigation.members.list.scroll
     }
@@ -396,6 +410,10 @@ impl DashboardState {
 
     pub fn member_horizontal_scroll(&self) -> usize {
         self.navigation.members.list.horizontal_scroll
+    }
+
+    pub fn channel_content_height(&self) -> usize {
+        self.navigation.channels.list.content_height()
     }
 
     pub fn member_content_height(&self) -> usize {
@@ -526,14 +544,20 @@ impl DashboardState {
             FocusedNavigationAction::JumpBottom => self.jump_channel_selection_bottom(),
             FocusedNavigationAction::HalfPageDown => {
                 let distance = self.navigation.channels.list.content_height() / 2;
-                self.move_channel_selection_down_by(distance.max(1));
+                let selected_line = self.selected_channel_line_from_entries();
+                self.select_channel_near_line(selected_line.saturating_add(distance.max(1)));
+                self.navigation.channels.list.keep_selection_visible();
+                self.clamp_channel_viewport();
             }
             FocusedNavigationAction::HalfPageUp => {
                 let distance = self.navigation.channels.list.content_height() / 2;
-                self.move_channel_selection_up_by(distance.max(1));
+                let selected_line = self.selected_channel_line_from_entries();
+                self.select_channel_near_line(selected_line.saturating_sub(distance.max(1)));
+                self.navigation.channels.list.keep_selection_visible();
+                self.clamp_channel_viewport();
             }
             FocusedNavigationAction::ScrollViewportDown => {
-                let len = self.channel_pane_filtered_entries().len();
+                let len = self.count_channel_lines();
                 self.navigation.channels.list.scroll_down(len);
             }
             FocusedNavigationAction::ScrollViewportUp => self.navigation.channels.list.scroll_up(),
@@ -733,17 +757,22 @@ impl DashboardState {
     }
 
     fn select_visible_channel_row(&mut self, row: usize) -> bool {
-        let index = self.navigation.channels.list.scroll.saturating_add(row);
+        let target_line = self.navigation.channels.list.scroll.saturating_add(row);
         let entries = self.channel_pane_filtered_entries();
-        if !entries
-            .get(index)
-            .is_some_and(ChannelPaneEntry::is_selectable)
-        {
-            return false;
+        for (entry_index, line_index) in self.channel_line_indices() {
+            if line_index == target_line {
+                if entries
+                    .get(entry_index)
+                    .is_some_and(ChannelPaneEntry::is_selectable)
+                {
+                    self.navigation.channels.list.selected = entry_index;
+                    self.navigation.channels.list.keep_selection_visible();
+                    return true;
+                }
+                return false;
+            }
         }
-        self.navigation.channels.list.selected = index;
-        self.navigation.channels.list.keep_selection_visible();
-        true
+        false
     }
 
     fn select_visible_member_line(&mut self, row: usize) -> bool {
@@ -836,12 +865,20 @@ impl DashboardState {
 
     pub(super) fn clamp_channel_viewport(&mut self) {
         let entries_len = self.channel_pane_filtered_entries().len();
-        self.navigation.channels.list.clamp_selected(entries_len);
-        let selected = self.navigation.channels.list.selected;
+        if entries_len == 0 {
+            self.navigation.channels.list.selected = 0;
+            self.navigation.channels.list.scroll = 0;
+            return;
+        }
+
+        self.navigation.channels.list.selected =
+            self.navigation.channels.list.selected.min(entries_len - 1);
+        let selected_line = self.selected_channel_line_from_entries();
+        let len = self.count_channel_lines();
         self.navigation
             .channels
             .list
-            .clamp_viewport(selected, entries_len);
+            .clamp_viewport(selected_line, len);
     }
 
     pub(super) fn clamp_member_viewport(&mut self) {
@@ -860,6 +897,94 @@ impl DashboardState {
             .members
             .list
             .clamp_viewport(selected_line, len);
+    }
+
+    pub fn channel_entry_has_activity_row(&self, entry: &ChannelPaneEntry<'_>) -> bool {
+        match entry {
+            ChannelPaneEntry::Channel { state, .. } if state.is_dm() && !state.recipients.is_empty() => {
+                let recipient = &state.recipients[0];
+                !matches!(recipient.status, PresenceStatus::Offline | PresenceStatus::Unknown)
+                    && !self.user_activities(recipient.user_id).is_empty()
+            }
+            _ => false,
+        }
+    }
+
+    pub(super) fn selected_channel_line(&self, entries: &[ChannelPaneEntry<'_>]) -> Option<usize> {
+        let selected_channel = self.navigation.channels.list.selected.min(entries.len().saturating_sub(1));
+        let mut channel_index = 0usize;
+        let mut line_index = 0usize;
+        for entry in entries {
+            if channel_index == selected_channel {
+                return Some(line_index);
+            }
+            line_index += 1;
+            if self.channel_entry_has_activity_row(entry) {
+                line_index += 1;
+            }
+            channel_index += 1;
+        }
+        None
+    }
+
+    pub(super) fn selected_channel_line_from_entries(&self) -> usize {
+        let entries = self.channel_pane_filtered_entries();
+        self.selected_channel_line(&entries).unwrap_or_default()
+    }
+
+    pub fn channel_entry_line_count(&self, entries: &[ChannelPaneEntry<'_>]) -> usize {
+        entries
+            .iter()
+            .map(|e| 1 + usize::from(self.channel_entry_has_activity_row(e)))
+            .sum()
+    }
+
+    pub(super) fn count_channel_lines(&self) -> usize {
+        self.channel_pane_filtered_entries()
+            .iter()
+            .map(|e| 1 + usize::from(self.channel_entry_has_activity_row(e)))
+            .sum()
+    }
+
+    fn channel_line_indices(&self) -> Vec<(usize, usize)> {
+        let entries = self.channel_pane_filtered_entries();
+        let mut indices = Vec::new();
+        let mut entry_index = 0usize;
+        let mut line_index = 0usize;
+        for entry in &entries {
+            indices.push((entry_index, line_index));
+            entry_index += 1;
+            line_index += 1;
+            if self.channel_entry_has_activity_row(entry) {
+                line_index += 1;
+            }
+        }
+        indices
+    }
+
+    fn select_channel_near_line(&mut self, target_line: usize) {
+        let entries = self.channel_pane_filtered_entries();
+        let mut last_selectable_entry = None;
+        for (entry_index, line_index) in self.channel_line_indices() {
+            if line_index >= target_line {
+                if entries
+                    .get(entry_index)
+                    .is_some_and(ChannelPaneEntry::is_selectable)
+                {
+                    self.navigation.channels.list.selected = entry_index;
+                }
+                return;
+            }
+            if entries
+                .get(entry_index)
+                .is_some_and(ChannelPaneEntry::is_selectable)
+            {
+                last_selectable_entry = Some(entry_index);
+            }
+        }
+        if let Some(entry_index) = last_selectable_entry {
+            self.navigation.channels.list.selected = entry_index;
+        }
     }
 
     pub(super) fn selected_member_line(&self) -> usize {

--- a/src/tui/state/presentation.rs
+++ b/src/tui/state/presentation.rs
@@ -1,7 +1,8 @@
 use ratatui::style::{Color, Style};
 
 use crate::discord::{
-    ChannelRecipientState, ChannelState, GuildMemberState, PresenceStatus, RoleState,
+    ActivityInfo, ActivityKind, ChannelRecipientState, ChannelState, GuildMemberState,
+    PresenceStatus, RoleState,
 };
 use crate::tui::theme;
 
@@ -76,6 +77,53 @@ pub(super) fn is_online_status(status: PresenceStatus) -> bool {
         status,
         PresenceStatus::Online | PresenceStatus::Idle | PresenceStatus::DoNotDisturb
     )
+}
+
+/// Selects the single activity used by compact member and DM sidebar rows.
+///
+/// The predicate is media-independent so loading an emoji image can change the
+/// leading glyph without adding or removing a visual row.
+pub(in crate::tui) fn primary_compact_activity(
+    activities: &[ActivityInfo],
+) -> Option<&ActivityInfo> {
+    activities
+        .iter()
+        .filter(|activity| compact_activity_has_visible_content(activity))
+        .min_by_key(|activity| compact_activity_priority(activity.kind))
+}
+
+fn compact_activity_has_visible_content(activity: &ActivityInfo) -> bool {
+    let has_text = |value: Option<&str>| value.is_some_and(|value| !value.trim().is_empty());
+
+    match activity.kind {
+        ActivityKind::Custom => {
+            has_text(activity.state.as_deref())
+                || activity
+                    .emoji
+                    .as_ref()
+                    .is_some_and(|emoji| emoji.id.is_some() || !emoji.name.trim().is_empty())
+        }
+        ActivityKind::Listening => {
+            !activity.name.trim().is_empty() || has_text(activity.details.as_deref())
+        }
+        ActivityKind::Competing => true,
+        ActivityKind::Playing
+        | ActivityKind::Streaming
+        | ActivityKind::Watching
+        | ActivityKind::Unknown => !activity.name.trim().is_empty(),
+    }
+}
+
+fn compact_activity_priority(kind: ActivityKind) -> u8 {
+    match kind {
+        ActivityKind::Streaming => 0,
+        ActivityKind::Playing => 1,
+        ActivityKind::Listening => 2,
+        ActivityKind::Watching => 3,
+        ActivityKind::Competing => 4,
+        ActivityKind::Custom => 5,
+        ActivityKind::Unknown => 6,
+    }
 }
 
 pub(super) fn sorted_hoisted_roles<'a>(roles: &'a [&'a RoleState]) -> Vec<&'a RoleState> {

--- a/src/tui/state/tests/members.rs
+++ b/src/tui/state/tests/members.rs
@@ -497,3 +497,20 @@ fn member_half_page_scrolls_by_rendered_lines() {
     assert_eq!(state.selected_member(), 0);
     assert_eq!(state.selected_member_line(), 1);
 }
+
+#[test]
+fn member_focused_selection_line_accounts_for_scroll_offset() {
+    let mut state = state_with_members(8);
+    state.focus_pane(FocusPane::Members);
+    state.set_member_view_height(3);
+
+    for _ in 0..4 {
+        state.move_down();
+    }
+    assert_eq!(state.selected_member(), 4);
+    assert_eq!(state.selected_member_line(), 5);
+
+    let scroll = state.member_scroll();
+    let relative = state.focused_member_selection_line().unwrap();
+    assert_eq!(relative + scroll, state.selected_member_line());
+}

--- a/src/tui/state/tests/panes.rs
+++ b/src/tui/state/tests/panes.rs
@@ -170,13 +170,25 @@ fn channel_navigation_skips_over_activity_subrows() {
     let charlie = Id::new(30);
 
     state.push_event(AppEvent::ChannelUpsert(dm_channel_with_recipient(
-        Id::new(100), "alice", alice, "alice", 1,
+        Id::new(100),
+        "alice",
+        alice,
+        "alice",
+        1,
     )));
     state.push_event(AppEvent::ChannelUpsert(dm_channel_with_recipient(
-        Id::new(101), "bob", bob, "bob", 2,
+        Id::new(101),
+        "bob",
+        bob,
+        "bob",
+        2,
     )));
     state.push_event(AppEvent::ChannelUpsert(dm_channel_with_recipient(
-        Id::new(102), "charlie", charlie, "charlie", 3,
+        Id::new(102),
+        "charlie",
+        charlie,
+        "charlie",
+        3,
     )));
 
     state.push_event(AppEvent::PresenceUpdate {
@@ -209,7 +221,7 @@ fn channel_navigation_skips_over_activity_subrows() {
 fn channel_half_page_scrolls_by_rendered_lines() {
     let mut state = DashboardState::new();
     let mut recipient_ids = Vec::new();
-    for (idx, id) in (1u64..=4).enumerate() {
+    for id in 1u64..=4 {
         let user_id: Id<UserMarker> = Id::new(id + 10);
         recipient_ids.push(user_id);
         state.push_event(AppEvent::ChannelUpsert(dm_channel_with_recipient(

--- a/src/tui/state/tests/panes.rs
+++ b/src/tui/state/tests/panes.rs
@@ -255,6 +255,68 @@ fn channel_half_page_scrolls_by_rendered_lines() {
 }
 
 #[test]
+fn channel_half_page_up_resolves_activity_row_to_parent_dm() {
+    let mut state = DashboardState::new();
+    let alice = Id::new(10);
+    let bob = Id::new(20);
+    state.push_event(AppEvent::ChannelUpsert(dm_channel_with_recipient(
+        Id::new(100),
+        "alice",
+        alice,
+        "alice",
+        2,
+    )));
+    state.push_event(AppEvent::ChannelUpsert(dm_channel_with_recipient(
+        Id::new(101),
+        "bob",
+        bob,
+        "bob",
+        1,
+    )));
+    state.push_event(AppEvent::PresenceUpdate {
+        guild_id: None,
+        presence: crate::discord::PresenceEventFields {
+            user_id: alice,
+            status: PresenceStatus::Online,
+            activities: vec![ActivityInfo::test(ActivityKind::Playing, "Game")],
+        },
+    });
+    state.activate_guild(ActiveGuildScope::DirectMessages);
+    state.focus_pane(FocusPane::Channels);
+    state.set_channel_view_height(2);
+    state.move_down();
+    assert_eq!(state.selected_channel(), 1);
+
+    state.half_page_up();
+
+    assert_eq!(state.selected_channel(), 0);
+}
+
+#[test]
+fn empty_custom_activity_does_not_reserve_channel_row() {
+    let mut state = DashboardState::new();
+    let alice = Id::new(10);
+    state.push_event(AppEvent::ChannelUpsert(dm_channel_with_recipient(
+        Id::new(100),
+        "alice",
+        alice,
+        "alice",
+        1,
+    )));
+    state.push_event(AppEvent::PresenceUpdate {
+        guild_id: None,
+        presence: crate::discord::PresenceEventFields {
+            user_id: alice,
+            status: PresenceStatus::Online,
+            activities: vec![ActivityInfo::test(ActivityKind::Custom, "Custom Status")],
+        },
+    });
+    state.activate_guild(ActiveGuildScope::DirectMessages);
+
+    assert_eq!(state.count_channel_lines(), 1);
+}
+
+#[test]
 fn channel_focused_selection_line_accounts_for_scroll_offset() {
     let mut state = state_with_many_channels(8);
     state.focus_pane(FocusPane::Channels);

--- a/src/tui/state/tests/panes.rs
+++ b/src/tui/state/tests/panes.rs
@@ -145,6 +145,124 @@ fn channel_scroll_uses_scrolloff() {
     assert_eq!(state.channel_scroll(), 1);
 }
 
+fn dm_channel_with_recipient(
+    channel_id: Id<ChannelMarker>,
+    name: &str,
+    recipient_id: Id<UserMarker>,
+    recipient_name: &str,
+    last_message_id: u64,
+) -> ChannelInfo {
+    ChannelInfo {
+        last_message_id: Some(Id::new(last_message_id)),
+        recipients: Some(vec![ChannelRecipientInfo {
+            status: Some(PresenceStatus::Online),
+            ..ChannelRecipientInfo::test(recipient_id, recipient_name)
+        }]),
+        ..dm_channel_info(channel_id, name)
+    }
+}
+
+#[test]
+fn channel_navigation_skips_over_activity_subrows() {
+    let mut state = DashboardState::new();
+    let alice = Id::new(10);
+    let bob = Id::new(20);
+    let charlie = Id::new(30);
+
+    state.push_event(AppEvent::ChannelUpsert(dm_channel_with_recipient(
+        Id::new(100), "alice", alice, "alice", 1,
+    )));
+    state.push_event(AppEvent::ChannelUpsert(dm_channel_with_recipient(
+        Id::new(101), "bob", bob, "bob", 2,
+    )));
+    state.push_event(AppEvent::ChannelUpsert(dm_channel_with_recipient(
+        Id::new(102), "charlie", charlie, "charlie", 3,
+    )));
+
+    state.push_event(AppEvent::PresenceUpdate {
+        guild_id: None,
+        presence: crate::discord::PresenceEventFields {
+            user_id: bob,
+            status: PresenceStatus::Online,
+            activities: vec![ActivityInfo::test(ActivityKind::Playing, "Concord")],
+        },
+    });
+
+    state.activate_guild(ActiveGuildScope::DirectMessages);
+    state.focus_pane(FocusPane::Channels);
+    state.set_channel_view_height(20);
+
+    // DMs sorted by last_message_id desc: charlie(3), bob(2), alice(1).
+    // Entries: 0 charlie, 1 bob (+activity), 2 alice.
+    // Lines: 0 charlie, 1 bob, 2 activity, 3 alice.
+    assert_eq!(state.selected_channel(), 0);
+    assert_eq!(state.count_channel_lines(), 4);
+
+    state.move_down();
+    assert_eq!(state.selected_channel(), 1);
+
+    state.move_down();
+    assert_eq!(state.selected_channel(), 2);
+}
+
+#[test]
+fn channel_half_page_scrolls_by_rendered_lines() {
+    let mut state = DashboardState::new();
+    let mut recipient_ids = Vec::new();
+    for (idx, id) in (1u64..=4).enumerate() {
+        let user_id: Id<UserMarker> = Id::new(id + 10);
+        recipient_ids.push(user_id);
+        state.push_event(AppEvent::ChannelUpsert(dm_channel_with_recipient(
+            Id::new(id + 100),
+            &format!("dm {id}"),
+            user_id,
+            &format!("user {id}"),
+            id,
+        )));
+    }
+
+    state.push_event(AppEvent::PresenceUpdate {
+        guild_id: None,
+        presence: crate::discord::PresenceEventFields {
+            user_id: recipient_ids[1],
+            status: PresenceStatus::Online,
+            activities: vec![ActivityInfo::test(ActivityKind::Playing, "Game")],
+        },
+    });
+
+    state.activate_guild(ActiveGuildScope::DirectMessages);
+    state.focus_pane(FocusPane::Channels);
+    state.set_channel_view_height(5);
+
+    // DMs sorted by last_message_id desc: dm4, dm3, dm2(+activity), dm1.
+    // Lines: 0 dm4, 1 dm3, 2 dm2, 3 activity, 4 dm1.
+    assert_eq!(state.selected_channel(), 0);
+
+    state.half_page_down();
+    assert_eq!(state.selected_channel(), 2);
+}
+
+#[test]
+fn channel_focused_selection_line_accounts_for_scroll_offset() {
+    let mut state = state_with_many_channels(8);
+    state.focus_pane(FocusPane::Channels);
+    state.set_channel_view_height(3);
+
+    for _ in 0..4 {
+        state.move_down();
+    }
+    assert_eq!(state.selected_channel(), 4);
+
+    let scroll = state.channel_scroll();
+    let entries = state.channel_pane_filtered_entries();
+    let focused = state.focused_channel_selection_line(&entries);
+    assert!(focused.is_some());
+    let absolute = state.selected_channel_line(&entries).unwrap();
+    assert_eq!(focused, Some(absolute));
+    assert!(absolute >= scroll);
+    assert!(absolute < scroll + 3);
+}
+
 #[test]
 fn member_scroll_uses_scrolloff() {
     let mut state = state_with_members(8);

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -304,7 +304,7 @@ pub(in crate::tui) fn render_with_message_viewport_plan(
         render_guilds(frame, areas.guilds, state);
     }
     if state.is_pane_visible(FocusPane::Channels) {
-        render_channels(frame, areas.channels, state);
+        render_channels(frame, areas.channels, state, &emoji_images);
     }
     let media_occlusion_areas = background_media_occlusion_areas(frame.area(), state);
     render_messages(

--- a/src/tui/ui/activity.rs
+++ b/src/tui/ui/activity.rs
@@ -1,7 +1,11 @@
-use crate::discord::{ActivityInfo, ActivityKind};
-use crate::tui::text::sanitize_for_display_width;
+use ratatui::text::{Line, Span};
 
-use super::types::EmojiImage;
+use crate::discord::{ActivityInfo, ActivityKind};
+use crate::tui::text::{sanitize_for_display_width, truncate_display_width_from};
+
+use super::{theme, types::EmojiImage};
+
+const ACTIVITY_IMAGE_WIDTH: usize = 2;
 
 /// Glyph rendered at the start of an activity primary line.
 #[derive(Clone, Debug)]
@@ -31,13 +35,89 @@ impl ActivityRender {
 
     #[cfg(test)]
     pub(super) fn to_display_string(&self) -> String {
-        match &self.leading {
-            ActivityLeading::None => self.body.clone(),
-            ActivityLeading::Icon(c) if self.body.is_empty() => c.to_string(),
-            ActivityLeading::Icon(c) => format!("{c} {}", self.body),
-            ActivityLeading::Image(_) if self.body.is_empty() => "  ".to_owned(),
-            ActivityLeading::Image(_) => format!("   {}", self.body),
+        compact_activity_line(self.clone(), 0, usize::MAX, 0)
+            .line
+            .spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect()
+    }
+}
+
+pub(super) struct ActivityImagePlacement {
+    pub(super) column: usize,
+    pub(super) url: String,
+}
+
+pub(super) struct CompactActivityLine {
+    pub(super) line: Line<'static>,
+    pub(super) image: Option<ActivityImagePlacement>,
+}
+
+/// Builds the compact activity row shared by list panes.
+///
+/// Each pane owns the columns before the activity and passes that value as
+/// `leading_width`. This function owns the layout after that boundary so icon
+/// spacing, the two-cell image placeholder, truncation, and image placement
+/// cannot drift between panes.
+pub(super) fn compact_activity_line(
+    render: ActivityRender,
+    leading_width: usize,
+    available_width: usize,
+    horizontal_scroll: usize,
+) -> CompactActivityLine {
+    let has_body = !render.body.is_empty();
+    let content_prefix_width = match &render.leading {
+        ActivityLeading::None => 0,
+        ActivityLeading::Icon(_) => 1 + usize::from(has_body),
+        ActivityLeading::Image(_) => ACTIVITY_IMAGE_WIDTH,
+    };
+    let body = truncate_display_width_from(
+        &render.body,
+        horizontal_scroll,
+        available_width
+            .saturating_sub(leading_width)
+            .saturating_sub(content_prefix_width),
+    );
+    let leading = Span::raw(" ".repeat(leading_width));
+    let body = Span::styled(
+        body,
+        theme::current().style(theme::HighlightGroup::Activity),
+    );
+
+    match render.leading {
+        ActivityLeading::Image(url) => CompactActivityLine {
+            line: Line::from(vec![
+                leading,
+                Span::raw(" ".repeat(ACTIVITY_IMAGE_WIDTH)),
+                body,
+            ]),
+            image: Some(ActivityImagePlacement {
+                column: leading_width,
+                url,
+            }),
+        },
+        ActivityLeading::Icon(icon) => {
+            let mut spans = vec![
+                leading,
+                Span::styled(
+                    icon.to_string(),
+                    theme::current().style(theme::HighlightGroup::PresenceOnline),
+                ),
+            ];
+            if has_body {
+                spans.push(Span::raw(" "));
+            }
+            spans.push(body);
+            CompactActivityLine {
+                line: Line::from(spans),
+                image: None,
+            }
         }
+        ActivityLeading::None => CompactActivityLine {
+            line: Line::from(vec![leading, body]),
+            image: None,
+        },
     }
 }
 
@@ -135,5 +215,47 @@ fn build_custom(activity: &ActivityInfo, emoji_images: &[EmojiImage<'_>]) -> Act
     ActivityRender {
         leading: ActivityLeading::None,
         body,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compact_activity_line_aligns_custom_image_with_icon() {
+        let leading_width = 4;
+        let available_width = 20;
+        let image = compact_activity_line(
+            ActivityRender {
+                leading: ActivityLeading::Image("https://example.com/emoji.png".to_owned()),
+                body: "status".to_owned(),
+            },
+            leading_width,
+            available_width,
+            0,
+        );
+        let icon = compact_activity_line(
+            ActivityRender {
+                leading: ActivityLeading::Icon('▶'),
+                body: "status".to_owned(),
+            },
+            leading_width,
+            available_width,
+            0,
+        );
+
+        let image_placement = image.image.expect("custom image placement");
+        assert_eq!(image_placement.column, leading_width);
+        assert_eq!(
+            image_placement.url,
+            "https://example.com/emoji.png".to_owned()
+        );
+        assert_eq!(image.line.spans[0].content, icon.line.spans[0].content);
+        assert_eq!(image.line.spans[1].content.as_ref(), "  ");
+        assert_eq!(image.line.spans[2].content.as_ref(), "status");
+        assert_eq!(icon.line.spans[1].content.as_ref(), "▶");
+        assert_eq!(icon.line.spans[2].content.as_ref(), " ");
+        assert_eq!(icon.line.spans[3].content.as_ref(), "status");
     }
 }

--- a/src/tui/ui/panes/channels.rs
+++ b/src/tui/ui/panes/channels.rs
@@ -1,5 +1,5 @@
-use super::*;
 use super::members::primary_activity_summary;
+use super::*;
 use crate::tui::ui::emoji_overlay::{EmojiSlot, overlay_emoji_slots};
 
 pub(in crate::tui::ui) fn render_channels(
@@ -99,7 +99,9 @@ pub(in crate::tui::ui) fn render_channels(
         .filter_map(|(line_index, (entry, is_activity_row))| {
             if *is_activity_row {
                 let ChannelPaneEntry::Channel {
-                    state: channel, branch, ..
+                    state: channel,
+                    branch,
+                    ..
                 } = entry
                 else {
                     return None;
@@ -107,17 +109,18 @@ pub(in crate::tui::ui) fn render_channels(
                 let recipient = channel.recipients.first()?;
                 let activities = state.user_activities(recipient.user_id);
                 let render = primary_activity_summary(activities, emoji_images)?;
-                let dm_prefix_width = dm_presence_dot_span(channel)
-                    .map_or_else(|| channel_prefix(&channel.kind).width(), |span| span.content.width());
+                let dm_prefix_width = dm_presence_dot_span(channel).map_or_else(
+                    || channel_prefix(&channel.kind).width(),
+                    |span| span.content.width(),
+                );
                 let leading_width = branch.prefix().width() + dm_prefix_width + 2;
                 let body_width = max_width.saturating_sub(leading_width);
                 let body = truncate_display_width_from(
                     &render.body,
                     horizontal_scroll,
-                    body_width.saturating_sub(usize::from(matches!(
-                        render.leading,
-                        ActivityLeading::Icon(_)
-                    )) * 2),
+                    body_width.saturating_sub(
+                        usize::from(matches!(render.leading, ActivityLeading::Icon(_))) * 2,
+                    ),
                 );
                 let leading = " ".repeat(leading_width);
                 let line = match render.leading {

--- a/src/tui/ui/panes/channels.rs
+++ b/src/tui/ui/panes/channels.rs
@@ -1,6 +1,13 @@
 use super::*;
+use super::members::primary_activity_summary;
+use crate::tui::ui::emoji_overlay::{EmojiSlot, overlay_emoji_slots};
 
-pub(in crate::tui::ui) fn render_channels(frame: &mut Frame, area: Rect, state: &DashboardState) {
+pub(in crate::tui::ui) fn render_channels(
+    frame: &mut Frame,
+    area: Rect,
+    state: &DashboardState,
+    emoji_images: &[EmojiImage<'_>],
+) {
     let dashboard = state;
     let focused = state.focus() == FocusPane::Channels;
     let filter_query = state.channel_pane_filter_query();
@@ -42,7 +49,7 @@ pub(in crate::tui::ui) fn render_channels(frame: &mut Frame, area: Rect, state: 
     let (list_area, filter_area) = split_pane_filter_area(channels_area, filter_query.is_some());
 
     let channel_entries = state.channel_pane_filtered_entries();
-    let channel_entry_count = channel_entries.len();
+    let channel_line_count = state.channel_entry_line_count(&channel_entries);
     let all_channel_entries;
     let populated_channel_entries = if state.channel_pane_filter_query().is_some() {
         all_channel_entries = state.channel_pane_entries();
@@ -62,34 +69,94 @@ pub(in crate::tui::ui) fn render_channels(frame: &mut Frame, area: Rect, state: 
         })
         .collect();
     let channel_scroll = state.channel_scroll();
-    let selected_channel = (state.focus() == FocusPane::Channels && channel_entry_count > 0)
-        .then(|| state.selected_channel_from_entries(&channel_entries));
+    let content_height = state.channel_content_height();
+    let selected_line = state.focused_channel_selection_line(&channel_entries);
     let entries: Vec<_> = channel_entries
-        .into_iter()
+        .iter()
+        .flat_map(|entry| {
+            std::iter::once((entry, false)).chain(
+                state
+                    .channel_entry_has_activity_row(entry)
+                    .then_some((entry, true)),
+            )
+        })
+        .enumerate()
         .skip(channel_scroll)
-        .take(list_area.height as usize)
+        .take(content_height)
         .collect();
     let scrollbar_width = usize::from(vertical_scrollbar_visible(
         list_area,
         list_area.height as usize,
-        channel_entry_count,
+        channel_line_count,
     ));
     let max_width = (list_area.width as usize)
         .saturating_sub(selection_marker(false).content.width())
         .saturating_sub(scrollbar_width);
     let horizontal_scroll = state.channel_horizontal_scroll();
-    let selected = selected_channel
-        .filter(|selected| {
-            *selected >= channel_scroll && *selected < channel_scroll + entries.len()
-        })
-        .map(|selected| selected - channel_scroll);
+    let mut emoji_line_urls: Vec<(usize, String)> = Vec::new();
     let items: Vec<ListItem> = entries
         .iter()
-        .enumerate()
-        .map(|(index, entry)| {
-            let is_selected = selected == Some(index);
+        .filter_map(|(line_index, (entry, is_activity_row))| {
+            if *is_activity_row {
+                let ChannelPaneEntry::Channel {
+                    state: channel, branch, ..
+                } = entry
+                else {
+                    return None;
+                };
+                let recipient = channel.recipients.first()?;
+                let activities = state.user_activities(recipient.user_id);
+                let render = primary_activity_summary(activities, emoji_images)?;
+                let dm_prefix_width = dm_presence_dot_span(channel)
+                    .map_or_else(|| channel_prefix(&channel.kind).width(), |span| span.content.width());
+                let leading_width = branch.prefix().width() + dm_prefix_width + 2;
+                let body_width = max_width.saturating_sub(leading_width);
+                let body = truncate_display_width_from(
+                    &render.body,
+                    horizontal_scroll,
+                    body_width.saturating_sub(usize::from(matches!(
+                        render.leading,
+                        ActivityLeading::Icon(_)
+                    )) * 2),
+                );
+                let leading = " ".repeat(leading_width);
+                let line = match render.leading {
+                    ActivityLeading::Image(url) => {
+                        emoji_line_urls.push((*line_index, url));
+                        Line::from(vec![
+                            Span::raw(leading),
+                            Span::styled(
+                                body,
+                                theme::current().style(theme::HighlightGroup::Activity),
+                            ),
+                        ])
+                    }
+                    ActivityLeading::Icon(icon) => Line::from(vec![
+                        Span::raw(leading),
+                        Span::styled(
+                            icon.to_string(),
+                            theme::current().style(theme::HighlightGroup::PresenceOnline),
+                        ),
+                        Span::raw(" "),
+                        Span::styled(
+                            body,
+                            theme::current().style(theme::HighlightGroup::Activity),
+                        ),
+                    ]),
+                    ActivityLeading::None => Line::from(vec![
+                        Span::raw(leading),
+                        Span::styled(
+                            body,
+                            theme::current().style(theme::HighlightGroup::Activity),
+                        ),
+                    ]),
+                };
+                return Some(ListItem::new(line));
+            }
+
+            let is_selected = selected_line == Some(*line_index);
             let is_active = dashboard.is_active_channel_entry(entry);
-            styled_list_item(
+            Some(styled_list_item(
                 match entry {
                     ChannelPaneEntry::CategoryHeader { state, collapsed } => {
                         let arrow = if *collapsed { "▶ " } else { "▼ " };
@@ -305,12 +372,27 @@ pub(in crate::tui::ui) fn render_channels(frame: &mut Frame, area: Rect, state: 
                     }
                 },
                 is_selected,
-            )
+            ))
         })
         .collect();
 
     let list = List::new(items);
     frame.render_widget(list, list_area);
+
+    if state.show_custom_emoji() {
+        overlay_emoji_slots(
+            frame,
+            list_area,
+            emoji_images,
+            &[],
+            emoji_line_urls.iter().map(|(line_index, url)| EmojiSlot {
+                row_in_list: *line_index as isize - channel_scroll as isize,
+                col: list_area.x as isize + 2,
+                max_width: u16::MAX,
+                url: url.clone(),
+            }),
+        );
+    }
 
     render_pane_filter_bar_with_cursor(
         frame,
@@ -325,7 +407,7 @@ pub(in crate::tui::ui) fn render_channels(frame: &mut Frame, area: Rect, state: 
         list_area,
         state.channel_scroll(),
         list_area.height as usize,
-        channel_entry_count,
+        channel_line_count,
     );
 }
 

--- a/src/tui/ui/panes/channels.rs
+++ b/src/tui/ui/panes/channels.rs
@@ -1,4 +1,3 @@
-use super::members::primary_activity_summary;
 use super::*;
 use crate::tui::ui::emoji_overlay::{EmojiSlot, overlay_emoji_slots};
 
@@ -49,7 +48,8 @@ pub(in crate::tui::ui) fn render_channels(
     let (list_area, filter_area) = split_pane_filter_area(channels_area, filter_query.is_some());
 
     let channel_entries = state.channel_pane_filtered_entries();
-    let channel_line_count = state.channel_entry_line_count(&channel_entries);
+    let channel_rows = state.channel_pane_rows_from_entries(&channel_entries);
+    let channel_line_count = channel_rows.len();
     let all_channel_entries;
     let populated_channel_entries = if state.channel_pane_filter_query().is_some() {
         all_channel_entries = state.channel_pane_entries();
@@ -71,15 +71,8 @@ pub(in crate::tui::ui) fn render_channels(
     let channel_scroll = state.channel_scroll();
     let content_height = state.channel_content_height();
     let selected_line = state.focused_channel_selection_line(&channel_entries);
-    let entries: Vec<_> = channel_entries
+    let entries: Vec<_> = channel_rows
         .iter()
-        .flat_map(|entry| {
-            std::iter::once((entry, false)).chain(
-                state
-                    .channel_entry_has_activity_row(entry)
-                    .then_some((entry, true)),
-            )
-        })
         .enumerate()
         .skip(channel_scroll)
         .take(content_height)
@@ -89,77 +82,50 @@ pub(in crate::tui::ui) fn render_channels(
         list_area.height as usize,
         channel_line_count,
     ));
-    let max_width = (list_area.width as usize)
-        .saturating_sub(selection_marker(false).content.width())
-        .saturating_sub(scrollbar_width);
+    let available_width = (list_area.width as usize).saturating_sub(scrollbar_width);
+    let selection_marker_width = selection_marker(false).content.width();
+    let max_width = available_width.saturating_sub(selection_marker_width);
     let horizontal_scroll = state.channel_horizontal_scroll();
-    let mut emoji_line_urls: Vec<(usize, String)> = Vec::new();
+    let mut emoji_line_urls: Vec<(usize, usize, String)> = Vec::new();
     let items: Vec<ListItem> = entries
         .iter()
-        .filter_map(|(line_index, (entry, is_activity_row))| {
-            if *is_activity_row {
+        .map(|(line_index, row)| {
+            if let ChannelPaneRow::Activity {
+                entry, activity, ..
+            } = row
+            {
                 let ChannelPaneEntry::Channel {
                     state: channel,
                     branch,
-                    ..
                 } = entry
                 else {
-                    return None;
+                    unreachable!("only DM channel entries have activity rows");
                 };
-                let recipient = channel.recipients.first()?;
-                let activities = state.user_activities(recipient.user_id);
-                let render = primary_activity_summary(activities, emoji_images)?;
+                let render = build_activity_render(activity, emoji_images, true);
                 let dm_prefix_width = dm_presence_dot_span(channel).map_or_else(
                     || channel_prefix(&channel.kind).width(),
                     |span| span.content.width(),
                 );
-                let leading_width = branch.prefix().width() + dm_prefix_width + 2;
-                let body_width = max_width.saturating_sub(leading_width);
-                let body = truncate_display_width_from(
-                    &render.body,
+                let branch_width = branch.prefix().width();
+                let leading_width = selection_marker_width + branch_width + dm_prefix_width;
+                let activity_line = compact_activity_line(
+                    render,
+                    leading_width,
+                    available_width,
                     horizontal_scroll,
-                    body_width.saturating_sub(
-                        usize::from(matches!(render.leading, ActivityLeading::Icon(_))) * 2,
-                    ),
                 );
-                let leading = " ".repeat(leading_width);
-                let line = match render.leading {
-                    ActivityLeading::Image(url) => {
-                        emoji_line_urls.push((*line_index, url));
-                        Line::from(vec![
-                            Span::raw(leading),
-                            Span::styled(
-                                body,
-                                theme::current().style(theme::HighlightGroup::Activity),
-                            ),
-                        ])
-                    }
-                    ActivityLeading::Icon(icon) => Line::from(vec![
-                        Span::raw(leading),
-                        Span::styled(
-                            icon.to_string(),
-                            theme::current().style(theme::HighlightGroup::PresenceOnline),
-                        ),
-                        Span::raw(" "),
-                        Span::styled(
-                            body,
-                            theme::current().style(theme::HighlightGroup::Activity),
-                        ),
-                    ]),
-                    ActivityLeading::None => Line::from(vec![
-                        Span::raw(leading),
-                        Span::styled(
-                            body,
-                            theme::current().style(theme::HighlightGroup::Activity),
-                        ),
-                    ]),
-                };
-                return Some(ListItem::new(line));
+                if let Some(image) = activity_line.image {
+                    emoji_line_urls.push((*line_index, image.column, image.url));
+                }
+                return ListItem::new(activity_line.line);
             }
 
+            let ChannelPaneRow::Entry { entry, .. } = row else {
+                unreachable!("activity rows return before entry rendering");
+            };
             let is_selected = selected_line == Some(*line_index);
             let is_active = dashboard.is_active_channel_entry(entry);
-            Some(styled_list_item(
+            styled_list_item(
                 match entry {
                     ChannelPaneEntry::CategoryHeader { state, collapsed } => {
                         let arrow = if *collapsed { "▶ " } else { "▼ " };
@@ -375,7 +341,7 @@ pub(in crate::tui::ui) fn render_channels(
                     }
                 },
                 is_selected,
-            ))
+            )
         })
         .collect();
 
@@ -388,12 +354,14 @@ pub(in crate::tui::ui) fn render_channels(
             list_area,
             emoji_images,
             &[],
-            emoji_line_urls.iter().map(|(line_index, url)| EmojiSlot {
-                row_in_list: *line_index as isize - channel_scroll as isize,
-                col: list_area.x as isize + 2,
-                max_width: u16::MAX,
-                url: url.clone(),
-            }),
+            emoji_line_urls
+                .iter()
+                .map(|(line_index, column, url)| EmojiSlot {
+                    row_in_list: *line_index as isize - channel_scroll as isize,
+                    col: list_area.x as isize + *column as isize,
+                    max_width: u16::MAX,
+                    url: url.clone(),
+                }),
         );
     }
 

--- a/src/tui/ui/panes/members.rs
+++ b/src/tui/ui/panes/members.rs
@@ -1,6 +1,8 @@
 use super::*;
 use crate::tui::ui::emoji_overlay::{EmojiSlot, overlay_emoji_slots};
 
+const MEMBER_ACTIVITY_LEADING_WIDTH: usize = 4;
+
 pub(in crate::tui::ui) fn render_members(
     frame: &mut Frame,
     area: Rect,
@@ -17,8 +19,8 @@ pub(in crate::tui::ui) fn render_members(
     let content_height = state.member_content_height();
     let visible_end = scroll.saturating_add(content_height);
     let mut lines: Vec<Line<'static>> = Vec::new();
-    // (absolute_line_index, cdn_url) for activity rows that have a loaded emoji image.
-    let mut emoji_line_urls: Vec<(usize, String)> = Vec::new();
+    // (absolute_line_index, relative_column, cdn_url) for loaded activity emoji images.
+    let mut emoji_line_urls: Vec<(usize, usize, String)> = Vec::new();
     let content_width = (area.width as usize).saturating_sub(2);
     let max_name_width = (area.width as usize).saturating_sub(7).max(8);
     let selected_line = state
@@ -106,58 +108,16 @@ pub(in crate::tui::ui) fn render_members(
                         && line_index < visible_end
                         && let Some(render) = primary_activity_summary(activities, emoji_images)
                     {
-                        let line = match render.leading {
-                            ActivityLeading::Image(url) => {
-                                let body = truncate_display_width_from(
-                                    &render.body,
-                                    h_scroll,
-                                    max_name_width.saturating_sub(3),
-                                );
-                                emoji_line_urls.push((line_index, url));
-                                Line::from(vec![
-                                    Span::raw("      "),
-                                    Span::styled(
-                                        body,
-                                        theme::current().style(theme::HighlightGroup::Activity),
-                                    ),
-                                ])
-                            }
-                            ActivityLeading::Icon(icon) => {
-                                let body = truncate_display_width_from(
-                                    &render.body,
-                                    h_scroll,
-                                    max_name_width.saturating_sub(2),
-                                );
-                                Line::from(vec![
-                                    Span::raw("    "),
-                                    Span::styled(
-                                        icon.to_string(),
-                                        theme::current()
-                                            .style(theme::HighlightGroup::PresenceOnline),
-                                    ),
-                                    Span::raw(" "),
-                                    Span::styled(
-                                        body,
-                                        theme::current().style(theme::HighlightGroup::Activity),
-                                    ),
-                                ])
-                            }
-                            ActivityLeading::None => {
-                                let body = truncate_display_width_from(
-                                    &render.body,
-                                    h_scroll,
-                                    max_name_width,
-                                );
-                                Line::from(vec![
-                                    Span::raw("    "),
-                                    Span::styled(
-                                        body,
-                                        theme::current().style(theme::HighlightGroup::Activity),
-                                    ),
-                                ])
-                            }
-                        };
-                        lines.push(line);
+                        let activity_line = compact_activity_line(
+                            render,
+                            MEMBER_ACTIVITY_LEADING_WIDTH,
+                            MEMBER_ACTIVITY_LEADING_WIDTH.saturating_add(max_name_width),
+                            h_scroll,
+                        );
+                        if let Some(image) = activity_line.image {
+                            emoji_line_urls.push((line_index, image.column, image.url));
+                        }
+                        lines.push(activity_line.line);
                     }
                     line_index += 1;
                 }
@@ -179,12 +139,14 @@ pub(in crate::tui::ui) fn render_members(
             list,
             emoji_images,
             &[],
-            emoji_line_urls.iter().map(|(line_idx, url)| EmojiSlot {
-                row_in_list: *line_idx as isize - scroll as isize,
-                col: content_area.x as isize + 4,
-                max_width: u16::MAX,
-                url: url.clone(),
-            }),
+            emoji_line_urls
+                .iter()
+                .map(|(line_idx, column, url)| EmojiSlot {
+                    row_in_list: *line_idx as isize - scroll as isize,
+                    col: content_area.x as isize + *column as isize,
+                    max_width: u16::MAX,
+                    url: url.clone(),
+                }),
         );
     }
 
@@ -270,38 +232,12 @@ pub(in crate::tui::ui) fn member_display_label(
     )
 }
 
-/// Priority: Custom > Streaming > Listening > Playing > Watching > Competing > Unknown.
-/// Returns `(display_text, Option<cdn_url>)`. When the cdn_url is `Some`, the
-/// text contains a 2-space placeholder at the start for the image overlay.
+/// Compact ordering prefers live game signals before a custom status:
+/// Streaming > Playing > Listening > Watching > Competing > Custom > Unknown.
 pub(in crate::tui::ui) fn primary_activity_summary(
     activities: &[ActivityInfo],
     emoji_images: &[EmojiImage<'_>],
 ) -> Option<ActivityRender> {
-    let mut sorted: Vec<&ActivityInfo> = activities.iter().collect();
-    sorted.sort_by_key(|a| activity_priority(a.kind));
-    let mut image_only_fallback: Option<ActivityRender> = None;
-    for activity in sorted {
-        let render = build_activity_render(activity, emoji_images, true);
-        if !render.body.trim().is_empty() {
-            return Some(render);
-        }
-        if matches!(render.leading, ActivityLeading::Image(_)) && image_only_fallback.is_none() {
-            image_only_fallback = Some(render);
-        }
-    }
-    image_only_fallback
-}
-
-/// Member-list ordering. Intentionally differs from
-/// `popups::activity_priority`: see [`primary_activity_summary`].
-fn activity_priority(kind: ActivityKind) -> u8 {
-    match kind {
-        ActivityKind::Streaming => 0,
-        ActivityKind::Playing => 1,
-        ActivityKind::Listening => 2,
-        ActivityKind::Watching => 3,
-        ActivityKind::Competing => 4,
-        ActivityKind::Custom => 5,
-        ActivityKind::Unknown => 6,
-    }
+    primary_compact_activity(activities)
+        .map(|activity| build_activity_render(activity, emoji_images, true))
 }

--- a/src/tui/ui/panes/mod.rs
+++ b/src/tui/ui/panes/mod.rs
@@ -11,17 +11,18 @@ use ratatui_image::Image as RatatuiImage;
 use unicode_width::UnicodeWidthStr;
 
 use crate::discord::{
-    ActivityInfo, ActivityKind, ChannelUnreadState, GuildParticipationBlock,
-    GuildParticipationRestriction, MessageState, PresenceStatus,
+    ActivityInfo, ChannelUnreadState, GuildParticipationBlock, GuildParticipationRestriction,
+    MessageState, PresenceStatus,
 };
 
 use super::super::{
     message::format::{EMOJI_REACTION_IMAGE_WIDTH, format_attachment_summary, wrap_text_lines},
     state::{
-        ChannelPaneEntry, CommandPickerEntry, ComposerLock, DashboardState, EmojiPickerEntry,
-        FocusPane, GuildPaneEntry, LocalUploadPreviewView, MAX_MENTION_PICKER_VISIBLE, MemberEntry,
-        MemberGroup, MentionPickerEntry, MentionPickerTarget, apply_discord_foreground,
-        folder_style, normal_text_style, presence_marker,
+        ChannelPaneEntry, ChannelPaneRow, CommandPickerEntry, ComposerLock, DashboardState,
+        EmojiPickerEntry, FocusPane, GuildPaneEntry, LocalUploadPreviewView,
+        MAX_MENTION_PICKER_VISIBLE, MemberEntry, MemberGroup, MentionPickerEntry,
+        MentionPickerTarget, apply_discord_foreground, folder_style, normal_text_style,
+        presence_marker, primary_compact_activity,
     },
     text::{
         format_byte_size, sanitize_for_display_width, truncate_display_width,
@@ -30,7 +31,7 @@ use super::super::{
 };
 use super::{
     LOCAL_UPLOAD_PREVIEW_HEIGHT, LOCAL_UPLOAD_PREVIEW_WIDTH, active_text_style,
-    activity::{ActivityLeading, ActivityRender, build_activity_render},
+    activity::{ActivityRender, build_activity_render, compact_activity_line},
     channel_prefix, channel_unread_decoration, clear_area, dm_presence_dot_span,
     layout::{
         composer_inner_width, composer_rows_before_input, composer_upload_preview_line_count,

--- a/src/tui/ui/popups/profile.rs
+++ b/src/tui/ui/popups/profile.rs
@@ -679,22 +679,6 @@ fn push_activity_lines(
     }
 }
 
-/// Profile-popup ordering. Intentionally differs from
-/// `panes::activity_priority`: the popup has the vertical space to lead with
-/// the user's Custom Status, while the member-list row uses one line per
-/// member and prefers game-at-a-glance signals.
-fn activity_priority(kind: ActivityKind) -> u8 {
-    match kind {
-        ActivityKind::Custom => 0,
-        ActivityKind::Streaming => 1,
-        ActivityKind::Playing => 2,
-        ActivityKind::Listening => 3,
-        ActivityKind::Watching => 4,
-        ActivityKind::Competing => 5,
-        ActivityKind::Unknown => 6,
-    }
-}
-
 fn activity_secondary_line(activity: &ActivityInfo) -> Option<String> {
     match activity.kind {
         ActivityKind::Custom => None,
@@ -722,5 +706,21 @@ fn push_wrapped_paragraph(lines: &mut Vec<Line<'static>>, text: &str, width: usi
         } else {
             push_wrapped_styled_popup_text(lines, trimmed, width, Style::default());
         }
+    }
+}
+
+/// Profile-popup ordering. Intentionally differs from
+/// `panes::activity_priority`: the popup has the vertical space to lead with
+/// the user's Custom Status, while the member-list row uses one line per
+/// member and prefers game-at-a-glance signals.
+fn activity_priority(kind: ActivityKind) -> u8 {
+    match kind {
+        ActivityKind::Custom => 0,
+        ActivityKind::Streaming => 1,
+        ActivityKind::Playing => 2,
+        ActivityKind::Listening => 3,
+        ActivityKind::Watching => 4,
+        ActivityKind::Competing => 5,
+        ActivityKind::Unknown => 6,
     }
 }

--- a/src/tui/ui/popups/profile.rs
+++ b/src/tui/ui/popups/profile.rs
@@ -709,10 +709,9 @@ fn push_wrapped_paragraph(lines: &mut Vec<Line<'static>>, text: &str, width: usi
     }
 }
 
-/// Profile-popup ordering. Intentionally differs from
-/// `panes::activity_priority`: the popup has the vertical space to lead with
-/// the user's Custom Status, while the member-list row uses one line per
-/// member and prefers game-at-a-glance signals.
+/// Profile-popup ordering intentionally differs from the compact sidebar
+/// ordering. The popup has room to lead with Custom Status, while sidebar rows
+/// prefer game-at-a-glance signals.
 fn activity_priority(kind: ActivityKind) -> u8 {
     match kind {
         ActivityKind::Custom => 0,

--- a/src/tui/ui/tests.rs
+++ b/src/tui/ui/tests.rs
@@ -56,14 +56,15 @@ use crate::{
     discord::{
         ActivityEmoji, ActivityInfo, ActivityKind, AppEvent, ApplicationCommandInfo,
         ApplicationCommandOptionInfo, AttachmentDownloadId, AttachmentInfo, ChannelInfo,
-        ChannelNotificationOverrideInfo, ChannelRecipientState, ChannelState, ChannelUnreadState,
-        ChannelVisibilityStats, CustomEmojiInfo, EmbedInfo, GuildBoostTier, GuildFolder,
-        GuildMemberListUpdateInfo, GuildMemberState, GuildNotificationSettingsInfo, MemberInfo,
-        MentionInfo, MessageAttachmentUpload, MessageInfo, MessageInteractionInfo, MessageKind,
-        MessageSearchPage, MessageSearchQuery, MessageSnapshotInfo, MessageState, MutualGuildInfo,
-        NotificationLevel, PollAnswerInfo, PollInfo, PresenceStatus, ReactionEmoji, ReactionInfo,
-        ReactionUserInfo, ReadStateInfo, ReplyInfo, RoleInfo, UserGuildSettingsInfo,
-        UserProfileInfo, UserSettingsInfo, VoiceConnectionStatus, VoiceStateInfo,
+        ChannelNotificationOverrideInfo, ChannelRecipientInfo, ChannelRecipientState, ChannelState,
+        ChannelUnreadState, ChannelVisibilityStats, CustomEmojiInfo, EmbedInfo, GuildBoostTier,
+        GuildFolder, GuildMemberListUpdateInfo, GuildMemberState, GuildNotificationSettingsInfo,
+        MemberInfo, MentionInfo, MessageAttachmentUpload, MessageInfo, MessageInteractionInfo,
+        MessageKind, MessageSearchPage, MessageSearchQuery, MessageSnapshotInfo, MessageState,
+        MutualGuildInfo, NotificationLevel, PollAnswerInfo, PollInfo, PresenceStatus,
+        ReactionEmoji, ReactionInfo, ReactionUserInfo, ReadStateInfo, ReplyInfo, RoleInfo,
+        UserGuildSettingsInfo, UserProfileInfo, UserSettingsInfo, VoiceConnectionStatus,
+        VoiceStateInfo,
     },
     tui::{
         message::format::{

--- a/src/tui/ui/tests/panes.rs
+++ b/src/tui/ui/tests/panes.rs
@@ -433,7 +433,7 @@ fn dm_channel_pane_shows_unread_channel_count_badge() {
     let mut terminal = Terminal::new(backend).expect("test terminal should build");
 
     terminal
-        .draw(|frame| render_channels(frame, frame.area(), &state))
+        .draw(|frame| render_channels(frame, frame.area(), &state, &[]))
         .expect("draw should succeed");
 
     let buffer = terminal.backend().buffer();
@@ -470,7 +470,7 @@ fn dm_channel_pane_shows_loaded_unread_message_count_badge() {
     let mut terminal = Terminal::new(backend).expect("test terminal should build");
 
     terminal
-        .draw(|frame| render_channels(frame, frame.area(), &state))
+        .draw(|frame| render_channels(frame, frame.area(), &state, &[]))
         .expect("draw should succeed");
 
     let buffer = terminal.backend().buffer();
@@ -548,7 +548,7 @@ fn channel_pane_shows_voice_participants_under_voice_channel() {
     let backend = TestBackend::new(40, 9);
     let mut terminal = Terminal::new(backend).expect("test terminal should build");
     terminal
-        .draw(|frame| render_channels(frame, frame.area(), &state))
+        .draw(|frame| render_channels(frame, frame.area(), &state, &[]))
         .expect("draw should succeed");
 
     let buffer = terminal.backend().buffer();
@@ -642,7 +642,7 @@ fn channel_pane_shows_voice_participants_under_voice_channel() {
     let backend = TestBackend::new(40, 4);
     let mut terminal = Terminal::new(backend).expect("test terminal should build");
     terminal
-        .draw(|frame| render_channels(frame, frame.area(), &state))
+        .draw(|frame| render_channels(frame, frame.area(), &state, &[]))
         .expect("draw should succeed");
 
     let buffer = terminal.backend().buffer();
@@ -694,7 +694,7 @@ fn channel_pane_keeps_voice_participant_indicators_visible_after_name_truncation
     let backend = TestBackend::new(32, 5);
     let mut terminal = Terminal::new(backend).expect("test terminal should build");
     terminal
-        .draw(|frame| render_channels(frame, frame.area(), &state))
+        .draw(|frame| render_channels(frame, frame.area(), &state, &[]))
         .expect("draw should succeed");
 
     let buffer = terminal.backend().buffer();
@@ -824,7 +824,7 @@ fn pane_filters_keep_content_width_when_active() {
     let backend = TestBackend::new(32, 6);
     let mut terminal = Terminal::new(backend).expect("test terminal should build");
     terminal
-        .draw(|frame| render_channels(frame, frame.area(), &state))
+        .draw(|frame| render_channels(frame, frame.area(), &state, &[]))
         .expect("draw should succeed");
 
     let buffer = terminal.backend().buffer();
@@ -917,7 +917,7 @@ fn muted_category_and_channel_names_are_dimmed() {
     let mut terminal = Terminal::new(backend).expect("test terminal should build");
 
     terminal
-        .draw(|frame| render_channels(frame, frame.area(), &state))
+        .draw(|frame| render_channels(frame, frame.area(), &state, &[]))
         .expect("draw should succeed");
 
     let buffer = terminal.backend().buffer();
@@ -1174,7 +1174,7 @@ fn channel_pane_header_shows_guild_boost_line_only_when_boosted() {
         let backend = TestBackend::new(30, 8);
         let mut terminal = Terminal::new(backend).expect("test terminal should build");
         terminal
-            .draw(|frame| render_channels(frame, frame.area(), &state))
+            .draw(|frame| render_channels(frame, frame.area(), &state, &[]))
             .expect("draw should succeed");
         let buffer = terminal.backend().buffer();
         (0..buffer.area.height)

--- a/src/tui/ui/tests/panes.rs
+++ b/src/tui/ui/tests/panes.rs
@@ -486,6 +486,50 @@ fn dm_channel_pane_shows_loaded_unread_message_count_badge() {
 }
 
 #[test]
+fn dm_activity_uses_the_full_channel_row_width() {
+    let user_id = Id::new(10);
+    let mut state = DashboardState::new();
+    state.push_event(AppEvent::ChannelUpsert(ChannelInfo {
+        recipients: Some(vec![ChannelRecipientInfo {
+            status: Some(PresenceStatus::Online),
+            ..ChannelRecipientInfo::test(user_id, "alice")
+        }]),
+        name: "alice".to_owned(),
+        ..ChannelInfo::test(Id::new(20), "dm")
+    }));
+    state.push_event(AppEvent::PresenceUpdate {
+        guild_id: None,
+        presence: crate::discord::PresenceEventFields {
+            user_id,
+            status: PresenceStatus::Online,
+            activities: vec![ActivityInfo::test(ActivityKind::Unknown, "abcdefghijklmn")],
+        },
+    });
+    state.confirm_selected_guild();
+    state.focus_pane(FocusPane::Channels);
+    state.set_channel_view_height(2);
+    let backend = TestBackend::new(20, 5);
+    let mut terminal = Terminal::new(backend).expect("test terminal should build");
+
+    terminal
+        .draw(|frame| render_channels(frame, frame.area(), &state, &[]))
+        .expect("draw should succeed");
+
+    let rows = (0..terminal.backend().buffer().area.height)
+        .map(|row| {
+            (0..terminal.backend().buffer().area.width)
+                .map(|col| terminal.backend().buffer()[(col, row)].symbol())
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        rows.iter().any(|row| row.contains("abcdefghijklmn")),
+        "{}",
+        rows.join("\n")
+    );
+}
+
+#[test]
 fn channel_pane_shows_voice_participants_under_voice_channel() {
     let guild_id = Id::new(1);
     let text_id = Id::new(9);


### PR DESCRIPTION
<!--
Thanks for the contribution. Please keep the subject under ~72 characters
and use a semantic prefix (feat:, fix:, refactor:, docs:, chore:, test:).

By submitting this PR you agree it will be distributed under GPL-3.0-only.
-->

## Summary

<!-- What does this change do, in one or two sentences? -->

Rework rendering and input handling for the channels panel to allow multiple line out of one entry. And implement user activity rendering just like how the members panel.

## Why

<!-- The motivation. Link the issue it closes, e.g. "Closes #123". -->
<!-- Feature additions must have a related issue first. Feature PRs without a related issue may be closed without review. -->

Closes #235

## How

<!-- Notable implementation choices and any non-obvious trade-offs. -->

Rework the rendering and input handling for the channels panel. And make some code related to rendering user activity shared between the members and channels panel.

> [!NOTE]
> I wrote the rendering part mostly by myself, but the input handling and tests are written by OpenCode.

## Testing

<!-- How you verified the change. Mention the OS, terminal, and graphics protocol used for manual checks. -->

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] Manual test in a real terminal (describe below)

## Screenshots or recordings

<!-- For UI changes, attach a screenshot or asciinema/gif. Delete this section if not applicable. -->

https://github.com/user-attachments/assets/f880c97c-b470-413b-a4e9-2e9fec0caad3

## Checklist

- [x] One logical change per PR.
- [x] Link a related issue.
- [x] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [x] Change does not add self-bot automation, mass actions, or scraping.
- [x] Updated `README.md`, if behavior or workflows changed.
