### PR TITLE
fix(voice): satisfy Rust 1.91 clippy

### DIFF
--- a/src/discord/voice/dave.rs
+++ b/src/discord/voice/dave.rs
@@ -216,10 +216,10 @@ impl VoiceDaveState {
                 }
                 if transition_id == 0 {
                     self.execute_transition(transition_id)?;
-                } else if !self
+                } else if self
                     .pending_session
                     .as_ref()
-                    .is_some_and(|pending| pending.transition_id == transition_id)
+                    .is_none_or(|pending| pending.transition_id != transition_id)
                 {
                     send_dave_transition_ready(writer, transition_id).await?;
                 }


### PR DESCRIPTION
## Summary
- simplify the pending DAVE transition predicate using `Option::is_none_or`
- preserve the existing transition-ready behavior
- restore CI compatibility with Rust stable 1.91

## Why
Rust 1.91 now reports the existing negated `is_some_and` expression as `clippy::nonminimal_bool`. Because CI denies warnings, the unchanged baseline currently fails Clippy on Linux, macOS, and Windows, including PR #333.

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features discord::voice` — 244 passed, 1 ignored
- `git diff --check`

Unblocks #333.