### PR TITLE
fix(voice): stop demanding a transition id in DAVE prepare epoch

### DIFF
--- a/src/discord/voice/dave.rs
+++ b/src/discord/voice/dave.rs
@@ -72,7 +72,10 @@ pub(super) struct VoiceDaveState {
 }
 
 struct PendingDaveSession {
-    transition_id: u16,
+    /// `None` until Discord announces the transition this session belongs to.
+    /// An epoch prepared through opcode 24 has no transition id yet; the commit
+    /// or welcome that follows carries it.
+    transition_id: Option<u16>,
     protocol_version: NonZeroU16,
     session: DaveSession,
     execute_requested: bool,
@@ -197,7 +200,7 @@ impl VoiceDaveState {
                 self.pending_transitions
                     .insert(transition_id, protocol_version);
                 if self.pending_session.as_ref().is_some_and(|pending| {
-                    pending.transition_id == transition_id
+                    pending.transition_id == Some(transition_id)
                         && pending.protocol_version.get() != protocol_version
                 }) {
                     self.pending_session = None;
@@ -219,7 +222,7 @@ impl VoiceDaveState {
                 } else if self
                     .pending_session
                     .as_ref()
-                    .is_none_or(|pending| pending.transition_id != transition_id)
+                    .is_none_or(|pending| pending.transition_id != Some(transition_id))
                 {
                     send_dave_transition_ready(writer, transition_id).await?;
                 }
@@ -235,20 +238,19 @@ impl VoiceDaveState {
                 let data = value
                     .get("d")
                     .ok_or_else(|| "DAVE prepare epoch missing data".to_owned())?;
-                let transition_id = json_u16(data, "transition_id")?;
+                // This opcode carries only `protocol_version` and `epoch`. It has no
+                // transition id: the commit or welcome that completes the epoch is
+                // what announces one.
                 let epoch = json_u64(data, "epoch")?;
                 if epoch == 1 {
                     let protocol_version = json_u16(data, "protocol_version")
                         .or_else(|_| json_u16(data, "dave_protocol_version"))?;
-                    let key_package = self.prepare_epoch(transition_id, protocol_version, epoch)?;
+                    let key_package = self.prepare_epoch(protocol_version, epoch)?;
                     self.send_key_package(writer, key_package).await?;
                 } else {
                     logging::debug(
                         "voice",
-                        format!(
-                            "DAVE prepare epoch received: transition_id={} epoch={}",
-                            transition_id, epoch
-                        ),
+                        format!("DAVE prepare epoch received: epoch={epoch}"),
                     );
                 }
             }
@@ -390,12 +392,7 @@ impl VoiceDaveState {
         Ok(())
     }
 
-    fn prepare_epoch(
-        &mut self,
-        transition_id: u16,
-        protocol_version: u16,
-        epoch: u64,
-    ) -> Result<Vec<u8>, String> {
+    fn prepare_epoch(&mut self, protocol_version: u16, epoch: u64) -> Result<Vec<u8>, String> {
         let protocol_version = NonZeroU16::new(protocol_version)
             .ok_or_else(|| "DAVE prepare epoch has protocol version 0".to_owned())?;
         let mut session = self.new_session(protocol_version)?;
@@ -405,19 +402,16 @@ impl VoiceDaveState {
 
         // The current session must keep encrypting media until Discord executes the
         // prepared transition. Reinitializing it here creates the broadcast blackout.
-        self.pending_transitions
-            .insert(transition_id, protocol_version.get());
         self.pending_session = Some(PendingDaveSession {
-            transition_id,
+            transition_id: None,
             protocol_version,
             session,
-            execute_requested: transition_id == 0,
+            execute_requested: false,
         });
         logging::debug(
             "voice",
             format!(
-                "DAVE prepare epoch received: transition_id={} epoch={} protocol_version={}",
-                transition_id, epoch, protocol_version
+                "DAVE prepare epoch received: epoch={epoch} protocol_version={protocol_version}"
             ),
         );
         Ok(key_package)
@@ -446,7 +440,7 @@ impl VoiceDaveState {
         if self
             .pending_session
             .as_ref()
-            .is_some_and(|pending| pending.transition_id == transition_id)
+            .is_some_and(|pending| pending.transition_id == Some(transition_id))
         {
             let pending = self
                 .pending_session
@@ -516,7 +510,7 @@ impl VoiceDaveState {
         let pending_protocol_version = self
             .pending_session
             .as_ref()
-            .filter(|pending| pending.transition_id == transition_id)
+            .filter(|pending| pending.transition_id == Some(transition_id))
             .map(|pending| pending.protocol_version.get());
 
         if transition_id != 0 {
@@ -531,7 +525,7 @@ impl VoiceDaveState {
         let should_execute = self
             .pending_session
             .as_ref()
-            .filter(|pending| pending.transition_id == transition_id)
+            .filter(|pending| pending.transition_id == Some(transition_id))
             .is_some_and(|pending| transition_id == 0 || pending.execute_requested);
         if should_execute {
             self.execute_transition(transition_id)?;
@@ -543,7 +537,7 @@ impl VoiceDaveState {
         let pending_protocol_version = self
             .pending_session
             .as_ref()
-            .filter(|pending| pending.transition_id == transition_id)
+            .filter(|pending| pending.transition_id == Some(transition_id))
             .map(|pending| pending.protocol_version);
         if let Some(protocol_version) = pending_protocol_version {
             let session = self.new_session(protocol_version)?;
@@ -598,10 +592,12 @@ impl VoiceDaveState {
             session,
             ..
         } = self;
-        if let Some(pending) = pending_session
-            .as_mut()
-            .filter(|pending| pending.transition_id == transition_id)
-        {
+        // A session prepared for a new epoch adopts the first transition announced
+        // for it, since opcode 24 does not name one.
+        if let Some(pending) = pending_session.as_mut().filter(|pending| {
+            pending.transition_id == Some(transition_id) || pending.transition_id.is_none()
+        }) {
+            pending.transition_id = Some(transition_id);
             return Ok(&mut pending.session);
         }
         session
@@ -935,7 +931,7 @@ mod tests {
             .expect("active DAVE session should exist");
 
         let key_package = state
-            .prepare_epoch(7, 1, 1)
+            .prepare_epoch(1, 1)
             .expect("DAVE epoch should prepare");
 
         assert!(!key_package.is_empty());
@@ -944,13 +940,24 @@ mod tests {
             state.session.as_ref().map(std::ptr::from_ref),
             Some(active_session)
         );
-        assert_eq!(state.pending_transitions.get(&7), Some(&1));
         let pending = state
             .pending_session
             .as_ref()
             .expect("new DAVE epoch should use a separate session");
-        assert_eq!(pending.transition_id, 7);
+        assert_eq!(pending.transition_id, None);
         assert!(!pending.session.is_ready());
+
+        // The commit that completes the epoch is what names the transition.
+        state
+            .transition_session_mut(7)
+            .expect("prepared session should take the announced transition");
+        assert_eq!(
+            state
+                .pending_session
+                .as_ref()
+                .map(|pending| pending.transition_id),
+            Some(Some(7))
+        );
 
         state
             .execute_transition(7)
@@ -973,7 +980,7 @@ mod tests {
         let mut state = test_state();
 
         state
-            .prepare_epoch(9, 1, 1)
+            .prepare_epoch(1, 1)
             .expect("DAVE upgrade should prepare");
 
         assert_eq!(state.protocol_version, None);


### PR DESCRIPTION
## The bug

Opcode 24 `dave_protocol_prepare_epoch` is parsed as if it carried a `transition_id`:

```rust
let transition_id = json_u16(data, "transition_id")?;
let epoch = json_u64(data, "epoch")?;
```

It does not. [`discord/dave-protocol`](https://github.com/discord/dave-protocol/blob/main/protocol.md) gives its payload as `protocol_version` and `epoch` only — the transition that completes the epoch is announced later, by the commit (op 29) or welcome (op 30) that follows, both of which carry the id in the first two bytes of their binary payload.

So every opcode 24 fails with `missing numeric field: transition_id`.

## Why it ends a screen share

On the voice gateway that loses an epoch change. On the **broadcast** gateway the error is fatal, and the teardown does not recover:

```
[DEBUG] voice: voice client disconnected: user_id=… known_users=1 known_ssrcs=3
[ERROR] stream: missing numeric field: transition_id
[DEBUG] stream: stopping previous stream broadcast task before reconnect
[DEBUG] stream: connecting broadcast websocket: wss://…
[DEBUG] stream: stopping native capture backend because the capture source ended
[DEBUG] stream: screen cast portal session closed
[DEBUG] stream: broadcast websocket connected: status=101 Switching Protocols
[DEBUG] stream: active stream capture request has no prepared capture: … request_id=5
[ERROR] stream: prepared stream capture is unavailable
[DEBUG] gateway: deleting stream: …
```

The reconnect drops the portal session, then cannot find a prepared capture, and the stream is deleted. Restarting the broadcast is the only way back.

The trigger is membership. Discord rebuilds the MLS group whenever its participant set changes, and the broadcast connection has its own group — the one whose id derives from the RTC server id — so a viewer opening or closing the stream moves that epoch just as a voice-channel join or leave does. Either way the next opcode 24 arrives and fails.

That makes the lifetime of a share look like a timer when it isn't: in the log above it had run 26 minutes, and ended two seconds after a participant change. It survives exactly as long as nobody moves.

## The fix

Drop `transition_id` from the opcode 24 parse. `PendingDaveSession.transition_id` becomes `Option<u16>`, `None` until announced, and `transition_session_mut` binds it to the first transition that arrives for that session — which is what the protocol says identifies it.

`execute_requested` starts `false` for an epoch-prepared session, since the `transition_id == 0` shortcut ("reinitialization, execute immediately") only has meaning once an id exists.

## Notes

Verified against a real broadcast: the drop above is from a 2.5.10 client log with `CONCORD_DEBUG=1`.

Not fixed here: the broadcast reconnect path itself is not survivable — it releases the capture and then fails to re-acquire it, so *any* fatal websocket error ends the stream rather than resuming it. That is worth its own change; this PR removes the error that was reaching it.

`cargo clippy --all-targets` is clean on the touched file and `cargo test` passes (1700 tests).

Disclosure: this was vibe-coded — written by Claude (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

