### PR TITLE
feat(reactions): Customizing top 10 emojis in config.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ These shortcuts act on the selected message when the Messages pane is focused.
 | Key | Action                     |
 | --- | -------------------------- |
 | `y` | Copy message text          |
-| `r` | Add or remove a reaction   |
+| `r` | Open the reaction picker   |
 | `R` | Reply                      |
 | `d` | Delete                     |
 | `e` | Edit                       |
@@ -367,6 +367,11 @@ hour_format_24 = true
 [composer]
 # Send custom emoji your account cannot use directly as image links.
 emojis_as_links = false
+
+[reactions]
+# Up to 10 unicode emoji pinned at the top of the reaction picker.
+# When unset or empty, Concord uses the built-in quick reactions.
+# favorite_emojis = ["🔥", "👍", "❤️", "😂", "🎉", "😮", "😢", "🙏", "👀", "💯"]
 
 [presence]
 # Relay Rich Presence from local apps as your activity.

--- a/docs/keymap-options.md
+++ b/docs/keymap-options.md
@@ -177,7 +177,7 @@ Message actions:
 | Action name             | Default config | Action                                           |
 | ----------------------- | -------------- | ------------------------------------------------ |
 | `CopyMessage`           | `"y"`          | Copy selected message content.                   |
-| `ReactMessage`          | `"r"`          | Add or remove a reaction.                        |
+| `ReactMessage`          | `"r"`          | Open the reaction picker.                        |
 | `ReplyMessage`          | `"R"`          | Start a reply.                                   |
 | `DeleteMessage`         | `"d"`          | Open delete confirmation.                        |
 | `EditMessage`           | `"e"`          | Start editing the selected message.              |
@@ -191,6 +191,9 @@ Message actions:
 | `OpenThread`            | none           | Open the selected message's thread.              |
 | `ShowReactionUsers`     | none           | Show users who reacted to the selected message.  |
 | `OpenPollVotePicker`    | none           | Choose poll votes for the selected message.      |
+
+Favorite emojis from `[reactions].favorite_emojis` in `config.toml` are pinned
+at the top of the reaction picker opened by `ReactMessage`.
 
 Pane, options, and voice actions:
 
@@ -359,7 +362,7 @@ OpenPollVotePicker = "c"
 | Scoped action           | Default | Action                                           |
 | ----------------------- | ------- | ------------------------------------------------ |
 | `CopyMessage`           | `y`     | Copy selected message content.                   |
-| `ReactMessage`          | `r`     | Add or remove a reaction.                        |
+| `ReactMessage`          | `r`     | Open the reaction picker.                        |
 | `ReplyMessage`          | `R`     | Start a reply.                                   |
 | `DeleteMessage`         | `d`     | Open delete confirmation.                        |
 | `EditMessage`           | `e`     | Start editing the selected message.              |

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -43,6 +43,17 @@ impl Default for ComposerOptions {
     }
 }
 
