### PR TITLE
fix: match Discord webhook message grouping

### DIFF
--- a/src/discord/gateway/parser/messages.rs
+++ b/src/discord/gateway/parser/messages.rs
@@ -12,7 +12,7 @@ use crate::{
             Id,
             marker::{
                 AttachmentMarker, ChannelMarker, EmojiMarker, GuildMarker, MessageMarker,
-                RoleMarker, UserMarker,
+                RoleMarker, UserMarker, WebhookMarker,
             },
         },
     },
@@ -27,9 +27,18 @@ pub(crate) fn parse_message_info(data: &Value) -> Option<MessageInfo> {
     let channel_id = parse_id::<ChannelMarker>(data.get("channel_id")?)?;
     let message_id = parse_id::<MessageMarker>(data.get("id")?)?;
     let nonce = data.get("nonce").and_then(parse_id::<MessageMarker>);
+    let webhook_id = data.get("webhook_id").and_then(parse_id::<WebhookMarker>);
     let author = data.get("author")?;
     let author_id = parse_id::<UserMarker>(author.get("id")?)?;
-    let author_name = message_author_display_name(data, author);
+    let author_name = if webhook_id.is_some() {
+        display_name_from_parts_or_unknown(
+            None,
+            None,
+            author.get("username").and_then(Value::as_str),
+        )
+    } else {
+        message_author_display_name(data, author)
+    };
     let author_avatar_url = user_avatar_url(author_id, author);
     let author_is_bot = author.get("bot").and_then(Value::as_bool).unwrap_or(false);
     let author_role_ids = parse_message_author_role_ids(data);
@@ -79,6 +88,7 @@ pub(crate) fn parse_message_info(data: &Value) -> Option<MessageInfo> {
         channel_id,
         message_id,
         nonce,
+        webhook_id,
         author_id,
         author: author_name,
         author_avatar_url,

--- a/src/discord/gateway/parser/tests.rs
+++ b/src/discord/gateway/parser/tests.rs
@@ -2778,6 +2778,31 @@ fn message_create_parser_resolves_author_name_by_precedence() {
 }
 
 #[test]
+fn message_info_parser_preserves_webhook_identity() {
+    let message = parse_message_info(&json!({
+        "id": "20",
+        "channel_id": "10",
+        "webhook_id": "40",
+        "author": {
+            "id": "30",
+            "global_name": "cached bot name",
+            "username": "Persona One",
+            "avatar": "avatarhash",
+            "bot": true
+        },
+        "content": "hello"
+    }))
+    .expect("webhook message should parse");
+
+    assert_eq!(message.webhook_id, Some(Id::new(40)));
+    assert_eq!(message.author, "Persona One");
+    assert_eq!(
+        message.author_avatar_url.as_deref(),
+        Some("https://cdn.discordapp.com/avatars/30/avatarhash.png")
+    );
+}
+
+#[test]
 fn message_info_parser_tracks_author_role_payload_presence() {
     let cases = [
         (

--- a/src/discord/ids.rs
+++ b/src/discord/ids.rs
@@ -118,4 +118,7 @@ pub mod marker {
 
     #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
     pub struct UserMarker;
+
+    #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+    pub struct WebhookMarker;
 }

--- a/src/discord/message.rs
+++ b/src/discord/message.rs
@@ -6,7 +6,10 @@ pub use state::{MessageCapabilities, MessageState};
 use crate::discord::commands::ReactionEmoji;
 use crate::discord::ids::{
     Id,
-    marker::{AttachmentMarker, ChannelMarker, GuildMarker, MessageMarker, RoleMarker, UserMarker},
+    marker::{
+        AttachmentMarker, ChannelMarker, GuildMarker, MessageMarker, RoleMarker, UserMarker,
+        WebhookMarker,
+    },
 };
 
 pub const MESSAGE_FLAG_SUPPRESS_EMBEDS: u64 = 1 << 2;
@@ -400,6 +403,7 @@ pub struct MessageInfo {
     pub channel_id: Id<ChannelMarker>,
     pub message_id: Id<MessageMarker>,
     pub nonce: Option<Id<MessageMarker>>,
+    pub webhook_id: Option<Id<WebhookMarker>>,
     pub author_id: Id<UserMarker>,
     pub author: String,
     pub author_avatar_url: Option<String>,
@@ -432,6 +436,7 @@ impl Default for MessageInfo {
             channel_id: Id::new(1),
             message_id: Id::new(1),
             nonce: None,
+            webhook_id: None,
             author_id: Id::new(1),
             author: String::new(),
             author_avatar_url: None,

--- a/src/discord/message/state.rs
+++ b/src/discord/message/state.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 
 use crate::discord::ids::{
     Id,
-    marker::{ChannelMarker, GuildMarker, MessageMarker, RoleMarker, UserMarker},
+    marker::{ChannelMarker, GuildMarker, MessageMarker, RoleMarker, UserMarker, WebhookMarker},
 };
 use crate::discord::{
     AttachmentInfo, AttachmentMediaType, EmbedInfo, InlinePreviewInfo, MemberInfo, MentionInfo,
@@ -24,6 +24,7 @@ pub struct MessageState {
     pub nonce: Option<Id<MessageMarker>>,
     pub guild_id: Option<Id<GuildMarker>>,
     pub channel_id: Id<ChannelMarker>,
+    pub webhook_id: Option<Id<WebhookMarker>>,
     pub author_id: Id<UserMarker>,
     pub author: String,
     pub author_avatar_url: Option<String>,
@@ -54,6 +55,7 @@ impl Default for MessageState {
             nonce: None,
             guild_id: None,
             channel_id: Id::new(1),
+            webhook_id: None,
             author_id: Id::new(1),
             author: String::new(),
             author_avatar_url: None,
@@ -964,7 +966,9 @@ impl DiscordState {
             .chain(message_cache.pinned_messages.values_mut())
         {
             for message in messages.iter_mut().filter(|m| m.guild_id == Some(guild_id)) {
-                if let Some((display_name, avatar_url)) = identities.get(&message.author_id) {
+                if message.webhook_id.is_none()
+                    && let Some((display_name, avatar_url)) = identities.get(&message.author_id)
+                {
                     message.author = display_name.clone();
                     if avatar_url.is_some() || message.author_avatar_url.is_none() {
                         message.author_avatar_url = avatar_url.clone();
@@ -997,7 +1001,7 @@ impl DiscordState {
     ) {
         self.for_each_cached_message_mut(|message| {
             if message.guild_id == guild_id {
-                if message.author_id == user_id {
+                if message.webhook_id.is_none() && message.author_id == user_id {
                     message.author = display_name.to_owned();
                     if avatar_url.is_some() || message.author_avatar_url.is_none() {
                         message.author_avatar_url = avatar_url.map(str::to_owned);
@@ -1323,18 +1327,30 @@ impl DiscordState {
         message: &MessageInfo,
     ) -> MessageState {
         let guild_id = message.guild_id.or(channel_guild_id);
+        // A webhook author is a per-message display identity, not a guild
+        // member. Resolving it through member or profile caches would replace
+        // persona names and avatars supplied by tools such as Tupperbox.
+        let (author, author_avatar_url) = if message.webhook_id.is_some() {
+            (message.author.clone(), message.author_avatar_url.clone())
+        } else {
+            (
+                self.message_author_display_name(guild_id, message.author_id, &message.author),
+                self.message_author_avatar_url(
+                    guild_id,
+                    message.author_id,
+                    &message.author_avatar_url,
+                ),
+            )
+        };
         MessageState {
             id: message.message_id,
             nonce: message.nonce,
             guild_id,
             channel_id: message.channel_id,
+            webhook_id: message.webhook_id,
             author_id: message.author_id,
-            author: self.message_author_display_name(guild_id, message.author_id, &message.author),
-            author_avatar_url: self.message_author_avatar_url(
-                guild_id,
-                message.author_id,
-                &message.author_avatar_url,
-            ),
+            author,
+            author_avatar_url,
             author_is_bot: message.author_is_bot,
             message_kind: message.message_kind,
             interaction: message.interaction.clone(),
@@ -1564,6 +1580,7 @@ fn merge_duplicate_message_create(existing: &mut MessageState, incoming: &Messag
 fn merge_shared_message_fields(existing: &mut MessageState, incoming: &MessageState) {
     existing.guild_id = incoming.guild_id.or(existing.guild_id);
     existing.channel_id = incoming.channel_id;
+    existing.webhook_id = incoming.webhook_id.or(existing.webhook_id);
     existing.author_id = incoming.author_id;
     existing.author = preferred_user_label(&existing.author, &incoming.author);
     if incoming.author_avatar_url.is_some() || existing.author_avatar_url.is_none() {

--- a/src/discord/state/tests/profiles.rs
+++ b/src/discord/state/tests/profiles.rs
@@ -61,6 +61,74 @@ fn message_author_uses_cached_member_display_name() {
 }
 
 #[test]
+fn webhook_message_keeps_its_payload_author_identity() {
+    let guild_id = Id::new(1);
+    let channel_id = Id::new(2);
+    let author_id = Id::new(4);
+    let webhook_avatar = "https://cdn.discordapp.com/avatars/4/webhook.png";
+    let member_avatar = "https://cdn.discordapp.com/avatars/4/member.png";
+    let mut state = DiscordState::default();
+
+    state.apply_event(&guild_create_event(GuildCreateFixture {
+        channels: vec![ChannelInfo {
+            guild_id: Some(guild_id),
+            name: "general".to_owned(),
+            ..channel_info(channel_id, "GuildText", Vec::new())
+        }],
+        members: vec![MemberInfo {
+            avatar_url: Some(member_avatar.to_owned()),
+            ..member_info(author_id, "cached member")
+        }],
+        ..GuildCreateFixture::new(guild_id)
+    }));
+    state.apply_event(&message_create_event(MessageCreateFixture {
+        guild_id: Some(guild_id),
+        channel_id,
+        message_id: Id::new(3),
+        webhook_id: Some(Id::new(40)),
+        author_id,
+        author: "Persona One".to_owned(),
+        author_avatar_url: Some(webhook_avatar.to_owned()),
+        content: Some("hello".to_owned()),
+        ..MessageCreateFixture::test_fixture_default()
+    }));
+
+    let messages = state.messages_for_channel(channel_id);
+    assert_eq!(messages[0].author, "Persona One");
+    assert_eq!(
+        messages[0].author_avatar_url.as_deref(),
+        Some(webhook_avatar)
+    );
+
+    state.apply_event(&AppEvent::GuildMemberUpsert {
+        guild_id,
+        member: MemberInfo {
+            avatar_url: Some(member_avatar.to_owned()),
+            ..member_info(author_id, "updated member")
+        },
+    });
+
+    let messages = state.messages_for_channel(channel_id);
+    assert_eq!(messages[0].author, "Persona One");
+    assert_eq!(
+        messages[0].author_avatar_url.as_deref(),
+        Some(webhook_avatar)
+    );
+
+    state.apply_event(&AppEvent::UserProfileLoaded {
+        guild_id: Some(guild_id),
+        profile: profile_info(author_id.get(), Some("profile alias")),
+    });
+
+    let messages = state.messages_for_channel(channel_id);
+    assert_eq!(messages[0].author, "Persona One");
+    assert_eq!(
+        messages[0].author_avatar_url.as_deref(),
+        Some(webhook_avatar)
+    );
+}
+
+#[test]
 fn dm_message_author_prefers_friend_nickname() {
     let channel_id = Id::new(2);
     let author_id = Id::new(4);

--- a/src/tui/state/message_layout.rs
+++ b/src/tui/state/message_layout.rs
@@ -11,7 +11,7 @@ use crate::tui::{
     },
 };
 
-const AUTHOR_GROUP_MAX_GAP: Duration = Duration::from_secs(5 * 60);
+const AUTHOR_GROUP_MAX_GAP: Duration = Duration::from_secs(7 * 60);
 
 impl DashboardState {
     pub(crate) fn message_scroll_row_position(
@@ -102,7 +102,13 @@ impl DashboardState {
             return true;
         }
         messages.get(index - 1).is_none_or(|previous| {
+            // Discord webhooks can override their username per message.
+            // Discord starts a new group when that username changes, but
+            // keeps avatar-only changes in the existing group.
+            let webhook_username_changed =
+                current.webhook_id.is_some() && previous.author != current.author;
             previous.author_id != current.author_id
+                || webhook_username_changed
                 || messages_exceed_author_group_gap(previous, current)
         })
     }

--- a/src/tui/state/tests/members.rs
+++ b/src/tui/state/tests/members.rs
@@ -207,9 +207,21 @@ fn message_history_authors_missing_member_roles_are_requested_from_batch() {
     let mut known_member = message_info(channel_id, 22);
     known_member.author_id = Id::new(10);
     known_member.author_role_ids = vec![Id::new(100)];
+    let mut webhook = message_info(channel_id, 23);
+    webhook.webhook_id = Some(Id::new(200));
+    webhook.author_id = Id::new(93);
+    webhook.mentions = vec![crate::discord::MentionInfo::test(
+        Id::new(92),
+        "webhook mention",
+    )];
 
     assert_eq!(
-        state.missing_message_author_member_requests(&[message.clone(), duplicate, known_member]),
+        state.missing_message_author_member_requests(&[
+            message.clone(),
+            duplicate,
+            known_member,
+            webhook,
+        ]),
         vec![(
             guild_id,
             vec![
@@ -219,6 +231,7 @@ fn message_history_authors_missing_member_roles_are_requested_from_batch() {
                 Id::new(97),
                 Id::new(96),
                 Id::new(95),
+                Id::new(92),
             ]
         )]
     );

--- a/src/tui/state/user.rs
+++ b/src/tui/state/user.rs
@@ -106,7 +106,9 @@ impl DashboardState {
             let Some(guild_id) = guild_id else {
                 continue;
             };
-            users.push((*guild_id, message.author_id));
+            if message.webhook_id.is_none() {
+                users.push((*guild_id, message.author_id));
+            }
         }
 
         // The first Gateway batch must contain the names painted in the

--- a/src/tui/ui/tests.rs
+++ b/src/tui/ui/tests.rs
@@ -315,9 +315,23 @@ fn state_with_message_id(message_id: Id<MessageMarker>, content: &str) -> Dashbo
 }
 
 fn seed_channel_message(
-    mut state: DashboardState,
+    state: DashboardState,
     message_id: Id<MessageMarker>,
     content: &str,
+) -> DashboardState {
+    seed_channel_message_fixture(
+        state,
+        MessageCreateFixture {
+            message_id,
+            content: Some(content.to_owned()),
+            ..guild_message_create_fixture()
+        },
+    )
+}
+
+fn seed_channel_message_fixture(
+    mut state: DashboardState,
+    message: MessageCreateFixture,
 ) -> DashboardState {
     let guild_id = Id::new(1);
     let channel_id = Id::new(2);
@@ -334,10 +348,9 @@ fn seed_channel_message(
     state.confirm_selected_channel();
     state.focus_pane(FocusPane::Messages);
     state.push_event(message_create_event(MessageCreateFixture {
+        guild_id: Some(guild_id),
         channel_id,
-        message_id,
-        content: Some(content.to_owned()),
-        ..guild_message_create_fixture()
+        ..message
     }));
     state.push_event(empty_latest_message_history_loaded_event(channel_id));
     state

--- a/src/tui/ui/tests/messages.rs
+++ b/src/tui/ui/tests/messages.rs
@@ -1576,6 +1576,67 @@ fn message_viewport_lines_group_consecutive_messages_by_author() {
 }
 
 #[test]
+fn message_viewport_lines_match_discord_webhook_author_grouping() {
+    let cases = [
+        ("different username", "Persona Two", "avatar-two", 2),
+        ("avatar only", "Persona One", "avatar-two", 1),
+    ];
+
+    for (label, second_author, second_avatar, expected_header_count) in cases {
+        let webhook_id = Id::new(40);
+        let author_id = Id::new(30);
+        let mut state = seed_channel_message_fixture(
+            DashboardState::new(),
+            MessageCreateFixture {
+                message_id: Id::new(1),
+                webhook_id: Some(webhook_id),
+                author_id,
+                author: "Persona One".to_owned(),
+                author_avatar_url: Some("avatar-one".to_owned()),
+                author_is_bot: true,
+                content: Some("first line".to_owned()),
+                ..guild_message_create_fixture()
+            },
+        );
+        state.push_event(message_create_event(MessageCreateFixture {
+            message_id: Id::new(2),
+            webhook_id: Some(webhook_id),
+            author_id,
+            author: second_author.to_owned(),
+            author_avatar_url: Some(second_avatar.to_owned()),
+            author_is_bot: true,
+            content: Some("second line".to_owned()),
+            ..guild_message_create_fixture()
+        }));
+        state.jump_top();
+        let messages = state.messages();
+
+        let lines = message_viewport_lines(
+            &messages,
+            None,
+            &state,
+            super::default_message_viewport_layout(),
+            &[],
+        );
+        let texts = line_texts_from_ratatui(&lines);
+
+        assert_eq!(
+            texts.iter().filter(|text| text.contains("[bot]")).count(),
+            expected_header_count,
+            "{label}"
+        );
+        assert!(
+            texts.iter().any(|text| text.contains("first line")),
+            "{label}"
+        );
+        assert!(
+            texts.iter().any(|text| text.contains("second line")),
+            "{label}"
+        );
+    }
+}
+
+#[test]
 fn message_viewport_lines_dim_pending_message_content() {
     let mut state = state_with_message();
     state.insert_pending_message_for_test(MessageState {


### PR DESCRIPTION
<!--
Thanks for the contribution. Please keep the subject under ~72 characters
and use a semantic prefix (feat:, fix:, refactor:, docs:, chore:, test:).

By submitting this PR you agree it will be distributed under GPL-3.0-only.
-->

## Summary

<!-- What does this change do, in one or two sentences? -->

## Why

Closes #300 

## How

<!-- Notable implementation choices and any non-obvious trade-offs. -->

## Testing

<!-- How you verified the change. Mention the OS, terminal, and graphics protocol used for manual checks. -->

- [ ] `cargo fmt --all --check`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo test --all-features`
- [ ] Manual test in a real terminal (describe below)

## Screenshots or recordings

<!-- For UI changes, attach a screenshot or asciinema/gif. Delete this section if not applicable. -->

## Checklist

- [ ] One logical change per PR.
- [ ] Link a related issue.
- [ ] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [ ] Change does not add self-bot automation, mass actions, or scraping.
- [ ] Updated `README.md`, if behavior or workflows changed.
