### PR TITLE
fix: prevent false media playback errors

### DIFF
--- a/src/app/media_adapters.rs
+++ b/src/app/media_adapters.rs
@@ -21,8 +21,8 @@ pub(super) const ATTACHMENT_PREVIEW_TIMEOUT: Duration = Duration::from_secs(30);
 const MAX_ATTACHMENT_PREVIEW_BYTES: usize = 8 * 1024 * 1024;
 const ATTACHMENT_DOWNLOAD_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
 const ATTACHMENT_DOWNLOAD_PROGRESS_INTERVAL: Duration = Duration::from_millis(250);
-const MEDIA_PLAYER_WINDOW_READY_TIMEOUT: Duration = Duration::from_secs(300);
-const MEDIA_PLAYER_IPC_WINDOW_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const MEDIA_PLAYER_READY_TIMEOUT: Duration = Duration::from_secs(300);
+const MEDIA_PLAYER_IPC_READY_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 pub(super) async fn fetch_attachment_preview(url: &str) -> std::result::Result<Vec<u8>, String> {
     fetch_limited_bytes(
@@ -267,9 +267,9 @@ async fn monitor_media_player_window(
     url: String,
     label: String,
 ) {
-    let ready_timeout = sleep(MEDIA_PLAYER_WINDOW_READY_TIMEOUT);
+    let ready_timeout = sleep(MEDIA_PLAYER_READY_TIMEOUT);
     tokio::pin!(ready_timeout);
-    let ready_result = wait_for_media_player_window_ready(&ipc_endpoint);
+    let ready_result = wait_for_media_player_ready(&ipc_endpoint);
     tokio::pin!(ready_result);
 
     let outcome = tokio::select! {
@@ -308,8 +308,8 @@ async fn monitor_media_player_window(
         () = &mut ready_timeout => {
             MediaPlayerWindowMonitorOutcome::ReadinessFailed(
                 format!(
-                    "play {label} failed: media player did not report a window within {} seconds",
-                    MEDIA_PLAYER_WINDOW_READY_TIMEOUT.as_secs()
+                    "play {label} failed: media player did not configure video output within {} seconds",
+                    MEDIA_PLAYER_READY_TIMEOUT.as_secs()
                 ),
             )
         }
@@ -379,17 +379,17 @@ fn media_player_command_spec_for_url_with_ipc(
     })
 }
 
-async fn wait_for_media_player_window_ready(endpoint: &MediaPlayerIpcEndpoint) -> io::Result<()> {
+async fn wait_for_media_player_ready(endpoint: &MediaPlayerIpcEndpoint) -> io::Result<()> {
     #[cfg(unix)]
     {
         let stream = endpoint.connect().await?;
-        wait_for_mpv_window_id(stream).await
+        wait_for_mpv_video_output_ready(stream).await
     }
 
     #[cfg(windows)]
     {
         let stream = endpoint.connect().await?;
-        wait_for_mpv_window_id(stream).await
+        wait_for_mpv_video_output_ready(stream).await
     }
 
     #[cfg(not(any(unix, windows)))]
@@ -402,7 +402,7 @@ async fn wait_for_media_player_window_ready(endpoint: &MediaPlayerIpcEndpoint) -
     }
 }
 
-async fn wait_for_mpv_window_id<S>(stream: S) -> io::Result<()>
+async fn wait_for_mpv_video_output_ready<S>(stream: S) -> io::Result<()>
 where
     S: AsyncRead + AsyncWrite + Unpin,
 {
@@ -412,7 +412,7 @@ where
 
     loop {
         let request =
-            format!(r#"{{"command":["get_property","window-id"],"request_id":{request_id}}}"#);
+            format!(r#"{{"command":["get_property","vo-configured"],"request_id":{request_id}}}"#);
         reader.get_mut().write_all(request.as_bytes()).await?;
         reader.get_mut().write_all(b"\n").await?;
         reader.get_mut().flush().await?;
@@ -423,11 +423,12 @@ where
             if bytes_read == 0 {
                 return Err(io::Error::new(
                     io::ErrorKind::UnexpectedEof,
-                    "media player IPC closed before reporting a window",
+                    "media player IPC closed before configuring video output",
                 ));
             }
-            if let Some(window_ready) = mpv_window_id_response_readiness(&line, request_id) {
-                if window_ready {
+            if let Some(video_output_ready) = mpv_video_output_response_readiness(&line, request_id)
+            {
+                if video_output_ready {
                     return Ok(());
                 }
                 break;
@@ -435,11 +436,11 @@ where
         }
 
         request_id = request_id.saturating_add(1);
-        sleep(MEDIA_PLAYER_IPC_WINDOW_POLL_INTERVAL).await;
+        sleep(MEDIA_PLAYER_IPC_READY_POLL_INTERVAL).await;
     }
 }
 
-fn mpv_window_id_response_readiness(line: &[u8], request_id: u64) -> Option<bool> {
+fn mpv_video_output_response_readiness(line: &[u8], request_id: u64) -> Option<bool> {
     let Ok(value) = serde_json::from_slice::<serde_json::Value>(line) else {
         return None;
     };
@@ -447,18 +448,11 @@ fn mpv_window_id_response_readiness(line: &[u8], request_id: u64) -> Option<bool
         return None;
     }
     let success = value.get("error").and_then(serde_json::Value::as_str) == Some("success");
+    if !success {
+        return Some(false);
+    }
 
-    Some(
-        success
-            && match value.get("data") {
-                Some(serde_json::Value::Number(number)) => {
-                    number.as_i64().is_some_and(|id| id != 0)
-                        || number.as_u64().is_some_and(|id| id != 0)
-                }
-                Some(serde_json::Value::String(id)) => !id.is_empty() && id != "0",
-                _ => false,
-            },
-    )
+    value.get("data").and_then(serde_json::Value::as_bool)
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -509,9 +503,12 @@ mod tests {
 
     use super::{
         media_player_command_spec_for_url, media_player_command_spec_for_url_with_ipc,
-        media_player_spawn_error, mpv_window_id_response_readiness, open_url,
-        persist_unique_download_file, sanitize_filename, windows_open_url_command_spec,
+        media_player_spawn_error, mpv_video_output_response_readiness, open_url,
+        persist_unique_download_file, sanitize_filename, wait_for_mpv_video_output_ready,
+        windows_open_url_command_spec,
     };
+    use serde_json::{Value, json};
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
     fn unix_timestamp_nanos() -> u128 {
         std::time::SystemTime::now()
@@ -611,28 +608,131 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn mpv_video_output_readiness_polls_until_configured() {
+        let (client, server) = tokio::io::duplex(512);
+        let server = tokio::spawn(async move {
+            let mut server = BufReader::new(server);
+            let mut line = Vec::new();
+
+            server
+                .read_until(b'\n', &mut line)
+                .await
+                .expect("test server should read the first readiness request");
+            let request: Value =
+                serde_json::from_slice(&line).expect("readiness request should be valid JSON");
+            assert_eq!(request["command"], json!(["get_property", "vo-configured"]));
+            assert_eq!(request["request_id"], 1);
+            server
+                .get_mut()
+                .write_all(b"{\"data\":false,\"error\":\"success\",\"request_id\":1}\n")
+                .await
+                .expect("test server should report video output not configured");
+
+            line.clear();
+            server
+                .read_until(b'\n', &mut line)
+                .await
+                .expect("test server should read the next readiness request");
+            let request: Value =
+                serde_json::from_slice(&line).expect("readiness request should be valid JSON");
+            assert_eq!(request["command"], json!(["get_property", "vo-configured"]));
+            assert_eq!(request["request_id"], 2);
+            server
+                .get_mut()
+                .write_all(b"{\"data\":true,\"error\":\"success\",\"request_id\":2}\n")
+                .await
+                .expect("test server should report video output configured");
+        });
+
+        wait_for_mpv_video_output_ready(client)
+            .await
+            .expect("configured video output should complete readiness polling");
+        server.await.expect("test server should finish");
+    }
+
+    #[tokio::test]
+    async fn mpv_video_output_readiness_ignores_unrelated_messages() {
+        let (client, server) = tokio::io::duplex(512);
+        let server = tokio::spawn(async move {
+            let mut server = BufReader::new(server);
+            let mut line = Vec::new();
+            server
+                .read_until(b'\n', &mut line)
+                .await
+                .expect("test server should read the readiness request");
+            server
+                .get_mut()
+                .write_all(
+                    b"{\"event\":\"file-loaded\"}\nnot json\n{\"data\":true,\"error\":\"success\",\"request_id\":99}\n{\"data\":true,\"error\":\"success\",\"request_id\":1}\n",
+                )
+                .await
+                .expect("test server should send readiness messages");
+        });
+
+        wait_for_mpv_video_output_ready(client)
+            .await
+            .expect("matching configured response should complete readiness polling");
+        server.await.expect("test server should finish");
+    }
+
+    #[tokio::test]
+    async fn mpv_video_output_readiness_errors_when_ipc_closes() {
+        let (client, server) = tokio::io::duplex(512);
+        let server = tokio::spawn(async move {
+            let mut server = BufReader::new(server);
+            let mut line = Vec::new();
+            server
+                .read_until(b'\n', &mut line)
+                .await
+                .expect("test server should read the readiness request");
+        });
+
+        let error = wait_for_mpv_video_output_ready(client)
+            .await
+            .expect_err("closed IPC should fail before readiness");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::UnexpectedEof);
+        server.await.expect("test server should finish");
+    }
+
     #[test]
-    fn mpv_window_id_response_reports_window_readiness() {
+    fn mpv_video_output_response_requires_boolean_readiness() {
         assert_eq!(
-            mpv_window_id_response_readiness(
-                br#"{"data":945,"error":"success","request_id":7}"#,
+            mpv_video_output_response_readiness(
+                br#"{"data":true,"error":"success","request_id":7}"#,
                 7,
             ),
             Some(true)
         );
         assert_eq!(
-            mpv_window_id_response_readiness(
-                br#"{"data":null,"error":"success","request_id":7}"#,
+            mpv_video_output_response_readiness(
+                br#"{"data":false,"error":"success","request_id":7}"#,
                 7,
             ),
             Some(false)
         );
         assert_eq!(
-            mpv_window_id_response_readiness(
-                br#"{"data":945,"error":"success","request_id":6}"#,
+            mpv_video_output_response_readiness(
+                br#"{"data":true,"error":"success","request_id":6}"#,
                 7,
             ),
             None
+        );
+        for invalid_data in [
+            br#"{"error":"success","request_id":7}"#.as_slice(),
+            br#"{"data":null,"error":"success","request_id":7}"#.as_slice(),
+            br#"{"data":"true","error":"success","request_id":7}"#.as_slice(),
+            br#"{"data":1,"error":"success","request_id":7}"#.as_slice(),
+        ] {
+            assert_eq!(mpv_video_output_response_readiness(invalid_data, 7), None);
+        }
+        assert_eq!(
+            mpv_video_output_response_readiness(
+                br#"{"data":true,"error":"property unavailable","request_id":7}"#,
+                7,
+            ),
+            Some(false)
         );
     }
 


### PR DESCRIPTION
## Summary

Change the existing mpv readiness polling in `src/app/media_adapters.rs` to query mpv's video-output configured state rather than requiring a numeric platform window identifier. Keep the existing request-id correlation, retry interval, timeout, monitor outcome handling, and `MediaPlaybackWindowReady` publication path so the preparing toast clears as soon as mpv has initialized playback. Update the module's inline tests to drive the production polling function over an in-memory duplex stream, proving that an initial not-ready response is polled again, a ready response completes successfully, unrelated or malformed IPC messages are ignored, and a closed IPC connection before readiness remains an error.

External media playback can complete successfully and still emit a `GatewayError` reporting `media player readiness check failed: Broken pipe`. The current mpv monitor treats a nonzero `window-id` as the only readiness signal, but that property is tied to the active video-output/windowing backend and may never become usable on affected Linux setups. Concord therefore continues polling throughout otherwise successful playback and interprets the IPC socket closing when mpv exits as a startup failure. The issue is reproducible on every playback in the reporter's Arch Linux and Kitty environment, and the supplied log anchors the failure in `src/app/media_adapters.rs`.

Closes #268

## Why

Change the existing mpv readiness polling in `src/app/media_adapters.rs` to query mpv's video-output configured state rather than requiring a numeric platform window identifier. Keep the existing request-id correlation, retry interval, timeout, monitor outcome handling, and `MediaPlaybackWindowReady` publication path so the preparing toast clears as soon as mpv has initialized playback. Update the module's inline tests to drive the production polling function over an in-memory duplex stream, proving that an initial not-ready response is polled again, a ready response completes successfully, unrelated or malformed IPC messages are ignored, and a closed IPC connection before readiness remains an error.

## How

Not applicable to this change.

## Testing

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [ ] Manual test in a real terminal (describe below)
  Not verified: this needs a person on the named hardware or environment.
- Starting playback when mpv reports its video output configured publishes readiness through the existing monitor path and does not surface a gateway error. - A valid response indicating the video output is not configured causes another request after the existing poll interval; a later configured response completes readiness. - Unsolicited events, malformed JSON, and responses for another request ID are ignored until the matching readiness response arrives.

## Screenshots or recordings

No user-visible surface changes in this PR, so there is nothing to show.

## Checklist

- [ ] One logical change per PR.
- [ ] Link a related issue.
- [x] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [ ] Change does not add self-bot automation, mass actions, or scraping.
- [x] Updated `README.md`, if behavior or workflows changed.
