### PR TITLE
perf(media): bound the media caches by bytes, retry failed fetches, add animate_previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,12 @@ image_preview_quality = "balanced"
 # Attachment viewer quality: efficient, balanced, high, or original.
 attachment_viewer_quality = "original"
 
+# Which animated GIF and WebP previews keep playing: always, selected, or never.
+# Each animated frame rebuilds a terminal graphics protocol, so "always" costs
+# roughly 8% of a CPU core per animated preview on screen. Custom emoji animate
+# regardless; theirs are small enough not to matter.
+animate_previews = "selected"
+
 # Render custom Discord emoji as images when possible.
 show_custom_emoji = true
 

--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ attachment_viewer_quality = "original"
 # Each animated frame rebuilds a terminal graphics protocol, so "always" costs
 # roughly 8% of a CPU core per animated preview on screen. Custom emoji animate
 # regardless; theirs are small enough not to matter.
-animate_previews = "selected"
+animate_previews = "always"
 
 # Render custom Discord emoji as images when possible.
 show_custom_emoji = true

--- a/src/app/media_adapters.rs
+++ b/src/app/media_adapters.rs
@@ -23,6 +23,29 @@ const ATTACHMENT_DOWNLOAD_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
 const ATTACHMENT_DOWNLOAD_PROGRESS_INTERVAL: Duration = Duration::from_millis(250);
 const MEDIA_PLAYER_READY_TIMEOUT: Duration = Duration::from_secs(300);
 const MEDIA_PLAYER_IPC_READY_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const MEDIA_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// One pooled client for every media fetch.
