### PR TITLE
docs: add gentoo installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,26 @@ powershell -ExecutionPolicy Bypass -c "irm https://github.com/chojs23/concord/re
 The installer places `concord` under `$CARGO_HOME/bin`, which is usually
 `~/.cargo/bin` on Unix and `%USERPROFILE%\.cargo\bin` on Windows.
 
+### Gentoo
+
+Install the `darwincereska` overlay:
+
+```sh
+eselect repository add darwincereska git https://codeberg.org/darwincereska/gentoo-overlay.git
+```
+
+Sync the overlay:
+
+```sh
+emaint sync -r darwincereska
+```
+
+Install the package:
+
+```sh
+emerge -av net-im/concord
+```
+
 ### Build from source
 
 You need the Rust stable toolchain, Cargo, and the native dependencies listed in

--- a/README.md
+++ b/README.md
@@ -158,8 +158,9 @@ powershell -ExecutionPolicy Bypass -c "irm https://github.com/chojs23/concord/re
 The installer places `concord` under `$CARGO_HOME/bin`, which is usually
 `~/.cargo/bin` on Unix and `%USERPROFILE%\.cargo\bin` on Windows.
 
-### Gentoo
+### Gentoo (community overlay)
 
+This package is maintained by a community contributor and is not yet available in Gentoo GURU.
 Install the `darwincereska` overlay:
 
 ```sh


### PR DESCRIPTION
<!--
Thanks for the contribution. Please keep the subject under ~72 characters
and use a semantic prefix (feat:, fix:, refactor:, docs:, chore:, test:).

By submitting this PR you agree it will be distributed under GPL-3.0-only.
-->

## Summary

<!-- What does this change do, in one or two sentences? -->
Added installation instructions for Gentoo users.

## Why

<!-- The motivation. Link the issue it closes, e.g. "Closes #123". -->
<!-- Feature additions must have a related issue first. Feature PRs without a related issue may be closed without review. -->
It allows user to update and install through portage instead of doing a manual build through cargo where its not as easy to keep track with the updates.

## How

<!-- Notable implementation choices and any non-obvious trade-offs. -->
I maintain a Gentoo overlay and later plan to get concord approved into the GURU repository

## Testing

<!-- How you verified the change. Mention the OS, terminal, and graphics protocol used for manual checks. -->
No testing required as it was a change to the README

- [ ] `cargo fmt --all --check`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo test --all-features`
- [ ] Manual test in a real terminal (describe below)

## Screenshots or recordings

<!-- For UI changes, attach a screenshot or asciinema/gif. Delete this section if not applicable. -->

## Checklist

- [x] One logical change per PR.
- [ ] Link a related issue.
- [x] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [x] Change does not add self-bot automation, mass actions, or scraping.
- [x] Updated `README.md`, if behavior or workflows changed.
