### PR TITLE
feat: add config option for 12-hour time format

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,9 @@ show_custom_emoji = true
 # Crop avatars into circles instead of showing square images.
 circular_avatars = false
 
+# Show message times in 24-hour format (14:30) instead of 12-hour (2:30 PM).
+hour_format_24 = true
+
 [composer]
 # Send custom emoji your account cannot use directly as image links.
 emojis_as_links = false

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -24,6 +24,7 @@ pub struct DisplayOptions {
     pub image_protocol: ImageProtocolPreference,
     pub show_custom_emoji: bool,
     pub circular_avatars: bool,
+    pub hour_format_24: bool,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
@@ -667,6 +668,7 @@ impl Default for DisplayOptions {
             image_protocol: ImageProtocolPreference::default(),
             show_custom_emoji: true,
             circular_avatars: false,
+            hour_format_24: true,
         }
     }
 }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -20,6 +20,7 @@ fn display_options_default_to_all_media_enabled() {
     assert!(options.images_visible());
     assert!(!options.media_playback_enabled());
     assert!(options.custom_emoji_visible());
+    assert!(options.hour_format_24);
     assert_eq!(
         options.image_preview_quality,
         ImagePreviewQualityPreset::Balanced
@@ -39,6 +40,7 @@ fn global_disable_overrides_individual_toggles() {
         image_protocol: ImageProtocolPreference::Auto,
         show_custom_emoji: true,
         circular_avatars: false,
+        hour_format_24: true,
     };
 
     assert!(!options.avatars_visible());
@@ -255,6 +257,16 @@ fn app_config_parses_partial_toml_with_defaults() {
         };
         assert_eq!(config.credentials.store, expected_credential_store);
     }
+}
+
+#[test]
+fn hour_format_24_defaults_to_enabled_and_can_be_disabled() {
+    let defaults: AppOptions = toml::from_str("[display]\n").expect("display config should parse");
+    let twelve_hour: AppOptions =
+        toml::from_str("[display]\nhour_format_24 = false\n").expect("display config should parse");
+
+    assert!(defaults.display.hour_format_24);
+    assert!(!twelve_hour.display.hour_format_24);
 }
 
 #[test]
@@ -675,6 +687,7 @@ fn options_save_and_load_round_trip() {
             image_protocol: ImageProtocolPreference::Kitty,
             show_custom_emoji: false,
             circular_avatars: true,
+            hour_format_24: false,
         },
         composer: ComposerOptions {
             emojis_as_links: true,

--- a/src/tui/message/format.rs
+++ b/src/tui/message/format.rs
@@ -377,6 +377,7 @@ pub(in crate::tui) fn format_message_content_sections_with_loaded_custom_emoji_u
         &message.embeds,
         message.content.as_deref(),
         state.show_custom_emoji(),
+        state.hour_format_24(),
         width,
         loaded_custom_emoji_urls,
     ));

