### PR TITLE
fix: handle THREAD_MEMBER_UPDATE

### DIFF
--- a/src/discord/events.rs
+++ b/src/discord/events.rs
@@ -237,6 +237,10 @@ pub enum AppEvent {
     ThreadMembersUpdateDispatch {
         update: ThreadMembersUpdateInfo,
     },
+    ThreadMemberUpdate {
+        guild_id: Option<Id<GuildMarker>>,
+        channel_id: Id<ChannelMarker>,
+    },
     MessageCreate {
         message: MessageInfo,
     },
@@ -630,6 +634,7 @@ define_app_event_kinds! {
     ChannelDelete: AppEvent::ChannelDelete { .. },
     ThreadListSync: AppEvent::ThreadListSync { .. },
     ThreadMembersUpdateDispatch: AppEvent::ThreadMembersUpdateDispatch { .. },
+    ThreadMemberUpdate: AppEvent::ThreadMemberUpdate { .. },
     MessageCreate: AppEvent::MessageCreate { .. },
     MessageSendFailed: AppEvent::MessageSendFailed { .. },
     MessageSendRateLimited: AppEvent::MessageSendRateLimited { .. },
@@ -1609,6 +1614,7 @@ impl AppEventKind {
             | AppEventKind::GuildDelete
             | AppEventKind::ThreadListSync
             | AppEventKind::ThreadMembersUpdateDispatch
+            | AppEventKind::ThreadMemberUpdate
             | AppEventKind::ChannelUpsert
             | AppEventKind::ChannelDelete
             | AppEventKind::Ready => AppEventMetadata::mutating(SnapshotAreas::all()),

--- a/src/discord/gateway/parser.rs
+++ b/src/discord/gateway/parser.rs
@@ -16,7 +16,8 @@ mod voice;
 
 pub(crate) use channels::parse_channel_info;
 use channels::{
-    parse_channel_delete, parse_channel_upsert, parse_thread_list_sync, parse_thread_members_update,
+    parse_channel_delete, parse_channel_upsert, parse_thread_list_sync, parse_thread_member_update,
+    parse_thread_members_update,
 };
 use guilds::{
     parse_guild_create, parse_guild_delete, parse_guild_emojis_update,
@@ -101,6 +102,7 @@ fn parse_user_account_event_data(event_type: &str, data: &Value) -> Vec<AppEvent
         "CHANNEL_DELETE" | "THREAD_DELETE" => parse_channel_delete(data).into_iter().collect(),
         "THREAD_LIST_SYNC" => parse_thread_list_sync(data),
         "THREAD_MEMBERS_UPDATE" => parse_thread_members_update(data),
+        "THREAD_MEMBER_UPDATE" => parse_thread_member_update(data),
         "MESSAGE_CREATE" => parse_message_create(data).into_iter().collect(),
         "MESSAGE_UPDATE" => parse_message_update(data).into_iter().collect(),
         "MESSAGE_DELETE" => parse_message_delete(data).into_iter().collect(),

--- a/src/discord/gateway/parser/channels.rs
+++ b/src/discord/gateway/parser/channels.rs
@@ -293,6 +293,20 @@ pub(super) fn parse_thread_list_sync(data: &Value) -> Vec<AppEvent> {
     }]
 }
 
+pub(super) fn parse_thread_member_update(data: &Value) -> Vec<AppEvent> {
+    let channel_id = data
+        .get("id")
+        .and_then(parse_id::<ChannelMarker>)
+        .or_else(|| data.get("channel_id").and_then(parse_id::<ChannelMarker>));
+    let Some(channel_id) = channel_id else {
+        return Vec::new();
+    };
+    vec![AppEvent::ThreadMemberUpdate {
+        guild_id: data.get("guild_id").and_then(parse_id::<GuildMarker>),
+        channel_id,
+    }]
+}
+
 pub(super) fn parse_thread_members_update(data: &Value) -> Vec<AppEvent> {
     let Some(channel_id) = data.get("id").and_then(parse_id::<ChannelMarker>) else {
         return Vec::new();

--- a/src/discord/state.rs
+++ b/src/discord/state.rs
@@ -328,6 +328,9 @@ impl DiscordState {
                     self.set_current_user_thread_membership(update.channel_id, false);
                 }
             }
+            AppEvent::ThreadMemberUpdate { channel_id, .. } => {
+                self.set_current_user_thread_membership(*channel_id, true);
+            }
             AppEvent::ForumPostsLoaded {
                 threads,
                 first_messages,


### PR DESCRIPTION
The THREAD_MEMBER_UPDATE event wasn't being handled (note it's not the same as THREAD_MEMBERS_UPDATE), which meant that new threads don't show in the sidebar until restarting concord. Now new thread creation sets current_user_joined_thread = true and the thread appears in the sidebar immediately.

I didn't create an issue for this since it's a pretty simple change, but I can if I need to.

Tests and checks all pass:
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] Manual test in a real terminal