+#[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct ReactionOptions {
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub favorite_emojis: Vec<String>,
+}
+
+impl ReactionOptions {
+    pub const MAX_FAVORITE_EMOJIS: usize = 10;
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(default)]
 pub struct CredentialOptions {
@@ -225,6 +236,7 @@ impl Default for PresenceOptions {
 pub struct AppOptions {
     pub display: DisplayOptions,
     pub composer: ComposerOptions,
+    pub reactions: ReactionOptions,
     pub credentials: CredentialOptions,
     pub notifications: NotificationOptions,
     pub voice: VoiceOptions,

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -5,7 +5,7 @@ use crate::Result;
 
 use super::{
     AppOptions, BorderShape, BorderSurface, HighlightGroup, HighlightLinkOptions,
-    KeymapFileOptions, KeymapOptions, ThemeOptions, UiStateOptions,
+    KeymapFileOptions, KeymapOptions, ReactionOptions, ThemeOptions, UiStateOptions,
 };
 
 /// Parse `config.toml` tolerantly: a value with a wrong type or unknown variant
@@ -18,6 +18,10 @@ pub(super) fn parse_app_options(content: &str) -> Result<(AppOptions, Vec<String
     let options = AppOptions {
         display: section(&root, "display", &mut warnings),
         composer: section(&root, "composer", &mut warnings),
+        reactions: normalize_reaction_options(
+            section(&root, "reactions", &mut warnings),
+            &mut warnings,
+        ),
         credentials: section(&root, "credentials", &mut warnings),
         notifications: section(&root, "notifications", &mut warnings),
         voice: section(&root, "voice", &mut warnings),
@@ -25,6 +29,45 @@ pub(super) fn parse_app_options(content: &str) -> Result<(AppOptions, Vec<String
     };
 
     Ok((options, warnings))
+}
+
+fn normalize_reaction_options(
+    options: ReactionOptions,
+    warnings: &mut Vec<String>,
+) -> ReactionOptions {
+    let mut favorite_emojis = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    let mut truncated = false;
+
+    for (index, raw) in options.favorite_emojis.into_iter().enumerate() {
+        let Some(emoji) = emojis::get(&raw) else {
+            warnings.push(format!(
+                "[reactions] favorite_emojis[{index}] = \"{raw}\" is not a valid unicode emoji and was ignored"
+            ));
+            continue;
+        };
+        let value = emoji.as_str().to_owned();
+        if !seen.insert(value.clone()) {
+            warnings.push(format!(
+                "[reactions] favorite_emojis[{index}] = \"{raw}\" duplicates an earlier entry and was ignored"
+            ));
+            continue;
+        }
+        if favorite_emojis.len() >= ReactionOptions::MAX_FAVORITE_EMOJIS {
+            truncated = true;
+            continue;
+        }
+        favorite_emojis.push(value);
+    }
+
+    if truncated {
+        warnings.push(format!(
+            "[reactions] favorite_emojis truncated to {} entries",
+            ReactionOptions::MAX_FAVORITE_EMOJIS
+        ));
+    }
+
+    ReactionOptions { favorite_emojis }
 }
 
 fn one_entry(key: &str, value: toml::Value) -> toml::Table {

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -693,6 +693,7 @@ fn options_save_and_load_round_trip() {
             emojis_as_links: true,
             ping_on_reply: false,
         },
+        reactions: Default::default(),
         credentials: CredentialOptions {
             store: CredentialStoreMode::Plain,
         },
@@ -730,6 +731,7 @@ fn options_save_and_load_round_trip() {
 
     assert_eq!(loaded.display, options.display);
     assert_eq!(loaded.composer, options.composer);
+    assert_eq!(loaded.reactions, options.reactions);
     assert_eq!(loaded.notifications, options.notifications);
     assert_eq!(loaded.voice, options.voice);
     assert_eq!(loaded.presence, options.presence);
@@ -798,4 +800,53 @@ fn parse_keymap_options(toml: &str) -> KeymapOptions {
     toml::from_str::<KeymapFileOptions>(toml)
         .expect("keymap config should parse")
         .keymap
+}
+
+#[test]
+fn reaction_favorite_emojis_parse_and_normalize() {
+    let (options, warnings) = parse_app_options(
+        r#"[reactions]
+favorite_emojis = ["🔥", "not-an-emoji", "👍", "🔥", "❤️", "😂", "🎉", "😮", "😢", "🙏", "👀", "💯", "✨"]
+"#,
+    )
+    .expect("reactions config should parse");
+
+    assert_eq!(
+        options.reactions.favorite_emojis,
+        vec![
+            "🔥".to_owned(),
+            "👍".to_owned(),
+            "❤️".to_owned(),
+            "😂".to_owned(),
+            "🎉".to_owned(),
+            "😮".to_owned(),
+            "😢".to_owned(),
+            "🙏".to_owned(),
+            "👀".to_owned(),
+            "💯".to_owned(),
+        ]
+    );
+    assert!(
+        warnings
+            .iter()
+            .any(|warning| warning.contains("not a valid unicode emoji"))
+    );
+    assert!(
+        warnings
+            .iter()
+            .any(|warning| warning.contains("duplicates an earlier entry"))
+    );
+    assert!(
+        warnings
+            .iter()
+            .any(|warning| warning.contains("truncated to 10 entries"))
+    );
+}
+
+#[test]
+fn reaction_favorite_emojis_default_empty() {
+    let (options, warnings) =
+        parse_app_options("[display]\n").expect("empty reactions should use defaults");
+    assert!(options.reactions.favorite_emojis.is_empty());
+    assert!(warnings.is_empty());
 }

--- a/src/tui/input/tests/options.rs
+++ b/src/tui/input/tests/options.rs
@@ -48,6 +48,7 @@ fn options_popup_toggles_and_cycles_display_settings() {
             Some(AppOptions {
                 display: state.display_options(),
                 composer: state.composer_options(),
+                reactions: Default::default(),
                 credentials: Default::default(),
                 notifications: state.notification_options(),
                 voice: state.voice_options(),
@@ -110,6 +111,7 @@ fn options_popup_h_l_adjust_microphone_sensitivity_by_one_or_ten_db() {
         Some(AppOptions {
             display: state.display_options(),
             composer: state.composer_options(),
+            reactions: Default::default(),
             credentials: Default::default(),
             notifications: state.notification_options(),
             voice: state.voice_options(),
@@ -276,6 +278,7 @@ fn options_popup_sequences_own_continuations_then_restore_fixed_shortcuts() {
         Some(AppOptions {
             display: state.display_options(),
             composer: state.composer_options(),
+            reactions: Default::default(),
             credentials: Default::default(),
             notifications: state.notification_options(),
             voice: state.voice_options(),

--- a/src/tui/runtime/mod.rs
+++ b/src/tui/runtime/mod.rs
@@ -117,6 +117,7 @@ pub(super) async fn run_dashboard(
         ui_state_options,
     );
     state.apply_presence_options(options.presence);
+    state.apply_reaction_options(options.reactions);
     drop(snapshots.borrow_and_update());
     let initial_snapshot = client.current_discord_snapshot();
     let mut current_snapshot_revision = initial_snapshot.revision.global;

--- a/src/tui/state/emoji.rs
+++ b/src/tui/state/emoji.rs
@@ -4,17 +4,33 @@ use std::collections::HashSet;
 
 use super::EmojiReactionItem;
 
-const QUICK_UNICODE_EMOJIS: &[&str] = &["👍", "❤️", "😂", "🎉", "😮", "😢", "🙏", "👀"];
+pub(super) const DEFAULT_QUICK_UNICODE_EMOJIS: &[&str] =
+    &["👍", "❤️", "😂", "🎉", "😮", "😢", "🙏", "👀"];
 
-pub(super) fn quick_unicode_emoji_reaction_items() -> Vec<EmojiReactionItem> {
-    QUICK_UNICODE_EMOJIS
+pub(super) fn effective_quick_unicode_emojis(favorites: &[String]) -> Vec<String> {
+    if favorites.is_empty() {
+        DEFAULT_QUICK_UNICODE_EMOJIS
+            .iter()
+            .map(|emoji| (*emoji).to_owned())
+            .collect()
+    } else {
+        favorites.to_vec()
+    }
+}
+
+pub(super) fn quick_unicode_emoji_reaction_items(favorites: &[String]) -> Vec<EmojiReactionItem> {
+    effective_quick_unicode_emojis(favorites)
         .iter()
-        .map(|emoji| unicode_emoji_reaction_item(emoji))
+        .filter_map(|emoji| emojis::get(emoji).map(unicode_emoji_reaction_item_from_emoji))
         .collect()
 }
 
-pub(super) fn remaining_unicode_emoji_reaction_items() -> Vec<EmojiReactionItem> {
-    let quick_emojis: HashSet<&'static str> = QUICK_UNICODE_EMOJIS.iter().copied().collect();
+pub(super) fn remaining_unicode_emoji_reaction_items(
+    favorites: &[String],
+) -> Vec<EmojiReactionItem> {
+    let quick_emojis: HashSet<String> = effective_quick_unicode_emojis(favorites)
+        .into_iter()
+        .collect();
 
     emojis::iter()
         .filter(|emoji| !quick_emojis.contains(emoji.as_str()))
@@ -22,13 +38,10 @@ pub(super) fn remaining_unicode_emoji_reaction_items() -> Vec<EmojiReactionItem>
         .collect()
 }
 
-pub(super) fn is_quick_unicode_emoji(value: &str) -> bool {
-    QUICK_UNICODE_EMOJIS.contains(&value)
-}
-
-fn unicode_emoji_reaction_item(value: &str) -> EmojiReactionItem {
-    let emoji = emojis::get(value).expect("quick emoji must exist");
-    unicode_emoji_reaction_item_from_emoji(emoji)
+pub(super) fn is_quick_unicode_emoji(value: &str, favorites: &[String]) -> bool {
+    effective_quick_unicode_emojis(favorites)
+        .iter()
+        .any(|emoji| emoji == value)
 }
 
 fn unicode_emoji_reaction_item_from_emoji(emoji: &emojis::Emoji) -> EmojiReactionItem {

--- a/src/tui/state/options.rs
+++ b/src/tui/state/options.rs
@@ -2,8 +2,8 @@ use std::collections::BTreeMap;
 
 use crate::config::{
     AppOptions, ComposerOptions, CredentialOptions, DisplayOptions, ImagePreviewQualityPreset,
-    KeymapOptions, NotificationOptions, PresenceOptions, UiStateOptions, VoiceOptions,
-    VoiceParticipantPlaybackOption,
+    KeymapOptions, NotificationOptions, PresenceOptions, ReactionOptions, UiStateOptions,
+    VoiceOptions, VoiceParticipantPlaybackOption,
 };
 use crate::discord::ids::{Id, marker::UserMarker};
 use crate::discord::{AppCommand, VoiceAudioSourceOptions, VoiceParticipantPlaybackSettings};
@@ -69,6 +69,8 @@ pub(super) struct SettingsState {
     // Not editable in the TUI: kept only so saving unrelated options round-trips
     // the user's Rich Presence choice instead of resetting it to the default.
     pub(super) presence_options: PresenceOptions,
+    // Not editable in the TUI: favorite reaction emojis live in config.toml.
+    pub(super) reaction_options: ReactionOptions,
     pub(super) key_bindings: KeyBindings,
     pub(super) voice_participant_playback:
         BTreeMap<Id<UserMarker>, VoiceParticipantPlaybackSettings>,
@@ -105,6 +107,10 @@ impl DashboardState {
 
     pub(in crate::tui) fn apply_presence_options(&mut self, presence_options: PresenceOptions) {
         self.options.presence_options = presence_options;
+    }
+
+    pub(in crate::tui) fn apply_reaction_options(&mut self, reaction_options: ReactionOptions) {
+        self.options.reaction_options = reaction_options;
     }
 
     #[cfg(test)]
@@ -354,6 +360,7 @@ impl DashboardState {
         Some(AppOptions {
             display: self.options.display_options,
             composer: self.options.composer_options,
+            reactions: self.options.reaction_options.clone(),
             credentials: self.options.credential_options,
             notifications: self.options.notification_options.clone(),
             voice: self.options.voice_options.clone(),

--- a/src/tui/state/popups/reactions.rs
+++ b/src/tui/state/popups/reactions.rs
@@ -32,7 +32,8 @@ impl DashboardState {
         &self,
         guild_id: Option<Id<GuildMarker>>,
     ) -> Vec<EmojiReactionItem> {
-        let mut items = quick_unicode_emoji_reaction_items();
+        let favorites = &self.options.reaction_options.favorite_emojis;
+        let mut items = quick_unicode_emoji_reaction_items(favorites);
 
         if let Some(guild_id) = guild_id {
             items.extend(
@@ -82,7 +83,7 @@ impl DashboardState {
             );
         }
 
-        items.extend(remaining_unicode_emoji_reaction_items());
+        items.extend(remaining_unicode_emoji_reaction_items(favorites));
 
         items
     }
@@ -97,7 +98,11 @@ impl DashboardState {
             return items;
         };
 
-        filter_emoji_reaction_items(items, filter)
+        filter_emoji_reaction_items(
+            items,
+            filter,
+            &self.options.reaction_options.favorite_emojis,
+        )
     }
 
     pub fn filtered_emoji_reaction_items_slice(&self) -> Option<&[EmojiReactionItem]> {
@@ -320,21 +325,25 @@ impl DashboardState {
     }
 
     pub fn push_emoji_reaction_filter_char(&mut self, value: char) {
+        let favorites = self.options.reaction_options.favorite_emojis.clone();
         if let Some(picker) = self.popups.emoji_reaction_picker_mut()
             && let Some(filter) = &mut picker.filter
         {
             filter.push(value);
-            picker.filtered_items = filter_emoji_reaction_items_from_slice(&picker.items, filter);
+            picker.filtered_items =
+                filter_emoji_reaction_items_from_slice(&picker.items, filter, &favorites);
             picker.selection.select(0);
         }
     }
 
     pub fn pop_emoji_reaction_filter_char(&mut self) {
+        let favorites = self.options.reaction_options.favorite_emojis.clone();
         if let Some(picker) = self.popups.emoji_reaction_picker_mut()
             && let Some(filter) = &mut picker.filter
         {
             filter.pop();
-            picker.filtered_items = filter_emoji_reaction_items_from_slice(&picker.items, filter);
+            picker.filtered_items =
+                filter_emoji_reaction_items_from_slice(&picker.items, filter, &favorites);
             picker.selection.select(0);
         }
     }
@@ -404,8 +413,9 @@ impl DashboardState {
 fn filter_emoji_reaction_items(
     items: Vec<EmojiReactionItem>,
     filter: &str,
+    favorites: &[String],
 ) -> Vec<EmojiReactionItem> {
-    filter_emoji_reaction_items_from_slice(&items, filter)
+    filter_emoji_reaction_items_from_slice(&items, filter, favorites)
 }
 
 fn prioritize_existing_reactions(
@@ -438,6 +448,7 @@ fn prioritize_existing_reactions(
 fn filter_emoji_reaction_items_from_slice(
     items: &[EmojiReactionItem],
     filter: &str,
+    favorites: &[String],
 ) -> Vec<EmojiReactionItem> {
     let filter = filter.trim();
     if filter.is_empty() {
@@ -450,7 +461,7 @@ fn filter_emoji_reaction_items_from_slice(
         .filter_map(|(index, item)| {
             emoji_reaction_filter_score(item, filter).map(|score| {
                 (
-                    usize::from(emoji_reaction_is_remaining_unicode(item)),
+                    usize::from(emoji_reaction_is_remaining_unicode(item, favorites)),
                     score,
                     index,
                     item.clone(),
@@ -465,8 +476,11 @@ fn filter_emoji_reaction_items_from_slice(
     scored.into_iter().map(|(_, _, _, item)| item).collect()
 }
 
-fn emoji_reaction_is_remaining_unicode(item: &EmojiReactionItem) -> bool {
-    matches!(&item.emoji, crate::discord::ReactionEmoji::Unicode(emoji) if !is_quick_unicode_emoji(emoji))
+fn emoji_reaction_is_remaining_unicode(item: &EmojiReactionItem, favorites: &[String]) -> bool {
+    matches!(
+        &item.emoji,
+        crate::discord::ReactionEmoji::Unicode(emoji) if !is_quick_unicode_emoji(emoji, favorites)
+    )
 }
 
 fn emoji_reaction_filter_score(item: &EmojiReactionItem, filter: &str) -> Option<FuzzyScore> {

--- a/src/tui/state/tests/emoji_reactions.rs
+++ b/src/tui/state/tests/emoji_reactions.rs
@@ -606,3 +606,24 @@ fn reaction_users_popup_opens_highlighted_reaction() {
     );
     assert!(state.is_active_modal_popup(crate::tui::state::ActiveModalPopupKind::ReactionUsers));
 }
+
+#[test]
+fn emoji_picker_uses_configured_favorite_emojis_at_top() {
+    let mut state = state_with_messages(1);
+    state.focus_pane(FocusPane::Messages);
+    state.apply_reaction_options(crate::config::ReactionOptions {
+        favorite_emojis: vec!["🔥".to_owned(), "💯".to_owned()],
+    });
+
+    let items = state.emoji_reaction_items();
+    assert_eq!(
+        items[..2]
+            .iter()
+            .map(|item| item.emoji.clone())
+            .collect::<Vec<_>>(),
+        vec![
+            ReactionEmoji::Unicode("🔥".to_owned()),
+            ReactionEmoji::Unicode("💯".to_owned()),
+        ]
+    );
+}


### PR DESCRIPTION
## Summary

Adds `[reactions] favorite_emojis` (up to 10 unicode emoji) pinned at the top of the reaction picker.

## Why

Ability to choose what emojis you want to use quickly.

## How

- Empty or unset `favorite_emojis` keeps the existing built-in quick set (`👍 ❤️ 😂 🎉 😮 😢 🙏 👀`).
- Config parse is tolerant: invalid unicode, duplicates, and entries past 10 are dropped with warnings.
- Documented in `README.md` and `docs/keymap-options.md`.

## Testing

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] Manual test in a real terminal (describe below)

MacOS 27 beta. Ghostty.

Tested the config.toml changes, rebinds, tested reaction picker.

## Checklist

- [x] One logical change per PR.
- [ ] Link a related issue.
- [x] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [x] Change does not add self-bot automation, mass actions, or scraping.
- [x] Updated `README.md`, if behavior or workflows changed.