--- a/src/tui/message/format/embed.rs
+++ b/src/tui/message/format/embed.rs
@@ -19,6 +19,7 @@ pub(super) fn format_embed_lines(
     embeds: &[EmbedInfo],
     message_content: Option<&str>,
     show_custom_emoji: bool,
+    hour_format_24: bool,
     width: usize,
     loaded_custom_emoji_urls: &[String],
 ) -> Vec<MessageContentLine> {
@@ -29,6 +30,7 @@ pub(super) fn format_embed_lines(
                 embed,
                 message_content,
                 show_custom_emoji,
+                hour_format_24,
                 width,
                 loaded_custom_emoji_urls,
             )
@@ -40,6 +42,7 @@ fn format_embed(
     embed: &EmbedInfo,
     message_content: Option<&str>,
     show_custom_emoji: bool,
+    hour_format_24: bool,
     width: usize,
     loaded_custom_emoji_urls: &[String],
 ) -> Vec<MessageContentLine> {
@@ -98,7 +101,7 @@ fn format_embed(
             loaded_custom_emoji_urls,
         );
     }
-    let footer = format_embed_footer(embed);
+    let footer = format_embed_footer(embed, hour_format_24);
     push_embed_text(
         &mut lines,
         footer.as_deref(),
@@ -216,10 +219,13 @@ fn strip_embed_markdown_emphasis(value: &str) -> String {
     value.replace("**", "")
 }
 
-fn format_embed_footer(embed: &EmbedInfo) -> Option<String> {
+fn format_embed_footer(embed: &EmbedInfo, hour_format_24: bool) -> Option<String> {
     match (
         embed.footer_text.as_deref(),
-        embed.timestamp.as_deref().and_then(format_embed_timestamp),
+        embed
+            .timestamp
+            .as_deref()
+            .and_then(|timestamp| format_embed_timestamp(timestamp, hour_format_24)),
     ) {
         (Some(text), Some(timestamp)) => Some(format!("{text} · {timestamp}")),
         (Some(text), None) => Some(text.to_owned()),
@@ -228,10 +234,11 @@ fn format_embed_footer(embed: &EmbedInfo) -> Option<String> {
     }
 }
 
-fn format_embed_timestamp(timestamp: &str) -> Option<String> {
+fn format_embed_timestamp(timestamp: &str, hour_format_24: bool) -> Option<String> {
+    let format = if hour_format_24 { "%H:%M" } else { "%I:%M %p" };
     DateTime::parse_from_rfc3339(timestamp)
         .ok()
-        .map(|datetime| datetime.with_timezone(&Local).format("%H:%M").to_string())
+        .map(|datetime| datetime.with_timezone(&Local).format(format).to_string())
 }
 
 fn push_embed_text(

--- a/src/tui/message/format/system.rs
+++ b/src/tui/message/format/system.rs
@@ -299,6 +299,7 @@ pub(super) fn format_forwarded_snapshot(
             &snapshot.embeds,
             snapshot.content.as_deref(),
             state.show_custom_emoji(),
+            state.hour_format_24(),
             width.saturating_sub(2).max(1),
             loaded_custom_emoji_urls,
         )

--- a/src/tui/message/time.rs
+++ b/src/tui/message/time.rs
@@ -16,9 +16,13 @@ pub(in crate::tui) fn message_local_datetime(
     DateTime::from_timestamp_millis(unix_millis).map(|dt| dt.with_timezone(&Local))
 }
 
-pub(in crate::tui) fn format_message_local_time(message_id: Id<MessageMarker>) -> String {
+pub(in crate::tui) fn format_message_local_time(
+    message_id: Id<MessageMarker>,
+    hour_format_24: bool,
+) -> String {
+    let format = if hour_format_24 { "%H:%M" } else { "%I:%M %p" };
     message_local_datetime(message_id)
-        .map(|dt| dt.format("%H:%M").to_string())
+        .map(|dt| dt.format(format).to_string())
         .unwrap_or_else(|| "--:--".to_owned())
 }
 

--- a/src/tui/state/options.rs
+++ b/src/tui/state/options.rs
@@ -298,6 +298,10 @@ impl DashboardState {
         self.options.display_options.circular_avatars
     }
 
+    pub fn hour_format_24(&self) -> bool {
+        self.options.display_options.hour_format_24
+    }
+
     pub fn show_images(&self) -> bool {
         self.options.display_options.images_visible()
     }

--- a/src/tui/state/popups/options.rs
+++ b/src/tui/state/popups/options.rs
@@ -7,7 +7,7 @@ use super::{
     ActiveModalPopupKind, ModalPopup, OptionsCategory, OptionsPopupState, SelectablePopupTarget,
 };
 
-const DISPLAY_OPTION_COUNT: usize = 8;
+const DISPLAY_OPTION_COUNT: usize = 9;
 const COMPOSER_OPTION_COUNT: usize = 1;
 const NOTIFICATION_OPTION_COUNT: usize = 1;
 const VOICE_OPTION_COUNT: usize = VoiceOption::ALL.len();
@@ -277,6 +277,14 @@ impl DashboardState {
                 effective: options.media_playback_enabled(),
                 description: "Allow videos to open in the external media player.",
             },
+            DisplayOptionItem {
+                label: "24-hour time",
+                enabled: options.hour_format_24,
+                value: None,
+                gauge: None,
+                effective: options.hour_format_24,
+                description: "Show message time in 24-hour (14:30) instead of 12 hour (2:30 pm).",
+            },
         ]
     }
 
@@ -487,6 +495,10 @@ impl DashboardState {
             (OptionsCategory::Display, 7) => {
                 self.options.display_options.media_playback =
                     !self.options.display_options.media_playback
+            }
+            (OptionsCategory::Display, 8) => {
+                self.options.display_options.hour_format_24 =
+                    !self.options.display_options.hour_format_24
             }
             (OptionsCategory::Composer, 0) => {
                 self.options.composer_options.emojis_as_links =

--- a/src/tui/ui/message/list.rs
+++ b/src/tui/ui/message/list.rs
@@ -319,7 +319,7 @@ fn message_viewport_lines_from_plan(
                 .collect(),
         );
 
-        let sent_time = format_message_sent_time(row.message.id);
+        let sent_time = format_message_sent_time(row.message.id, state.hour_format_24());
         let preview_spacers = inline_preview_spacers_for_message(
             row.message,
             plan.layout.preview_width,
@@ -457,7 +457,7 @@ fn render_unread_banner(frame: &mut Frame, area: Rect, state: &DashboardState) {
         theme.style(theme::HighlightGroup::Normal),
     );
 
-    let since_label = format_unread_banner_since(banner.since_message_id);
+    let since_label = format_unread_banner_since(banner.since_message_id, state.hour_format_24());
     let left = match since_label {
         Some(time) => format!(" {} unread messages since {}", banner.unread_count, time),
         None => format!(" {} unread messages", banner.unread_count),
@@ -500,10 +500,18 @@ fn unread_banner_line(left: String, right: &str, width: usize, style: Style) -> 
     ])
 }
 
-fn format_unread_banner_since(message_id: Id<MessageMarker>) -> Option<String> {
+fn format_unread_banner_since(
+    message_id: Id<MessageMarker>,
+    hour_format_24: bool,
+) -> Option<String> {
+    let format = if hour_format_24 {
+        "%Y-%m-%d %H:%M"
+    } else {
+        "%Y-%m-%d %I:%M %p"
+    };
     Some(
         message_local_datetime(message_id)?
-            .format("%Y-%m-%d %H:%M")
+            .format(format)
             .to_string(),
     )
 }
@@ -1007,8 +1015,11 @@ pub(in crate::tui::ui) fn selected_message_card_width(
         .max(4)
 }
 
-pub(in crate::tui::ui) fn format_message_sent_time(message_id: Id<MessageMarker>) -> String {
-    format_message_local_time(message_id)
+pub(in crate::tui::ui) fn format_message_sent_time(
+    message_id: Id<MessageMarker>,
+    hour_format_24: bool,
+) -> String {
+    format_message_local_time(message_id, hour_format_24)
 }
 
 pub(in crate::tui::ui) fn date_separator_line(

--- a/src/tui/ui/popups/search.rs
+++ b/src/tui/ui/popups/search.rs
@@ -24,6 +24,7 @@ pub(in crate::tui::ui) fn render_search_popup(
             &view,
             usize::from(layout.results.height),
             usize::from(layout.results.width),
+            state.hour_format_24(),
         )),
         layout.results,
     );
@@ -193,6 +194,7 @@ fn search_popup_result_lines(
     view: &SearchPopupView,
     max_result_lines: usize,
     width: usize,
+    hour_format_24: bool,
 ) -> Vec<Line<'static>> {
     if max_result_lines == 0 {
         return Vec::new();
@@ -228,7 +230,9 @@ fn search_popup_result_lines(
         .enumerate()
         .skip(start)
         .take(max_result_lines)
-        .map(|(index, result)| search_result_line(result, index == view.selected, width))
+        .map(|(index, result)| {
+            search_result_line(result, index == view.selected, width, hour_format_24)
+        })
         .collect()
 }
 
@@ -268,7 +272,12 @@ fn search_field_line(field: &SearchFieldView, width: usize) -> Line<'static> {
     Line::from(vec![Span::styled(label, label_style), value])
 }
 
-fn search_result_line(result: &SearchResultItem, selected: bool, width: usize) -> Line<'static> {
+fn search_result_line(
+    result: &SearchResultItem,
+    selected: bool,
+    width: usize,
+    hour_format_24: bool,
+) -> Line<'static> {
     let style = if selected {
         highlight_style()
     } else {
@@ -286,7 +295,10 @@ fn search_result_line(result: &SearchResultItem, selected: bool, width: usize) -
                 theme::current().style(theme::HighlightGroup::MessageAuthor),
             ));
             spans.push(Span::styled(
-                format!("{}: ", format_message_sent_time(item.message_id)),
+                format!(
+                    "{}: ",
+                    format_message_sent_time(item.message_id, hour_format_24)
+                ),
                 theme::current().style(theme::HighlightGroup::MessageTimestamp),
             ));
             spans.push(Span::raw(item.content.clone()));

--- a/src/tui/ui/tests/media.rs
+++ b/src/tui/ui/tests/media.rs
@@ -108,7 +108,7 @@ fn selected_author_group_keeps_avatar_body_inside_border() {
         super::narrow_message_viewport_layout(20),
         &[],
     );
-    let sent_time = format_message_sent_time(Id::new(1));
+    let sent_time = format_message_sent_time(Id::new(1), true);
 
     let texts = line_texts_from_ratatui(&lines);
 

--- a/src/tui/ui/tests/messages.rs
+++ b/src/tui/ui/tests/messages.rs
@@ -1878,7 +1878,7 @@ fn message_viewport_lines_keep_rows_from_tall_following_message() {
     .take(5)
     .collect::<Vec<_>>();
     let visible_text = line_texts_from_ratatui(&visible_rows);
-    let sent_time = format_message_sent_time(Id::new(1));
+    let sent_time = format_message_sent_time(Id::new(1), true);
 
     assert!(visible_text[0].starts_with("╭─oooo  "));
     assert!(visible_text[0].contains(&sent_time));

--- a/src/tui/ui/tests/misc.rs
+++ b/src/tui/ui/tests/misc.rs
@@ -743,7 +743,7 @@ fn selected_grouped_continuation_stamps_time_on_border() {
     });
     let texts = line_texts_from_ratatui(&lines);
 
-    let sent_time = format_message_sent_time(Id::new(2));
+    let sent_time = format_message_sent_time(Id::new(2), true);
     assert!(texts[3].starts_with("╔"));
     assert!(texts[4].starts_with("║ "));
     assert!(texts[4].contains("follow-up"));
@@ -783,7 +783,7 @@ fn selected_multiline_continuation_keeps_time_off_content_lines() {
     );
     let texts = line_texts_from_ratatui(&lines);
 
-    let sent_time = format_message_sent_time(Id::new(2));
+    let sent_time = format_message_sent_time(Id::new(2), true);
     let content_lines: Vec<&String> = texts.iter().filter(|line| line.starts_with("│ ")).collect();
 
     assert!(

--- a/src/tui/ui/tests/popups.rs
+++ b/src/tui/ui/tests/popups.rs
@@ -322,7 +322,7 @@ fn search_popup_message_results_show_sent_time() {
 
     let dump = render_dashboard_dump(120, 28, &mut state);
     let rendered = dump.join("\n");
-    let expected_time = format_message_sent_time(message_id);
+    let expected_time = format_message_sent_time(message_id, true);
 
     assert!(
         rendered.contains(&format!("#general neo {expected_time}: needle result")),


### PR DESCRIPTION
<!--
Thanks for the contribution. Please keep the subject under ~72 characters
and use a semantic prefix (feat:, fix:, refactor:, docs:, chore:, test:).

By submitting this PR you agree it will be distributed under GPL-3.0-only.
-->

## Summary

Added a `hour_format_24` display option so message timestamps can render
in 12-hour format (02:30 PM) instead of 24-hour (14:30). The format was
previously hard-coded to `%H:%M` in several places; this threads the
preference through message rows, embed footers, the unread banner, and
search results.

## Why

[12 hour time is easier to tell for people who use 12 hour time in every other aspect of their daily lives](https://github.com/chojs23/concord/issues/305)

## How

Defaults to true (24-hour) to preserve existing behavior, so no current
config is affected. Also adds a "24-hour time" toggle to the Display
options popup.

## Testing

I ran the testing commands mentioned in the CONTRIBUTING.md as well as used cargos build and test commands to test it with my own Discord. This testing was performed on Arch Linux with Kitty using Kitty Graphics Protocol.

- [ x] `cargo fmt --all --check`
- [ x] `cargo clippy --all-targets --all-features -- -D warnings`
- [ x] `cargo test --all-features`
- [ x] Manual test in a real terminal (describe below)

## Screenshots or recordings

<img width="1113" height="310" alt="message_and_embeds" src="https://github.com/user-attachments/assets/4aca4e56-dfcb-4845-bafb-79dc707ffa62" />
<img width="849" height="326" alt="search_results" src="https://github.com/user-attachments/assets/2be8e27d-711e-4dff-a178-a833e5ac9f8d" />
<img width="1149" height="49" alt="unread_banner" src="https://github.com/user-attachments/assets/1c332ef6-e3d9-4cd7-8e2c-a2f785739c76" />


## Checklist

- [ x] One logical change per PR.
- [ x] Link a related issue.
- [ x] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [ x] Change does not add self-bot automation, mass actions, or scraping.
- [ x] Updated `README.md`, if behavior or workflows changed.