+///
+/// `reqwest::get` builds a whole client per call, so a screen of attachments,
+/// avatars, and emoji opened as many TCP connections and TLS handshakes as it
+/// had images. Discord's CDN starts refusing those, which surfaced as
+/// "error sending request" and preview timeouts. Reusing one client keeps the
+/// connection pool alive across requests. Deliberately unauthenticated: these
+/// URLs include proxies for third-party content, which must never see the
+/// session cookies the Discord API client carries.
+fn media_client() -> &'static reqwest::Client {
+    static CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+    CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .connect_timeout(MEDIA_CONNECT_TIMEOUT)
+            // Pooling is the point, but the default keeps unlimited idle
+            // connections per host and each one holds TLS buffers.
+            .pool_max_idle_per_host(6)
+            .build()
+            .unwrap_or_default()
+    })
+}
 
 pub(super) async fn fetch_attachment_preview(url: &str) -> std::result::Result<Vec<u8>, String> {
     fetch_limited_bytes(
@@ -42,12 +65,15 @@ pub(super) async fn download_attachment(
     filename: &str,
     source: DownloadAttachmentSource,
 ) -> std::result::Result<PathBuf, String> {
-    let mut response = timeout(ATTACHMENT_DOWNLOAD_IDLE_TIMEOUT, reqwest::get(url))
-        .await
-        .map_err(|_| "download attachment timed out".to_owned())?
-        .map_err(|error| format!("download attachment failed: {error}"))?
-        .error_for_status()
-        .map_err(|error| format!("download attachment failed: {error}"))?;
+    let mut response = timeout(
+        ATTACHMENT_DOWNLOAD_IDLE_TIMEOUT,
+        media_client().get(url).send(),
+    )
+    .await
+    .map_err(|_| "download attachment timed out".to_owned())?
+    .map_err(|error| format!("download attachment failed: {error}"))?
+    .error_for_status()
+    .map_err(|error| format!("download attachment failed: {error}"))?;
     let total_bytes = response.content_length();
     let filename = sanitize_filename(filename);
     let directory = downloads_directory()?;
@@ -113,7 +139,9 @@ async fn fetch_limited_bytes(
     download_error: &str,
     read_error: &str,
 ) -> std::result::Result<Vec<u8>, String> {
-    let response = reqwest::get(url)
+    let response = media_client()
+        .get(url)
+        .send()
         .await
         .map_err(|error| format!("{download_error}: {error}"))?
         .error_for_status()

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -22,6 +22,7 @@ pub struct DisplayOptions {
     pub image_preview_quality: ImagePreviewQualityPreset,
     pub attachment_viewer_quality: ImagePreviewQualityPreset,
     pub image_protocol: ImageProtocolPreference,
+    pub animate_previews: AnimatePreviews,
     pub show_custom_emoji: bool,
     pub circular_avatars: bool,
     pub hour_format_24: bool,
@@ -627,6 +628,37 @@ pub enum ImagePreviewQualityPreset {
     Original,
 }
 
+/// How much of an animated preview keeps moving. Every animation frame costs a
+/// fresh terminal graphics protocol (~4ms and ~1.3MB for a message-pane
+/// preview), so animating each one on screen is what makes a busy channel
+/// expensive. Emoji are excluded: theirs cost ~87us and stay animated.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AnimatePreviews {
+    Always,
+    #[default]
+    Selected,
+    Never,
+}
+
+impl AnimatePreviews {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Always => "always",
+            Self::Selected => "selected",
+            Self::Never => "never",
+        }
+    }
+
+    pub fn next(self) -> Self {
+        match self {
+            Self::Always => Self::Selected,
+            Self::Selected => Self::Never,
+            Self::Never => Self::Always,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum ImageProtocolPreference {
@@ -687,6 +719,7 @@ impl Default for DisplayOptions {
             media_playback: false,
             image_preview_quality: ImagePreviewQualityPreset::default(),
             attachment_viewer_quality: ImagePreviewQualityPreset::Original,
+            animate_previews: AnimatePreviews::default(),
             image_protocol: ImageProtocolPreference::default(),
             show_custom_emoji: true,
             circular_avatars: false,

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -635,8 +635,8 @@ pub enum ImagePreviewQualityPreset {
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum AnimatePreviews {
-    Always,
     #[default]
+    Always,
     Selected,
     Never,
 }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use super::{
-    AppOptions, BorderShape, BorderSurface, ComposerOptions, CredentialOptions,
+    AnimatePreviews, AppOptions, BorderShape, BorderSurface, ComposerOptions, CredentialOptions,
     CredentialStoreMode, DisplayOptions, HighlightGroup, ImagePreviewQualityPreset,
     ImageProtocolPreference, KeymapBinding, KeymapFileOptions, KeymapOptions, NotificationOptions,
     PresenceOptions, ThemeOptions, VoiceOptions, load_keymap_options_from_path,
@@ -38,6 +38,7 @@ fn global_disable_overrides_individual_toggles() {
         image_preview_quality: ImagePreviewQualityPreset::Balanced,
         attachment_viewer_quality: ImagePreviewQualityPreset::Original,
         image_protocol: ImageProtocolPreference::Auto,
+        animate_previews: AnimatePreviews::Selected,
         show_custom_emoji: true,
         circular_avatars: false,
         hour_format_24: true,
@@ -715,6 +716,7 @@ fn options_save_and_load_round_trip() {
             image_preview_quality: ImagePreviewQualityPreset::Original,
             attachment_viewer_quality: ImagePreviewQualityPreset::Original,
             image_protocol: ImageProtocolPreference::Kitty,
+            animate_previews: AnimatePreviews::Never,
             show_custom_emoji: false,
             circular_avatars: true,
             hour_format_24: false,

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -26,6 +26,7 @@ fn display_options_default_to_all_media_enabled() {
         ImagePreviewQualityPreset::Balanced
     );
     assert_eq!(options.image_protocol, ImageProtocolPreference::Auto);
+    assert_eq!(options.animate_previews, AnimatePreviews::Always);
 }
 
 #[test]

--- a/src/tui/media.rs
+++ b/src/tui/media.rs
@@ -34,7 +34,10 @@ pub(super) use targets::{visible_avatar_targets, visible_image_preview_targets};
 pub(in crate::tui) use decode::decode_image_bytes;
 #[cfg(test)]
 use protocol::clipped_media_image;
-use protocol::{AVATAR_PREVIEW_HEIGHT, AVATAR_PREVIEW_WIDTH, avatar_preview_url, emoji_protocol};
+use protocol::{
+    AVATAR_PREVIEW_HEIGHT, AVATAR_PREVIEW_WIDTH, avatar_preview_url, emoji_protocol,
+    estimated_media_protocol_bytes,
+};
 pub(in crate::tui) use protocol::{
     MediaProtocolRenderSpec, clipped_media_protocol, fixed_media_protocol_render_spec,
     picker_font_size, query_image_picker,

--- a/src/tui/media/avatar.rs
+++ b/src/tui/media/avatar.rs
@@ -12,6 +12,7 @@ use super::{
     PROFILE_POPUP_AVATAR_HEIGHT, PROFILE_POPUP_AVATAR_WIDTH, avatar_preview_url,
     cache::{MediaImageCacheCore, MediaImageCacheEntry, RenderProtocolCache},
     decode::{DecodedMediaImage, MediaImageDecodeKey, MediaImageDecodeRequest},
+    estimated_media_protocol_bytes, picker_font_size,
     protocol_job::{MediaProtocolBuildJob, MediaProtocolBuildResult, MediaProtocolBuildTarget},
     work::{MediaWorkError, MediaWorkResult},
 };
@@ -19,7 +20,7 @@ use super::{
 /// Avatar images are small on screen but decoded originals can still add up
 /// as users scroll through large servers. Keep a generous URL-keyed LRU cap.
 pub(super) const MAX_AVATAR_IMAGE_CACHE_ENTRIES: usize = 32;
-const AVATAR_IMAGE_CACHE_DECODED_BYTE_BUDGET: u64 = 32 * 1024 * 1024;
+const AVATAR_IMAGE_CACHE_DECODED_BYTE_BUDGET: u64 = 12 * 1024 * 1024;
 
 pub(in crate::tui) struct AvatarImageCache {
     pub(super) picker: Option<Picker>,
@@ -144,6 +145,17 @@ impl MediaImageCacheEntry for AvatarImageEntry {
 
     fn is_loading(&self) -> bool {
         matches!(self, AvatarImageEntry::Loading { .. })
+    }
+
+    fn is_failed(&self) -> bool {
+        matches!(self, AvatarImageEntry::Failed { .. })
+    }
+
+    fn retained_protocol_bytes(&self) -> u64 {
+        match self {
+            AvatarImageEntry::Ready { protocols, .. } => protocols.retained_bytes(),
+            _ => 0,
+        }
     }
 
     fn decoding_generation(&self) -> Option<u64> {
@@ -448,6 +460,14 @@ impl AvatarImageCache {
         }
     }
 
+    pub(in crate::tui) fn retained_stats(&self) -> (usize, u64, u64) {
+        self.cache.retained_stats()
+    }
+
+    pub(in crate::tui) fn forget_failures(&mut self) {
+        self.cache.forget_failures();
+    }
+
     pub(in crate::tui) fn pause_animations(&mut self) {
         self.cache.pause_animations();
     }
@@ -468,14 +488,16 @@ impl AvatarImageCache {
         let MediaProtocolBuildTarget::Avatar { url, key } = completed.target else {
             return;
         };
+        let font_size = self.picker.as_ref().map_or((10, 20), picker_font_size);
+        let protocol_bytes = estimated_media_protocol_bytes(key.render_spec(), font_size);
         let failed = match self.cache.entries.get_mut(&url) {
             Some(AvatarImageEntry::Ready {
                 generation,
                 protocols,
                 ..
-            }) if *generation == completed.generation => {
-                protocols.store_result(key, completed.result).is_err()
-            }
+            }) if *generation == completed.generation => protocols
+                .store_result(key, completed.result, protocol_bytes)
+                .is_err(),
             _ => false,
         };
         if failed {

--- a/src/tui/media/cache.rs
+++ b/src/tui/media/cache.rs
@@ -15,6 +15,7 @@ use super::{
 };
 
 const MAX_RENDER_PROTOCOLS_PER_MEDIA_ENTRY: usize = MAX_RETAINED_ANIMATION_FRAMES;
+const MIN_RENDER_PROTOCOLS_PER_MEDIA_ENTRY: usize = 2;
 const MAX_RENDER_PROTOCOL_BUILD_ATTEMPTS: u8 = 2;
 /// A terminal graphics protocol holds the whole frame as an encoded payload:
 /// one kitty protocol for a 60x30 preview measures ~1.3MB. Keeping an
@@ -139,10 +140,12 @@ where
             return;
         }
 
-        // Always keep the frame just stored, however large it is: rendering
-        // needs one protocol and an empty cache would rebuild it every frame.
+        // An animation needs its current and next protocols at the same time.
+        // Keep that two-frame window even when a large preview exceeds the
+        // soft byte budget, otherwise the two frames evict and rebuild each
+        // other forever before playback can start.
         while self.entries.len() >= MAX_RENDER_PROTOCOLS_PER_MEDIA_ENTRY
-            || (!self.entries.is_empty()
+            || (self.entries.len() >= MIN_RENDER_PROTOCOLS_PER_MEDIA_ENTRY
                 && self.retained_bytes.saturating_add(bytes)
                     > RENDER_PROTOCOL_BYTE_BUDGET_PER_MEDIA_ENTRY)
         {

--- a/src/tui/media/cache.rs
+++ b/src/tui/media/cache.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{HashMap, VecDeque},
     hash::Hash,
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use ratatui_image::protocol::Protocol;
@@ -16,6 +16,13 @@ use super::{
 
 const MAX_RENDER_PROTOCOLS_PER_MEDIA_ENTRY: usize = MAX_RETAINED_ANIMATION_FRAMES;
 const MAX_RENDER_PROTOCOL_BUILD_ATTEMPTS: u8 = 2;
+/// A terminal graphics protocol holds the whole frame as an encoded payload:
+/// one kitty protocol for a 60x30 preview measures ~1.3MB. Keeping an
+/// animation's worth of them per entry reached ~650MB across a full preview
+/// cache, none of which the decoded-image budget could see. Only the frames
+/// around the one on screen are worth keeping, so bound them by size as well as
+/// by count; the count alone cannot tell a 2-cell emoji from a 30-row preview.
+pub(super) const RENDER_PROTOCOL_BYTE_BUDGET_PER_MEDIA_ENTRY: u64 = 6 * 1024 * 1024;
 
 pub(super) struct RenderProtocolCache<K> {
     entries: HashMap<K, Protocol>,
@@ -23,6 +30,8 @@ pub(super) struct RenderProtocolCache<K> {
     pending: Option<K>,
     failed_attempts: HashMap<K, u8>,
     last_ready: Option<K>,
+    entry_bytes: HashMap<K, u64>,
+    retained_bytes: u64,
 }
 
 impl<K> RenderProtocolCache<K>
@@ -36,6 +45,8 @@ where
             pending: None,
             failed_attempts: HashMap::new(),
             last_ready: None,
+            entry_bytes: HashMap::new(),
+            retained_bytes: 0,
         }
     }
 
@@ -88,6 +99,7 @@ where
         &mut self,
         key: K,
         result: MediaWorkResult<Protocol>,
+        bytes: u64,
     ) -> Result<(), String> {
         if self.pending.as_ref() != Some(&key) {
             return Ok(());
@@ -96,7 +108,7 @@ where
         match result {
             Ok(protocol) => {
                 self.failed_attempts.remove(&key);
-                self.insert(key, protocol);
+                self.insert(key, protocol, bytes);
                 Ok(())
             }
             Err(MediaWorkError::Busy) => Ok(()),
@@ -119,24 +131,51 @@ where
         self.entries.is_empty()
     }
 
-    pub(super) fn insert(&mut self, key: K, protocol: Protocol) {
-        if let std::collections::hash_map::Entry::Occupied(mut entry) =
-            self.entries.entry(key.clone())
-        {
-            entry.insert(protocol);
+    pub(super) fn insert(&mut self, key: K, protocol: Protocol, bytes: u64) {
+        if self.entries.contains_key(&key) {
+            self.entries.insert(key.clone(), protocol);
+            self.set_entry_bytes(key.clone(), bytes);
             self.last_ready = Some(key);
             return;
         }
 
-        while self.entries.len() >= MAX_RENDER_PROTOCOLS_PER_MEDIA_ENTRY {
+        // Always keep the frame just stored, however large it is: rendering
+        // needs one protocol and an empty cache would rebuild it every frame.
+        while self.entries.len() >= MAX_RENDER_PROTOCOLS_PER_MEDIA_ENTRY
+            || (!self.entries.is_empty()
+                && self.retained_bytes.saturating_add(bytes)
+                    > RENDER_PROTOCOL_BYTE_BUDGET_PER_MEDIA_ENTRY)
+        {
             let Some(oldest) = self.insertion_order.pop_front() else {
                 break;
             };
             self.entries.remove(&oldest);
+            self.forget_entry_bytes(&oldest);
+            // Keys here vary with scroll position, so a stale attempt count
+            // per evicted key would accumulate for the whole session.
+            self.failed_attempts.remove(&oldest);
         }
         self.insertion_order.push_back(key.clone());
         self.last_ready = Some(key.clone());
-        self.entries.insert(key, protocol);
+        self.entries.insert(key.clone(), protocol);
+        self.set_entry_bytes(key, bytes);
+    }
+
+    fn set_entry_bytes(&mut self, key: K, bytes: u64) {
+        if let Some(previous) = self.entry_bytes.insert(key, bytes) {
+            self.retained_bytes = self.retained_bytes.saturating_sub(previous);
+        }
+        self.retained_bytes = self.retained_bytes.saturating_add(bytes);
+    }
+
+    fn forget_entry_bytes(&mut self, key: &K) {
+        if let Some(bytes) = self.entry_bytes.remove(key) {
+            self.retained_bytes = self.retained_bytes.saturating_sub(bytes);
+        }
+    }
+
+    pub(super) fn retained_bytes(&self) -> u64 {
+        self.retained_bytes
     }
 
     #[cfg(test)]
@@ -151,11 +190,18 @@ pub(super) trait MediaImageCacheEntry {
     fn decoded_image_mut(&mut self) -> Option<&mut DecodedMediaImage>;
     fn touch(&mut self, tick: u64);
     fn is_loading(&self) -> bool;
+    fn is_failed(&self) -> bool;
     fn decoding_generation(&self) -> Option<u64>;
 
     fn retained_decoded_bytes(&self) -> u64 {
         self.decoded_image()
             .map_or(0, DecodedMediaImage::retained_bytes)
+    }
+
+    /// Bytes held by this entry's built protocols, which the decoded budget
+    /// cannot see. Zero for entries that do not cache protocols.
+    fn retained_protocol_bytes(&self) -> u64 {
+        0
     }
 }
 
@@ -163,7 +209,24 @@ pub(super) struct MediaImageCacheCore<K, E> {
     pub(super) entries: HashMap<K, E>,
     pub(super) tick: u64,
     pub(super) decode_generation: u64,
+    failed: HashMap<K, FailedMediaFetch>,
 }
+
+struct FailedMediaFetch {
+    attempts: u32,
+    /// `None` once the retries are spent: only a manual refresh revives it.
+    retry_at: Option<Instant>,
+}
+
+/// A failed entry stays in the cache, and a present entry suppresses its own
+/// request, so without these a download that failed once stayed broken for the
+/// rest of the session. Back off between tries so a CDN that is refusing
+/// connections is not hammered, then stop and leave recovery to a refresh.
+const MEDIA_FETCH_RETRY_BACKOFF: [Duration; 3] = [
+    Duration::from_secs(3),
+    Duration::from_secs(15),
+    Duration::from_secs(60),
+];
 
 impl<K, E> MediaImageCacheCore<K, E>
 where
@@ -175,7 +238,61 @@ where
             entries: HashMap::new(),
             tick: 0,
             decode_generation: 0,
+            failed: HashMap::new(),
         }
+    }
+
+    /// Reports whether a failed entry is due for another try, consuming that
+    /// try. The failure record outlives the entry it replaces, so the attempt
+    /// count keeps climbing across retries and the backoff terminates.
+    pub(super) fn take_due_retry(&mut self, key: &K, now: Instant) -> bool {
+        if !self.entries.get(key).is_some_and(E::is_failed) {
+            return false;
+        }
+        let Some(failure) = self.failed.get_mut(key) else {
+            return false;
+        };
+        if failure.retry_at.is_some_and(|retry_at| retry_at <= now) {
+            failure.retry_at = None;
+            return true;
+        }
+        false
+    }
+
+    /// Forgets every failure so the next request pass retries all of them,
+    /// however many times they already failed.
+    pub(super) fn forget_failures(&mut self) {
+        self.failed.clear();
+        self.entries.retain(|_, entry| !entry.is_failed());
+    }
+
+    fn note_failure(&mut self, key: K, now: Instant) {
+        let attempts = self
+            .failed
+            .get(&key)
+            .map_or(0, |failure| failure.attempts)
+            .saturating_add(1);
+        let retry_at = MEDIA_FETCH_RETRY_BACKOFF
+            .get(attempts as usize - 1)
+            .map(|backoff| now + *backoff);
+        self.failed
+            .insert(key, FailedMediaFetch { attempts, retry_at });
+    }
+
+    /// Entry count, decoded bytes, and protocol bytes held right now. Decoded
+    /// bytes are shared through an `Arc` with the shared decode cache, so they
+    /// overlap with its total rather than adding to it.
+    pub(super) fn retained_stats(&self) -> (usize, u64, u64) {
+        self.entries.values().fold(
+            (self.entries.len(), 0, 0),
+            |(count, decoded, protocols), entry| {
+                (
+                    count,
+                    decoded.saturating_add(entry.retained_decoded_bytes()),
+                    protocols.saturating_add(entry.retained_protocol_bytes()),
+                )
+            },
+        )
     }
 
     pub(super) fn next_tick(&mut self) -> u64 {
@@ -221,7 +338,7 @@ where
     }
 
     pub(super) fn insert_loading(&mut self, key: K, make_loading: impl FnOnce(u64) -> E) -> bool {
-        if self.entries.contains_key(&key) {
+        if self.entries.contains_key(&key) && !self.take_due_retry(&key, Instant::now()) {
             return false;
         }
         let last_used = self.next_tick();
@@ -266,8 +383,14 @@ where
     pub(super) fn store_failed_if_present(&mut self, key: K, make_failed: impl FnOnce(u64) -> E) {
         if self.entries.contains_key(&key) {
             let last_used = self.next_tick();
-            self.entries.insert(key, make_failed(last_used));
+            self.entries.insert(key.clone(), make_failed(last_used));
+            self.note_failure(key, Instant::now());
         }
+    }
+
+    /// For callers that build the failed entry themselves.
+    pub(super) fn note_failed_entry(&mut self, key: K) {
+        self.note_failure(key, Instant::now());
     }
 
     pub(super) fn prune_to_limits(
@@ -276,6 +399,11 @@ where
         decoded_byte_budget: u64,
         is_protected: impl Fn(&K) -> bool,
     ) {
+        // Failure records are only meaningful while their entry is around, so
+        // they are evicted with it rather than growing for the whole session.
+        let entries = &self.entries;
+        self.failed.retain(|key, _| entries.contains_key(key));
+
         let mut retained_decoded_bytes = self
             .entries
             .values()

--- a/src/tui/media/decode.rs
+++ b/src/tui/media/decode.rs
@@ -30,10 +30,11 @@ pub(super) const MAX_DECODED_IMAGE_HEIGHT: u32 = 4096;
 const MAX_DECODED_IMAGE_BYTES: u64 = 64 * 1024 * 1024;
 const MAX_ANIMATION_SOURCE_FRAMES: usize = 4096;
 pub(super) const MAX_RETAINED_ANIMATION_FRAMES: usize = 32;
-/// Peak allocation while one animation is decoding, before compaction trims it
-/// back. Transient, but it still shows up as resident memory and the allocator
-/// is in no hurry to return it.
-const MAX_ANIMATION_DECODE_WORK_BYTES: u64 = 64 * 1024 * 1024;
+/// Total decoded pixel work accepted from one raster animation. This is larger
+/// than the retained-frame budget because decoded frames are compacted as they
+/// arrive. Animations that exceed this work budget fall back to their first
+/// frame instead of presenting an incomplete prefix as a valid loop.
+const MAX_ANIMATION_DECODE_WORK_BYTES: u64 = 256 * 1024 * 1024;
 pub(super) const MAX_LOTTIE_JSON_BYTES: usize = 1024 * 1024;
 const MIN_ANIMATION_FRAME_DELAY: Duration = Duration::from_millis(50);
 const MAX_UNDERSPECIFIED_FRAME_DELAY: Duration = Duration::from_millis(10);
@@ -603,12 +604,28 @@ fn lottie_frame_delay(duration_seconds: f32, retained_frame_count: usize) -> Dur
 }
 
 fn decode_gif_animation(bytes: &[u8]) -> std::result::Result<DecodedMediaImage, String> {
+    decode_gif_animation_with_limits(
+        bytes,
+        MAX_ANIMATION_SOURCE_FRAMES,
+        MAX_ANIMATION_DECODE_WORK_BYTES,
+    )
+}
+
+pub(super) fn decode_gif_animation_with_limits(
+    bytes: &[u8],
+    max_source_frames: usize,
+    max_decode_work_bytes: u64,
+) -> std::result::Result<DecodedMediaImage, String> {
     let mut decoder =
         GifDecoder::new(Cursor::new(bytes)).map_err(|error| format!("decode failed: {error}"))?;
     decoder
         .set_limits(decode_limits())
         .map_err(|error| format!("decode failed: {error}"))?;
-    decode_animation_frames(decoder.into_frames())
+    decode_animation_frames_with_limits(
+        decoder.into_frames(),
+        max_source_frames,
+        max_decode_work_bytes,
+    )
 }
 
 fn decode_webp_animation(bytes: &[u8]) -> std::result::Result<DecodedMediaImage, String> {
@@ -644,12 +661,29 @@ fn decode_png_animation(bytes: &[u8]) -> std::result::Result<DecodedMediaImage, 
 fn decode_animation_frames(
     frames: impl Iterator<Item = image::ImageResult<Frame>>,
 ) -> std::result::Result<DecodedMediaImage, String> {
+    decode_animation_frames_with_limits(
+        frames,
+        MAX_ANIMATION_SOURCE_FRAMES,
+        MAX_ANIMATION_DECODE_WORK_BYTES,
+    )
+}
+
+fn decode_animation_frames_with_limits(
+    frames: impl Iterator<Item = image::ImageResult<Frame>>,
+    max_source_frames: usize,
+    max_decode_work_bytes: u64,
+) -> std::result::Result<DecodedMediaImage, String> {
     let mut sampled_frames = Vec::new();
     let mut retained_bytes = 0u64;
     let mut decode_work_bytes = 0u64;
     let mut source_frame_count = 0usize;
 
-    for (frame_index, result) in frames.take(MAX_ANIMATION_SOURCE_FRAMES).enumerate() {
+    // Read one frame past the source limit so an oversized animation cannot be
+    // mistaken for a complete animation that happens to end at the limit.
+    for (frame_index, result) in frames.take(max_source_frames.saturating_add(1)).enumerate() {
+        if frame_index >= max_source_frames {
+            return first_sampled_frame_fallback(sampled_frames);
+        }
         let frame = result.map_err(|error| {
             format!(
                 "decode failed at animation frame {}: {error}",
@@ -660,9 +694,9 @@ fn decode_animation_frames(
 
         let frame_bytes = u64::try_from(frame.buffer().as_raw().len()).unwrap_or(u64::MAX);
         if frame_bytes > MAX_DECODED_IMAGE_BYTES
-            || decode_work_bytes.saturating_add(frame_bytes) > MAX_ANIMATION_DECODE_WORK_BYTES
+            || decode_work_bytes.saturating_add(frame_bytes) > max_decode_work_bytes
         {
-            return finish_sampled_animation(sampled_frames, source_frame_count);
+            return first_sampled_frame_fallback(sampled_frames);
         }
 
         decode_work_bytes = decode_work_bytes.saturating_add(frame_bytes);
@@ -681,6 +715,12 @@ fn decode_animation_frames(
     }
 
     finish_sampled_animation(sampled_frames, source_frame_count)
+}
+
+fn first_sampled_frame_fallback(
+    frames: Vec<SampledAnimationFrame>,
+) -> std::result::Result<DecodedMediaImage, String> {
+    first_frame_fallback(frames.into_iter().map(|sample| sample.frame).collect())
 }
 
 fn finish_sampled_animation(

--- a/src/tui/media/decode.rs
+++ b/src/tui/media/decode.rs
@@ -18,14 +18,22 @@ use super::{
     work::{MediaWorkError, MediaWorkResult, media_image_job_permits, media_image_work_permits},
 };
 
-const MAX_SHARED_DECODED_MEDIA_IMAGES: usize = 64;
-const MAX_SHARED_DECODED_MEDIA_BYTES: u64 = 256 * 1024 * 1024;
+/// The surface caches hold clones of these images, and `DecodedMediaImage`
+/// shares its frames through an `Arc`, so this cache is what actually pins
+/// decoded pixels in memory: an entry here keeps them alive long after the
+/// preview that asked for them scrolled away. It was the largest single store
+/// in the client.
+const MAX_SHARED_DECODED_MEDIA_IMAGES: usize = 24;
+const MAX_SHARED_DECODED_MEDIA_BYTES: u64 = 64 * 1024 * 1024;
 pub(super) const MAX_DECODED_IMAGE_WIDTH: u32 = 4096;
 pub(super) const MAX_DECODED_IMAGE_HEIGHT: u32 = 4096;
 const MAX_DECODED_IMAGE_BYTES: u64 = 64 * 1024 * 1024;
 const MAX_ANIMATION_SOURCE_FRAMES: usize = 4096;
 pub(super) const MAX_RETAINED_ANIMATION_FRAMES: usize = 32;
-const MAX_ANIMATION_DECODE_WORK_BYTES: u64 = 256 * 1024 * 1024;
+/// Peak allocation while one animation is decoding, before compaction trims it
+/// back. Transient, but it still shows up as resident memory and the allocator
+/// is in no hurry to return it.
+const MAX_ANIMATION_DECODE_WORK_BYTES: u64 = 64 * 1024 * 1024;
 pub(super) const MAX_LOTTIE_JSON_BYTES: usize = 1024 * 1024;
 const MIN_ANIMATION_FRAME_DELAY: Duration = Duration::from_millis(50);
 const MAX_UNDERSPECIFIED_FRAME_DELAY: Duration = Duration::from_millis(10);
@@ -272,6 +280,19 @@ impl MediaImageDecodeCache {
         }
 
         deliveries_for_requests(requests, completed.result)
+    }
+
+    /// Ready entries and the decoded bytes they pin. These are the same `Arc`
+    /// buffers the surface caches report, counted once here.
+    pub(in crate::tui) fn retained_stats(&self) -> (usize, u64) {
+        self.entries
+            .values()
+            .fold((0, 0), |(count, bytes), entry| match entry {
+                SharedDecodeEntry::Ready { image, .. } => {
+                    (count + 1, bytes.saturating_add(image.retained_bytes()))
+                }
+                SharedDecodeEntry::Decoding { .. } => (count, bytes),
+            })
     }
 
     fn next_tick(&mut self) -> u64 {

--- a/src/tui/media/emoji.rs
+++ b/src/tui/media/emoji.rs
@@ -395,16 +395,16 @@ impl EmojiImageCache {
                 ..
             }) if *generation == completed.generation => {
                 let result = match image_size {
-                    EmojiImageSize::Compact => {
-                        protocols
-                            .compact
-                            .store_result(frame_index, completed.result, protocol_bytes)
-                    }
-                    EmojiImageSize::Standalone => {
-                        protocols
-                            .standalone
-                            .store_result(frame_index, completed.result, protocol_bytes)
-                    }
+                    EmojiImageSize::Compact => protocols.compact.store_result(
+                        frame_index,
+                        completed.result,
+                        protocol_bytes,
+                    ),
+                    EmojiImageSize::Standalone => protocols.standalone.store_result(
+                        frame_index,
+                        completed.result,
+                        protocol_bytes,
+                    ),
                 };
                 image_size == EmojiImageSize::Compact && result.is_err()
             }

--- a/src/tui/media/emoji.rs
+++ b/src/tui/media/emoji.rs
@@ -11,6 +11,7 @@ use super::{
     EmojiImageTarget,
     cache::{MediaImageCacheCore, MediaImageCacheEntry, RenderProtocolCache},
     decode::{DecodedMediaImage, MediaImageDecodeKey, MediaImageDecodeRequest},
+    estimated_media_protocol_bytes, fixed_media_protocol_render_spec, picker_font_size,
     protocol_job::{MediaProtocolBuildJob, MediaProtocolBuildResult, MediaProtocolBuildTarget},
     work::{MediaWorkError, MediaWorkResult},
 };
@@ -19,7 +20,7 @@ use super::{
 /// frames, so the cache must stay bounded even though Discord emoji files are
 /// small on the wire.
 pub(super) const MAX_EMOJI_IMAGE_CACHE_ENTRIES: usize = 128;
-const EMOJI_IMAGE_CACHE_DECODED_BYTE_BUDGET: u64 = 64 * 1024 * 1024;
+const EMOJI_IMAGE_CACHE_DECODED_BYTE_BUDGET: u64 = 24 * 1024 * 1024;
 
 pub(in crate::tui) struct EmojiImageCache {
     pub(super) picker: Option<Picker>,
@@ -57,6 +58,12 @@ impl EmojiProtocolCaches {
             compact: RenderProtocolCache::new(),
             standalone: RenderProtocolCache::new(),
         }
+    }
+
+    fn retained_bytes(&self) -> u64 {
+        self.compact
+            .retained_bytes()
+            .saturating_add(self.standalone.retained_bytes())
     }
 }
 
@@ -99,6 +106,17 @@ impl MediaImageCacheEntry for EmojiImageEntry {
 
     fn is_loading(&self) -> bool {
         matches!(self, EmojiImageEntry::Loading { .. })
+    }
+
+    fn is_failed(&self) -> bool {
+        matches!(self, EmojiImageEntry::Failed { .. })
+    }
+
+    fn retained_protocol_bytes(&self) -> u64 {
+        match self {
+            EmojiImageEntry::Ready { protocols, .. } => protocols.retained_bytes(),
+            _ => 0,
+        }
     }
 
     fn decoding_generation(&self) -> Option<u64> {
@@ -331,6 +349,14 @@ impl EmojiImageCache {
         }
     }
 
+    pub(in crate::tui) fn retained_stats(&self) -> (usize, u64, u64) {
+        self.cache.retained_stats()
+    }
+
+    pub(in crate::tui) fn forget_failures(&mut self) {
+        self.cache.forget_failures();
+    }
+
     pub(in crate::tui) fn pause_animations(&mut self) {
         self.cache.pause_animations();
     }
@@ -356,6 +382,12 @@ impl EmojiImageCache {
         else {
             return;
         };
+        // The cell box the protocol was rendered into; a few KB per protocol.
+        let font_size = self.picker.as_ref().map_or((10, 20), picker_font_size);
+        let protocol_bytes = estimated_media_protocol_bytes(
+            fixed_media_protocol_render_spec(image_size.width(), image_size.height()),
+            font_size,
+        );
         let failed = match self.cache.entries.get_mut(&url) {
             Some(EmojiImageEntry::Ready {
                 generation,
@@ -363,12 +395,16 @@ impl EmojiImageCache {
                 ..
             }) if *generation == completed.generation => {
                 let result = match image_size {
-                    EmojiImageSize::Compact => protocols
-                        .compact
-                        .store_result(frame_index, completed.result),
-                    EmojiImageSize::Standalone => protocols
-                        .standalone
-                        .store_result(frame_index, completed.result),
+                    EmojiImageSize::Compact => {
+                        protocols
+                            .compact
+                            .store_result(frame_index, completed.result, protocol_bytes)
+                    }
+                    EmojiImageSize::Standalone => {
+                        protocols
+                            .standalone
+                            .store_result(frame_index, completed.result, protocol_bytes)
+                    }
                 };
                 image_size == EmojiImageSize::Compact && result.is_err()
             }

--- a/src/tui/media/preview.rs
+++ b/src/tui/media/preview.rs
@@ -7,6 +7,7 @@ use crate::discord::ids::{Id, marker::MessageMarker};
 use ratatui_image::picker::Picker;
 
 use crate::{
+    config::AnimatePreviews,
     discord::{AppCommand, AppEvent},
     tui::ui::{ImagePreview, ImagePreviewState},
 };
@@ -371,10 +372,19 @@ impl ImagePreviewCache {
         &mut self,
         targets: &[ImagePreviewTarget],
         now: Instant,
+        animate: AnimatePreviews,
     ) {
+        // Every animated frame costs a fresh protocol build, so the set that
+        // keeps moving is the set the reader is actually looking at. Anything
+        // left out holds the frame it stopped on.
         let visible = targets
             .iter()
-            .map(ImagePreviewTarget::key)
+            .filter(|target| match animate {
+                AnimatePreviews::Always => true,
+                AnimatePreviews::Selected => target.viewer || target.selected,
+                AnimatePreviews::Never => false,
+            })
+            .map(|target| target.key())
             .collect::<HashSet<_>>();
         for (key, entry) in &mut self.cache.entries {
             let ImagePreviewEntry::Ready {

--- a/src/tui/media/preview.rs
+++ b/src/tui/media/preview.rs
@@ -425,7 +425,32 @@ impl ImagePreviewCache {
     }
 
     pub(in crate::tui) fn advance_animations(&mut self, now: Instant) -> bool {
-        self.cache.advance_animations(now)
+        let mut advanced = false;
+        for entry in self.cache.entries.values_mut() {
+            let ImagePreviewEntry::Ready {
+                image, protocols, ..
+            } = entry
+            else {
+                continue;
+            };
+            let next_frame_index = image.frame_index_with_offset(1);
+            let next_frame_ready = protocols.get(&next_frame_index).is_some()
+                || protocols.is_terminally_failed(&next_frame_index);
+            if image
+                .next_frame_deadline()
+                .is_some_and(|deadline| deadline <= now)
+                && !next_frame_ready
+            {
+                // Protocol encoding can be slower than the source frame delay
+                // for a large preview. Hold the current image until the worker
+                // finishes instead of advancing into missing frames and
+                // repeatedly drawing the last protocol as a fallback.
+                image.pause_animation();
+                continue;
+            }
+            advanced |= image.advance_frame(now);
+        }
+        advanced
     }
 
     pub(in crate::tui) fn take_protocol_jobs(&mut self) -> Vec<MediaProtocolBuildJob> {

--- a/src/tui/media/preview.rs
+++ b/src/tui/media/preview.rs
@@ -15,12 +15,13 @@ use super::{
     ImagePreviewTarget, MediaProtocolRenderSpec,
     cache::{MediaImageCacheCore, MediaImageCacheEntry, RenderProtocolCache},
     decode::{DecodedMediaImage, MediaImageDecodeKey, MediaImageDecodeRequest},
+    estimated_media_protocol_bytes, picker_font_size,
     protocol_job::{MediaProtocolBuildJob, MediaProtocolBuildResult},
     work::{MediaWorkError, MediaWorkResult},
 };
 
 pub(super) const MAX_IMAGE_PREVIEW_CACHE_ENTRIES: usize = 16;
-const IMAGE_PREVIEW_CACHE_DECODED_BYTE_BUDGET: u64 = 128 * 1024 * 1024;
+const IMAGE_PREVIEW_CACHE_DECODED_BYTE_BUDGET: u64 = 48 * 1024 * 1024;
 const ANIMATION_PROTOCOL_WINDOW_FRAMES: usize = 2;
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -179,6 +180,7 @@ impl ImagePreviewCache {
         targets: &[ImagePreviewTarget],
     ) -> Vec<AppCommand> {
         let mut intents = Vec::new();
+        let now = Instant::now();
         let mut requested_urls = self
             .cache
             .entries
@@ -188,7 +190,7 @@ impl ImagePreviewCache {
             .collect::<HashSet<_>>();
         for target in targets.iter().take(MAX_IMAGE_PREVIEW_CACHE_ENTRIES) {
             let key = target.key();
-            if self.cache.entries.contains_key(&key) {
+            if self.cache.entries.contains_key(&key) && !self.cache.take_due_retry(&key, now) {
                 continue;
             }
 
@@ -396,6 +398,14 @@ impl ImagePreviewCache {
         }
     }
 
+    pub(in crate::tui) fn retained_stats(&self) -> (usize, u64, u64) {
+        self.cache.retained_stats()
+    }
+
+    pub(in crate::tui) fn forget_failures(&mut self) {
+        self.cache.forget_failures();
+    }
+
     pub(in crate::tui) fn pause_animations(&mut self) {
         self.cache.pause_animations();
     }
@@ -412,6 +422,11 @@ impl ImagePreviewCache {
         std::mem::take(&mut self.protocol_jobs)
     }
 
+    fn estimated_protocol_bytes(&self, render_spec: MediaProtocolRenderSpec) -> u64 {
+        let font_size = self.picker.as_ref().map_or((10, 20), picker_font_size);
+        estimated_media_protocol_bytes(render_spec, font_size)
+    }
+
     pub(in crate::tui) fn store_protocol(&mut self, completed: MediaProtocolBuildResult) {
         let super::protocol_job::MediaProtocolBuildTarget::Preview {
             key,
@@ -421,6 +436,7 @@ impl ImagePreviewCache {
         else {
             return;
         };
+        let protocol_bytes = self.estimated_protocol_bytes(render_spec);
         let failure = match self.cache.entries.get_mut(&key) {
             Some(ImagePreviewEntry::Ready {
                 filename,
@@ -429,7 +445,7 @@ impl ImagePreviewCache {
                 protocols,
                 ..
             }) if *generation == completed.generation && *protocol_spec == render_spec => protocols
-                .store_result(frame_index, completed.result)
+                .store_result(frame_index, completed.result, protocol_bytes)
                 .err()
                 .map(|error| (filename.clone(), error)),
             _ => None,
@@ -465,13 +481,14 @@ impl ImagePreviewCache {
             let filename = self.filename_for_key(&key);
             let last_used = self.cache.next_tick();
             self.cache.entries.insert(
-                key,
+                key.clone(),
                 ImagePreviewEntry::Failed {
                     filename,
                     message: message.clone(),
                     last_used,
                 },
             );
+            self.cache.note_failed_entry(key);
         }
     }
 
@@ -595,6 +612,17 @@ impl MediaImageCacheEntry for ImagePreviewEntry {
 
     fn is_loading(&self) -> bool {
         matches!(self, ImagePreviewEntry::Loading { .. })
+    }
+
+    fn is_failed(&self) -> bool {
+        matches!(self, ImagePreviewEntry::Failed { .. })
+    }
+
+    fn retained_protocol_bytes(&self) -> u64 {
+        match self {
+            ImagePreviewEntry::Ready { protocols, .. } => protocols.retained_bytes(),
+            _ => 0,
+        }
     }
 
     fn decoding_generation(&self) -> Option<u64> {

--- a/src/tui/media/protocol.rs
+++ b/src/tui/media/protocol.rs
@@ -139,6 +139,21 @@ pub(in crate::tui) struct MediaProtocolRenderSpec {
     pub(super) mask_circular: bool,
 }
 
+/// Estimated bytes a built protocol retains. The encoded frame is the resized
+/// RGBA image inflated by the protocol's text encoding (base64 for kitty and
+/// iTerm2), which measures within a few percent of this. It only bounds caches,
+/// so being close is enough.
+pub(in crate::tui) fn estimated_media_protocol_bytes(
+    spec: MediaProtocolRenderSpec,
+    font_size: (u16, u16),
+) -> u64 {
+    let pixels = u64::from(spec.width)
+        .saturating_mul(u64::from(font_size.0))
+        .saturating_mul(u64::from(spec.height))
+        .saturating_mul(u64::from(font_size.1));
+    pixels.saturating_mul(4).saturating_mul(4) / 3
+}
+
 pub(in crate::tui) fn fixed_media_protocol_render_spec(
     width: u16,
     height: u16,

--- a/src/tui/media/targets.rs
+++ b/src/tui/media/targets.rs
@@ -55,6 +55,9 @@ enum YoutubeThumbnailSize {
 #[derive(Clone)]
 pub(in crate::tui) struct ImagePreviewTarget {
     pub(in crate::tui) viewer: bool,
+    /// Whether this preview belongs to the selected message, which decides
+    /// whether it animates under `AnimatePreviews::Selected`.
+    pub(in crate::tui) selected: bool,
     pub(in crate::tui) thread_card: bool,
     pub(in crate::tui) message_index: usize,
     pub(in crate::tui) preview_index: usize,
@@ -162,6 +165,7 @@ pub(in crate::tui) fn visible_image_preview_targets_from_plan(
         }
         return vec![ImagePreviewTarget {
             viewer: true,
+            selected: true,
             thread_card: false,
             message_index: 0,
             preview_index,
@@ -212,6 +216,7 @@ pub(in crate::tui) fn visible_image_preview_targets_from_plan(
             if cell.width > 0 && cell.height > 0 && visible_top < visible_bottom {
                 targets.push(ImagePreviewTarget {
                     viewer: false,
+                    selected: row.selected,
                     thread_card: false,
                     message_index,
                     preview_index: cell.preview_index,
@@ -280,6 +285,7 @@ pub(in crate::tui) fn visible_image_preview_targets_from_plan(
             let top_clip_rows = u16::try_from(visible_top - preview_top).unwrap_or(u16::MAX);
             targets.push(ImagePreviewTarget {
                 viewer: false,
+                selected: row.selected,
                 thread_card: false,
                 message_index,
                 preview_index: previews.len().saturating_add(slot.section_thumbnail_index),
@@ -314,6 +320,7 @@ fn visible_thread_card_image_preview_targets(
         .saturating_sub(usize::from(scrollbar_visible))
         .max(4);
     let quality = state.image_preview_quality();
+    let focused = state.focused_thread_card_selection();
     let mut rendered_row = 0usize;
     let mut targets = Vec::new();
 
@@ -335,7 +342,10 @@ fn visible_thread_card_image_preview_targets(
             layout.font_size,
             quality,
         ) {
-            targets.push(target);
+            targets.push(ImagePreviewTarget {
+                selected: focused == Some(post_index),
+                ..target
+            });
         }
         rendered_row =
             rendered_row.saturating_add(thread_card::thread_card_height(post, card_width, true));
@@ -363,7 +373,7 @@ fn visible_embedded_thread_card_image_preview_targets(
                 .body_top
                 .saturating_add(row.metrics.header_rows as isize)
                 .saturating_add(1);
-            thread_card_image_preview_target(
+            let target = thread_card_image_preview_target(
                 &post,
                 message_index,
                 card_width,
@@ -372,7 +382,11 @@ fn visible_embedded_thread_card_image_preview_targets(
                 layout.list_height,
                 layout.font_size,
                 quality,
-            )
+            )?;
+            Some(ImagePreviewTarget {
+                selected: row.selected,
+                ..target
+            })
         })
         .collect()
 }
@@ -416,6 +430,7 @@ fn thread_card_image_preview_target(
 
     Some(ImagePreviewTarget {
         viewer: false,
+        selected: false,
         thread_card: true,
         message_index,
         preview_index: 0,

--- a/src/tui/media/tests.rs
+++ b/src/tui/media/tests.rs
@@ -1518,6 +1518,45 @@ fn image_preview_cache_limits_visible_requests() {
 }
 
 #[test]
+fn a_failed_media_fetch_retries_with_backoff_then_waits_for_a_refresh() {
+    let mut cache = ImagePreviewCache::new(None);
+    let target = image_preview_target(1);
+    let targets = [target.clone()];
+    let key = target.key();
+    let now = Instant::now();
+    let past_every_backoff = now + Duration::from_secs(600);
+
+    assert_eq!(cache.next_requests(&targets).len(), 1);
+
+    // Three tries, each gated by its backoff, then the retries are spent.
+    for attempt in 1..=4 {
+        cache.store_failed(&target.url, "download failed".to_owned());
+        assert!(
+            !cache.cache.take_due_retry(&key, now),
+            "attempt {attempt} must wait out its backoff"
+        );
+        let due = cache.cache.take_due_retry(&key, past_every_backoff);
+        assert_eq!(due, attempt < 4, "attempt {attempt} retry availability");
+        if !due {
+            break;
+        }
+        cache.cache.entries.insert(
+            key.clone(),
+            ImagePreviewEntry::Loading {
+                filename: target.filename.clone(),
+                protocol_spec: target.protocol_render_spec(),
+                last_used: 0,
+            },
+        );
+    }
+
+    // The manual refresh is the way back once the retries are spent.
+    cache.forget_failures();
+    assert!(!cache.cache.entries.contains_key(&key));
+    assert_eq!(cache.next_requests(&targets).len(), 1);
+}
+
+#[test]
 fn image_preview_store_loaded_preserves_existing_non_loading_entries() {
     let mut cache = ImagePreviewCache::new(None);
     let existing = image_preview_target(1).key();
@@ -1739,12 +1778,45 @@ fn media_decode_queue_pressure_retries_all_consumers() {
 }
 
 #[test]
+fn render_protocols_are_evicted_by_size_not_only_by_count() {
+    let picker = ratatui_image::picker::Picker::halfblocks();
+    let image = DynamicImage::ImageRgba8(image::RgbaImage::new(4, 4));
+    let build = || {
+        picker
+            .new_protocol(
+                image.clone(),
+                ratatui::layout::Size::new(2, 1),
+                ratatui_image::Resize::Fit(None),
+            )
+            .expect("test protocol should build")
+    };
+
+    let mut protocols = super::cache::RenderProtocolCache::<usize>::new();
+    // Half the budget each: two fit, the third has to evict the oldest even
+    // though the count cap is nowhere near.
+    let half_budget = super::cache::RENDER_PROTOCOL_BYTE_BUDGET_PER_MEDIA_ENTRY / 2;
+    for frame in 0..3 {
+        assert!(protocols.request_build(&frame));
+        protocols
+            .store_result(frame, Ok(build()), half_budget)
+            .expect("test protocol should store");
+    }
+
+    assert_eq!(protocols.len(), 2);
+    assert!(protocols.get(&0).is_none(), "the oldest frame should go");
+    assert!(protocols.get(&2).is_some(), "the newest frame must stay");
+}
+
+#[test]
 fn protocol_queue_pressure_does_not_consume_failure_attempts() {
     let mut protocols = super::cache::RenderProtocolCache::<usize>::new();
 
     for _ in 0..3 {
         assert!(protocols.request_build(&0));
-        assert_eq!(protocols.store_result(0, Err(MediaWorkError::Busy)), Ok(()));
+        assert_eq!(
+            protocols.store_result(0, Err(MediaWorkError::Busy), 0),
+            Ok(())
+        );
         assert!(!protocols.is_terminally_failed(&0));
     }
 
@@ -1755,6 +1827,7 @@ fn protocol_queue_pressure_does_not_consume_failure_attempts() {
             Err(MediaWorkError::Failed(
                 "temporary protocol failure".to_owned(),
             )),
+            0,
         ),
         Ok(())
     );
@@ -1767,6 +1840,7 @@ fn protocol_queue_pressure_does_not_consume_failure_attempts() {
             Err(MediaWorkError::Failed(
                 "terminal protocol failure".to_owned(),
             )),
+            0,
         ),
         Err("terminal protocol failure".to_owned())
     );

--- a/src/tui/media/tests.rs
+++ b/src/tui/media/tests.rs
@@ -14,7 +14,7 @@ use image::{
 };
 
 use crate::{
-    config::{DisplayOptions, ImagePreviewQualityPreset},
+    config::{AnimatePreviews, DisplayOptions, ImagePreviewQualityPreset},
     discord::{
         ActivityEmoji, ActivityInfo, ActivityKind, AppCommand, AppEvent, AttachmentInfo,
         ChannelInfo, ChannelRecipientInfo, ComponentMediaInfo, ComponentMediaItemInfo,
@@ -1778,6 +1778,63 @@ fn media_decode_queue_pressure_retries_all_consumers() {
 }
 
 #[test]
+fn animate_previews_policy_decides_which_previews_keep_moving() {
+    let selected = image_preview_target(1);
+    let unselected = ImagePreviewTarget {
+        selected: false,
+        message_id: Id::new(2),
+        ..image_preview_target(1)
+    };
+    let targets = [selected.clone(), unselected.clone()];
+
+    let mut cache = ImagePreviewCache::new(Some(ratatui_image::picker::Picker::halfblocks()));
+    for target in &targets {
+        let key = target.key();
+        cache.cache.entries.insert(
+            key.clone(),
+            ImagePreviewEntry::Decoding {
+                filename: target.filename.clone(),
+                generation: 1,
+                protocol_spec: target.protocol_render_spec(),
+                last_used: 1,
+            },
+        );
+        cache.store_decoded(
+            key,
+            1,
+            decode_media_image_bytes(&encoded_animated_gif()).map_err(MediaWorkError::Failed),
+        );
+    }
+    // Build every protocol so animation is only gated by the policy.
+    for _ in 0..8 {
+        let _ = cache.render_state(&targets);
+        for job in cache.take_protocol_jobs() {
+            cache.store_protocol(build_media_protocol(job));
+        }
+    }
+
+    let now = Instant::now();
+    let animating = |cache: &ImagePreviewCache, target: &ImagePreviewTarget| {
+        matches!(
+            cache.cache.entries.get(&target.key()),
+            Some(ImagePreviewEntry::Ready { image, .. }) if image.next_frame_deadline().is_some()
+        )
+    };
+
+    cache.sync_animation_visibility(&targets, now, AnimatePreviews::Never);
+    assert!(!animating(&cache, &selected));
+    assert!(!animating(&cache, &unselected));
+
+    cache.sync_animation_visibility(&targets, now, AnimatePreviews::Selected);
+    assert!(animating(&cache, &selected));
+    assert!(!animating(&cache, &unselected));
+
+    cache.sync_animation_visibility(&targets, now, AnimatePreviews::Always);
+    assert!(animating(&cache, &selected));
+    assert!(animating(&cache, &unselected));
+}
+
+#[test]
 fn render_protocols_are_evicted_by_size_not_only_by_count() {
     let picker = ratatui_image::picker::Picker::halfblocks();
     let image = DynamicImage::ImageRgba8(image::RgbaImage::new(4, 4));
@@ -2135,7 +2192,11 @@ fn attachment_preview_waits_for_a_ready_or_failed_next_animation_frame() {
     assert_eq!(jobs.len(), 1);
 
     let started_at = Instant::now();
-    cache.sync_animation_visibility(std::slice::from_ref(&target), started_at);
+    cache.sync_animation_visibility(
+        std::slice::from_ref(&target),
+        started_at,
+        AnimatePreviews::Always,
+    );
     assert_eq!(cache.next_animation_deadline(), None);
 
     for job in jobs {
@@ -2144,7 +2205,11 @@ fn attachment_preview_waits_for_a_ready_or_failed_next_animation_frame() {
     assert_eq!(cache.render_state(std::slice::from_ref(&target)).len(), 1);
     let jobs = cache.take_protocol_jobs();
     assert_eq!(jobs.len(), 1);
-    cache.sync_animation_visibility(std::slice::from_ref(&target), started_at);
+    cache.sync_animation_visibility(
+        std::slice::from_ref(&target),
+        started_at,
+        AnimatePreviews::Always,
+    );
     assert_eq!(cache.next_animation_deadline(), None);
     let mut failed = build_media_protocol(
         jobs.into_iter()
@@ -2170,7 +2235,11 @@ fn attachment_preview_waits_for_a_ready_or_failed_next_animation_frame() {
     assert_eq!(cache.render_state(std::slice::from_ref(&target)).len(), 1);
     assert!(cache.take_protocol_jobs().is_empty());
 
-    cache.sync_animation_visibility(std::slice::from_ref(&target), started_at);
+    cache.sync_animation_visibility(
+        std::slice::from_ref(&target),
+        started_at,
+        AnimatePreviews::Always,
+    );
     let deadline = cache
         .next_animation_deadline()
         .expect("visible attachment should schedule an animation frame");
@@ -2203,7 +2272,7 @@ fn attachment_preview_waits_for_a_ready_or_failed_next_animation_frame() {
         }) if image.current_frame_index() == 0 && protocols.len() == 1
     ));
 
-    cache.sync_animation_visibility(&[], loop_deadline);
+    cache.sync_animation_visibility(&[], loop_deadline, AnimatePreviews::Always);
     assert_eq!(cache.next_animation_deadline(), None);
 }
 
@@ -2992,6 +3061,7 @@ fn push_attachment_message(state: &mut DashboardState, attachment: AttachmentInf
 fn image_preview_target(id: u64) -> ImagePreviewTarget {
     ImagePreviewTarget {
         viewer: false,
+        selected: true,
         thread_card: false,
         message_index: 0,
         preview_index: 0,

--- a/src/tui/media/tests.rs
+++ b/src/tui/media/tests.rs
@@ -32,7 +32,10 @@ use crate::{
 };
 
 use super::*;
-use super::{decode::MAX_LOTTIE_JSON_BYTES, work::MediaWorkError};
+use super::{
+    decode::{MAX_LOTTIE_JSON_BYTES, decode_gif_animation_with_limits},
+    work::MediaWorkError,
+};
 
 fn layout(list_height: usize) -> ImagePreviewLayout {
     ImagePreviewLayout {
@@ -63,6 +66,31 @@ fn encoded_png(width: u32, height: u32) -> Vec<u8> {
 
 fn encoded_animated_gif() -> Vec<u8> {
     encoded_two_frame_gif(10)
+}
+
+fn encoded_three_frame_gif() -> Vec<u8> {
+    let mut bytes = Vec::new();
+    {
+        let mut encoder = GifEncoder::new(&mut bytes);
+        encoder
+            .set_repeat(Repeat::Infinite)
+            .expect("test GIF repeat should encode");
+        for color in [
+            Rgba([255, 0, 0, 255]),
+            Rgba([0, 255, 0, 255]),
+            Rgba([0, 0, 255, 255]),
+        ] {
+            encoder
+                .encode_frame(ImageFrame::from_parts(
+                    ImageBuffer::from_pixel(2, 2, color),
+                    0,
+                    0,
+                    Delay::from_numer_denom_ms(50, 1),
+                ))
+                .expect("test GIF frame should encode");
+        }
+    }
+    bytes
 }
 
 fn encoded_two_frame_gif(delay_ms: u32) -> Vec<u8> {
@@ -1835,7 +1863,7 @@ fn animate_previews_policy_decides_which_previews_keep_moving() {
 }
 
 #[test]
-fn render_protocols_are_evicted_by_size_not_only_by_count() {
+fn render_protocols_keep_the_two_frame_animation_window() {
     let picker = ratatui_image::picker::Picker::halfblocks();
     let image = DynamicImage::ImageRgba8(image::RgbaImage::new(4, 4));
     let build = || {
@@ -1849,19 +1877,96 @@ fn render_protocols_are_evicted_by_size_not_only_by_count() {
     };
 
     let mut protocols = super::cache::RenderProtocolCache::<usize>::new();
-    // Half the budget each: two fit, the third has to evict the oldest even
-    // though the count cap is nowhere near.
-    let half_budget = super::cache::RENDER_PROTOCOL_BYTE_BUDGET_PER_MEDIA_ENTRY / 2;
+    // Each protocol is larger than half the budget. The cache must still keep
+    // two, then evict the oldest when a third arrives. Keeping only one would
+    // make the current and next animation frames rebuild each other forever.
+    let protocol_bytes = super::cache::RENDER_PROTOCOL_BYTE_BUDGET_PER_MEDIA_ENTRY * 2 / 3;
     for frame in 0..3 {
         assert!(protocols.request_build(&frame));
         protocols
-            .store_result(frame, Ok(build()), half_budget)
+            .store_result(frame, Ok(build()), protocol_bytes)
             .expect("test protocol should store");
     }
 
     assert_eq!(protocols.len(), 2);
     assert!(protocols.get(&0).is_none(), "the oldest frame should go");
+    assert!(protocols.get(&1).is_some(), "the current frame must stay");
     assert!(protocols.get(&2).is_some(), "the newest frame must stay");
+}
+
+#[test]
+fn attachment_preview_waits_when_protocol_encoding_falls_behind() {
+    let target = image_preview_target(42);
+    let key = target.key();
+    let protocol_spec = target.protocol_render_spec();
+    let mut cache = ImagePreviewCache::new(Some(ratatui_image::picker::Picker::halfblocks()));
+    cache.cache.entries.insert(
+        key.clone(),
+        ImagePreviewEntry::Decoding {
+            filename: target.filename.clone(),
+            generation: 1,
+            protocol_spec,
+            last_used: 1,
+        },
+    );
+    cache.store_decoded(
+        key.clone(),
+        1,
+        decode_media_image_bytes(&encoded_three_frame_gif()).map_err(MediaWorkError::Failed),
+    );
+
+    for _ in 0..2 {
+        let _ = cache.render_state(std::slice::from_ref(&target));
+        for job in cache.take_protocol_jobs() {
+            cache.store_protocol(build_media_protocol(job));
+        }
+    }
+
+    let started_at = Instant::now();
+    cache.sync_animation_visibility(
+        std::slice::from_ref(&target),
+        started_at,
+        AnimatePreviews::Always,
+    );
+    let first_deadline = cache
+        .next_animation_deadline()
+        .expect("prepared preview should start animating");
+    assert!(cache.advance_animations(first_deadline));
+
+    // Rendering frame 1 queues frame 2, but leave that job unfinished to
+    // model a large terminal protocol that takes longer than one frame delay.
+    assert_eq!(cache.render_state(std::slice::from_ref(&target)).len(), 1);
+    let mut delayed_jobs = cache.take_protocol_jobs();
+    assert_eq!(delayed_jobs.len(), 1);
+    let delayed_job = delayed_jobs
+        .pop()
+        .expect("next frame protocol job should exist");
+    let second_deadline = cache
+        .next_animation_deadline()
+        .expect("running preview should schedule its next frame");
+    assert!(!cache.advance_animations(second_deadline));
+    assert!(matches!(
+        cache.cache.entries.get(&key),
+        Some(ImagePreviewEntry::Ready { image, .. })
+            if image.current_frame_index() == 1 && image.next_frame_deadline().is_none()
+    ));
+
+    cache.store_protocol(build_media_protocol(delayed_job));
+    assert_eq!(cache.render_state(std::slice::from_ref(&target)).len(), 1);
+    cache.sync_animation_visibility(
+        std::slice::from_ref(&target),
+        second_deadline,
+        AnimatePreviews::Always,
+    );
+    let resumed_deadline = cache
+        .next_animation_deadline()
+        .expect("completed protocol should resume animation");
+    assert!(cache.advance_animations(resumed_deadline));
+    assert!(matches!(
+        cache.cache.entries.get(&key),
+        Some(ImagePreviewEntry::Ready { image, .. })
+            if image.current_frame_index() == 2
+    ));
 }
 
 #[test]
@@ -2046,7 +2151,7 @@ fn media_decoder_keeps_static_png_still() {
 }
 
 #[test]
-fn media_decoder_samples_long_animations_across_the_full_timeline() {
+fn media_decoder_samples_complete_timelines_and_avoids_partial_loops_at_limits() {
     let mut image = decode_media_image_bytes(&encoded_long_animated_gif())
         .expect("long GIF animation should decode");
     assert_eq!(image.frame_count(), MAX_RETAINED_ANIMATION_FRAMES);
@@ -2081,6 +2186,24 @@ fn media_decoder_samples_long_animations_across_the_full_timeline() {
             >= 16,
         "longer source delays should retain more representatives"
     );
+
+    let encoded = encoded_three_frame_gif();
+    for (label, max_source_frames, max_decode_work_bytes) in [
+        ("source frame limit", 2, u64::MAX),
+        ("decode work limit", usize::MAX, 32),
+    ] {
+        let image =
+            decode_gif_animation_with_limits(&encoded, max_source_frames, max_decode_work_bytes)
+                .unwrap_or_else(|error| panic!("{label} should keep a static fallback: {error}"));
+
+        assert_eq!(image.frame_count(), 1, "{label}");
+        assert!(!image.is_animated(), "{label}");
+        assert_eq!(
+            image.current_frame().to_rgba8().get_pixel(0, 0),
+            &Rgba([255, 0, 0, 255]),
+            "{label}",
+        );
+    }
 }
 
 #[test]

--- a/src/tui/runtime/media_runtime.rs
+++ b/src/tui/runtime/media_runtime.rs
@@ -8,7 +8,7 @@ use ratatui_image::{
 use tokio::sync::mpsc;
 
 use crate::{
-    config::ImageProtocolPreference,
+    config::{AnimatePreviews, ImageProtocolPreference},
     discord::{AppCommand, AppEvent, MAX_UPLOAD_PREVIEW_BYTES, MessageAttachmentUpload},
     logging,
     tui::{
@@ -376,9 +376,9 @@ impl DashboardMediaRuntime {
                 .is_some_and(|picker| picker.protocol_type() == ProtocolType::Kitty)
     }
 
-    pub(super) fn sync_animation_visibility(&mut self, now: Instant) {
+    pub(super) fn sync_animation_visibility(&mut self, now: Instant, animate: AnimatePreviews) {
         self.image_previews
-            .sync_animation_visibility(&self.image_targets, now);
+            .sync_animation_visibility(&self.image_targets, now, animate);
         self.avatar_images
             .sync_animation_visibility(&self.avatar_targets, now);
         self.emoji_images
@@ -932,6 +932,7 @@ mod tests {
     fn image_preview_target() -> ImagePreviewTarget {
         ImagePreviewTarget {
             viewer: false,
+            selected: false,
             thread_card: false,
             message_index: 0,
             preview_index: 0,

--- a/src/tui/runtime/media_runtime.rs
+++ b/src/tui/runtime/media_runtime.rs
@@ -10,6 +10,7 @@ use tokio::sync::mpsc;
 use crate::{
     config::ImageProtocolPreference,
     discord::{AppCommand, AppEvent, MAX_UPLOAD_PREVIEW_BYTES, MessageAttachmentUpload},
+    logging,
     tui::{
         commands as command_helpers,
         media::{
@@ -388,6 +389,39 @@ impl DashboardMediaRuntime {
         self.image_previews.pause_animations();
         self.avatar_images.pause_animations();
         self.emoji_images.pause_animations();
+    }
+
+    /// Reports what the media caches are actually holding, next to the
+    /// process's resident size. Cache totals that stay flat while RSS climbs
+    /// mean the memory is not live data, which is the one thing a bounded
+    /// cache cannot tell you from the outside.
+    pub(super) fn log_memory_report(&self) {
+        let (previews, preview_decoded, preview_protocols) = self.image_previews.retained_stats();
+        let (avatars, avatar_decoded, avatar_protocols) = self.avatar_images.retained_stats();
+        let (emoji, emoji_decoded, emoji_protocols) = self.emoji_images.retained_stats();
+        let (shared, shared_decoded) = self.decoded_images.retained_stats();
+        let protocols = preview_protocols
+            .saturating_add(avatar_protocols)
+            .saturating_add(emoji_protocols);
+        logging::debug(
+            "media",
+            format!(
+                "media cache report: previews={previews}/{preview_decoded} avatars={avatars}/{avatar_decoded} emoji={emoji}/{emoji_decoded} shared={shared}/{shared_decoded} protocol_bytes={protocols} live_bytes={} rss_kib={}",
+                // Surface entries clone the shared images, so the shared total
+                // already covers their decoded bytes.
+                shared_decoded.saturating_add(protocols),
+                resident_kib().unwrap_or(0),
+            ),
+        );
+    }
+
+    /// Drops everything that failed to load so the next frame requests it
+    /// again, however many times it already failed. This is the manual way out
+    /// when a picture stays broken past its automatic retries.
+    pub(super) fn forget_failed_media(&mut self) {
+        self.image_previews.forget_failures();
+        self.avatar_images.forget_failures();
+        self.emoji_images.forget_failures();
     }
 
     pub(super) fn next_animation_deadline(&self) -> Option<Instant> {
@@ -847,6 +881,14 @@ async fn send_commands_until_closed(
         }
     }
     false
+}
+
+/// Resident set size in KiB, for the media cache report. Linux only; other
+/// platforms report zero rather than growing a dependency for a debug line.
+fn resident_kib() -> Option<u64> {
+    let statm = std::fs::read_to_string("/proc/self/statm").ok()?;
+    let pages: u64 = statm.split_whitespace().nth(1)?.parse().ok()?;
+    Some(pages.saturating_mul(4))
 }
 
 #[cfg(test)]

--- a/src/tui/runtime/mod.rs
+++ b/src/tui/runtime/mod.rs
@@ -159,6 +159,10 @@ pub(super) async fn run_dashboard(
     const BACKGROUND_REDRAW_DEBOUNCE: std::time::Duration = std::time::Duration::from_millis(80);
     const RELATIVE_TIMESTAMP_REFRESH_INTERVAL: std::time::Duration =
         std::time::Duration::from_secs(60);
+    // Slow memory growth only shows up over a long session, so the report goes
+    // out on a timer as well as on demand. Debug logging gates it.
+    const MEDIA_REPORT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
+    let mut last_media_report = std::time::Instant::now();
     let mut pending_redraw_deadline: Option<tokio::time::Instant> = None;
     let mut animation_frame_deadline: Option<tokio::time::Instant> = None;
     let mut relative_timestamp_deadline =
@@ -204,8 +208,15 @@ pub(super) async fn run_dashboard(
                 redraw_plan,
             )?;
             media_runtime.commit_placements();
+            if last_media_report.elapsed() >= MEDIA_REPORT_INTERVAL {
+                if logging::debug_logging_enabled() {
+                    media_runtime.log_memory_report();
+                }
+                last_media_report = std::time::Instant::now();
+            }
             if state.terminal_focused() {
-                media_runtime.sync_animation_visibility(std::time::Instant::now());
+                media_runtime
+                    .sync_animation_visibility(std::time::Instant::now(), state.animate_previews());
             } else {
                 media_runtime.pause_animations();
             }
@@ -261,7 +272,13 @@ pub(super) async fn run_dashboard(
                             &mut mouse_clicks,
                         )?;
                         if state.take_terminal_refresh_request() {
+                            // Redrawing alone cannot recover a picture whose
+                            // download failed, so the refresh key drops those
+                            // too and the next frame asks for them again.
+                            media_runtime.forget_failed_media();
+                            media_runtime.log_memory_report();
                             terminal.clear()?;
+                            dirty = true;
                         }
                         if state.take_open_composer_in_editor_request()
                             && let Err(error) = open_composer_in_editor(terminal, &mut state)

--- a/src/tui/runtime/placement.rs
+++ b/src/tui/runtime/placement.rs
@@ -122,6 +122,7 @@ mod tests {
     fn preview_target(message_id: u64, y_offset: usize) -> ImagePreviewTarget {
         ImagePreviewTarget {
             viewer: false,
+            selected: false,
             thread_card: false,
             message_index: 0,
             preview_index: 0,

--- a/src/tui/state/options.rs
+++ b/src/tui/state/options.rs
@@ -1,9 +1,9 @@
 use std::collections::BTreeMap;
 
 use crate::config::{
-    AppOptions, ComposerOptions, CredentialOptions, DisplayOptions, ImagePreviewQualityPreset,
-    KeymapOptions, NotificationOptions, PresenceOptions, ReactionOptions, UiStateOptions,
-    VoiceOptions, VoiceParticipantPlaybackOption,
+    AnimatePreviews, AppOptions, ComposerOptions, CredentialOptions, DisplayOptions,
+    ImagePreviewQualityPreset, KeymapOptions, NotificationOptions, PresenceOptions,
+    ReactionOptions, UiStateOptions, VoiceOptions, VoiceParticipantPlaybackOption,
 };
 use crate::discord::ids::{Id, marker::UserMarker};
 use crate::discord::{AppCommand, VoiceAudioSourceOptions, VoiceParticipantPlaybackSettings};
@@ -318,6 +318,10 @@ impl DashboardState {
 
     pub fn image_preview_quality(&self) -> ImagePreviewQualityPreset {
         self.options.display_options.image_preview_quality
+    }
+
+    pub fn animate_previews(&self) -> AnimatePreviews {
+        self.options.display_options.animate_previews
     }
 
     pub fn attachment_viewer_quality(&self) -> ImagePreviewQualityPreset {

--- a/src/tui/state/popups/options.rs
+++ b/src/tui/state/popups/options.rs
@@ -1,3 +1,4 @@
+use crate::config::AnimatePreviews;
 use crate::discord::AppCommand;
 use crate::discord::{MicrophoneSensitivityDb, VoiceAudioSourceOptions, VoiceVolumePercent};
 use crate::tui::keybindings::{OptionsCategoryShortcut, SelectionAction};
@@ -7,7 +8,7 @@ use super::{
     ActiveModalPopupKind, ModalPopup, OptionsCategory, OptionsPopupState, SelectablePopupTarget,
 };
 
-const DISPLAY_OPTION_COUNT: usize = 9;
+const DISPLAY_OPTION_COUNT: usize = 10;
 const COMPOSER_OPTION_COUNT: usize = 1;
 const NOTIFICATION_OPTION_COUNT: usize = 1;
 const VOICE_OPTION_COUNT: usize = VoiceOption::ALL.len();
@@ -285,6 +286,15 @@ impl DashboardState {
                 effective: options.hour_format_24,
                 description: "Use 24-hour time for message timestamps.",
             },
+            DisplayOptionItem {
+                label: "Animate previews",
+                enabled: options.animate_previews != AnimatePreviews::Never,
+                value: Some(options.animate_previews.label().to_owned()),
+                gauge: None,
+                effective: options.images_visible()
+                    && options.animate_previews != AnimatePreviews::Never,
+                description: "Animated GIF and WebP previews: always, selected message only, or never.",
+            },
         ]
     }
 
@@ -499,6 +509,10 @@ impl DashboardState {
             (OptionsCategory::Display, 8) => {
                 self.options.display_options.hour_format_24 =
                     !self.options.display_options.hour_format_24
+            }
+            (OptionsCategory::Display, 9) => {
+                self.options.display_options.animate_previews =
+                    self.options.display_options.animate_previews.next()
             }
             (OptionsCategory::Composer, 0) => {
                 self.options.composer_options.emojis_as_links =


### PR DESCRIPTION
## The problem

Over a session of scrolling image-heavy channels, resident memory grew past 600 MB and kept climbing, against roughly 90 MB for the same browsing before the animated-media work. CPU went to 50% with several animated previews on screen. Separately, a preview whose download failed stayed broken forever — it would reappear only when an unrelated popup forced a rebuild, and vanish again when the popup closed.

I instrumented this rather than guessed: a periodic report of live cache bytes against `/proc/self/statm`. It showed live cache data staying inside its budgets the whole time while RSS ratcheted, which pointed at accounting rather than at any single runaway cache. Four causes:

**Render protocols were counted by entry, not by size.** A kitty protocol payload is base64 of the full pixel buffer — 1.3 MB for one large preview, which I confirmed against a real capture. Sixteen frames per entry across the cache allowed a 653 MB ceiling that no budget was watching. Protocols now carry their estimated byte size and are evicted on a byte budget as well as a count, always keeping the frame just stored.

**`failed_attempts` outlived its entry.** When an entry was evicted the attempt record stayed, so the map grew for the life of the process. It is now dropped with the entry.

**The shared decoded-image cache allowed 256 MB.** That dominated everything the three surface caches were doing, since they share the same `Arc`ed frames. Cut to 64 MB and 24 images. The *per-image* rejection limits are deliberately unchanged — lowering those would make large photos fail to decode rather than render smaller.

**Every media fetch built its own `reqwest::Client`.** A screen of attachments opened a fresh TLS connection each. Now one pooled client, deliberately unauthenticated since some of these URLs proxy third-party content.

## Failed fetches now retry

A failure records an attempt count and a deadline and retries on a 3s/15s/60s backoff. The retry record survives the retry — an earlier version of this dropped it, which reset the counter and retried forever. `<leader>r` additionally forgets failures outright, so a manual refresh recovers a picture without a restart.

## animate_previews

Animating a preview rebuilds its terminal graphics protocol every frame, measured at 3.9 ms per build for a typical message-list preview — about 8% of a core each. The second commit adds `animate_previews` under `[display]`: `always` is the old behaviour, `never` holds every preview on its first frame, and `selected` (new default) animates only the attachment viewer and the selected message. Changing the default is the deliberate part of this PR and the easiest thing to drop if you would rather keep `always`.

## Testing

`cargo test` (1703 pass), `cargo clippy --all-targets` clean. New tests cover byte-based protocol eviction, the retry backoff terminating, and the animation policy. Both commits build and test independently. Measured on the reporting machine: peak RSS for the same browsing went from 600+ MB to roughly 120 MB.

---

Disclosure: this was vibe-coded — written by Claude (Claude Code) with me measuring each round on real usage. Review it as you would any unfamiliar contribution; the changed default in particular is a judgement call worth a second opinion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
