### PR TITLE
fix(nix): patch PipeWire bindgen fallbacks for immutable vendor sources

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -17,7 +17,7 @@
 }:
 
 let
-  commonArgs = {
+  baseArgs = {
     inherit pname version src;
 
     cargoExtraArgs = "--locked";
@@ -49,16 +49,47 @@ let
     # inside `nix develop` for the full test suite.
     doCheck = false;
 
-    postFixup = lib.optionalString stdenv.isLinux ''
-      wrapProgram "$out/bin/concord" \
-        --set-default PIPEWIRE_CONFIG_DIR "${pipewire}/share/pipewire"
-    '';
+  };
+
+  # PipeWire's sys crates ask bindgen to evaluate cast macros such as
+  # SPA_ID_INVALID and PW_ID_ANY. Bindgen otherwise writes its fallback files
+  # beside the vendored crate, which crane keeps in the immutable Nix store.
+  # TODO: Remove these patches after the sys crates set a fallback build directory.
+  cargoVendorDir = craneLib.vendorCargoDeps (baseArgs // {
+    overrideVendorCargoPackage = package: crate:
+      if package.name == "libspa-sys" && package.version == "0.10.0" then
+        crate.overrideAttrs
+          (old: {
+            patches = (old.patches or [ ]) ++ [
+              ./patches/libspa-sys-0.10.0-bindgen-out-dir.patch
+            ];
+          })
+      else if package.name == "pipewire-sys" && package.version == "0.10.0" then
+        crate.overrideAttrs
+          (old: {
+            patches = (old.patches or [ ]) ++ [
+              ./patches/pipewire-sys-0.10.0-bindgen-out-dir.patch
+            ];
+          })
+      else
+        crate;
+  });
+
+  commonArgs = baseArgs // {
+    inherit cargoVendorDir;
   };
 
   cargoArtifacts = craneLib.buildDepsOnly commonArgs;
 in
 craneLib.buildPackage (commonArgs // {
   inherit cargoArtifacts;
+
+  # buildDepsOnly has no installed binary, so apply the runtime wrapper only
+  # to the final package output.
+  postFixup = lib.optionalString stdenv.isLinux ''
+    wrapProgram "$out/bin/concord" \
+      --set-default PIPEWIRE_CONFIG_DIR "${pipewire}/share/pipewire"
+  '';
 
   meta = {
     inherit description homepage;

--- a/nix/patches/libspa-sys-0.10.0-bindgen-out-dir.patch
+++ b/nix/patches/libspa-sys-0.10.0-bindgen-out-dir.patch
@@ -1,0 +1,12 @@
+diff --git a/build.rs b/build.rs
+index c2c2e84..474f25d 100644
+--- a/build.rs
++++ b/build.rs
+@@ -34,6 +34,7 @@ fn main() {
+         .derive_eq(true)
+         // Some definitions are missing from the generated bindings without this
+         .clang_macro_fallback()
++        .clang_macro_fallback_build_dir(&out_path)
+         // Create callable wrapper functions around SPAs `static inline` functions so they
+         // can be called via FFI
+         .wrap_static_fns(true)

--- a/nix/patches/pipewire-sys-0.10.0-bindgen-out-dir.patch
+++ b/nix/patches/pipewire-sys-0.10.0-bindgen-out-dir.patch
@@ -1,0 +1,6 @@
+diff --git a/build.rs b/build.rs
+--- a/build.rs
++++ b/build.rs
+@@ -31 +31 @@ fn main() {
+-        .clang_macro_fallback();
++        .clang_macro_fallback().clang_macro_fallback_build_dir(PathBuf::from(env::var("OUT_DIR").unwrap()));


### PR DESCRIPTION
<!--
Thanks for the contribution. Please keep the subject under ~72 characters
and use a semantic prefix (feat:, fix:, refactor:, docs:, chore:, test:).

By submitting this PR you agree it will be distributed under GPL-3.0-only.
-->

## Summary

<!-- What does this change do, in one or two sentences? -->

## Why

Closes #288 
<!-- Link the issue it closes, e.g. "Closes #123". -->

## How

<!-- Notable implementation choices and any non-obvious trade-offs. -->

## Testing

<!-- How you verified the change. Mention the OS, terminal, and graphics protocol used for manual checks. -->

- [ ] `cargo fmt --all --check`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo test --all-features`
- [ ] Manual test in a real terminal (describe below)

## Screenshots or recordings

<!-- For UI changes, attach a screenshot or asciinema/gif. Delete this section if not applicable. -->

## Checklist

- [ ] One logical change per PR.
- [ ] Link a related issue.
- [ ] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [ ] Change does not add self-bot automation, mass actions, or scraping.
- [ ] Updated `README.md`, if behavior or workflows changed.
