### PR TITLE
fix(tui): expand tabs in fenced code blocks

### DIFF
--- a/src/tui/message/format/markdown.rs
+++ b/src/tui/message/format/markdown.rs
@@ -2,7 +2,7 @@
 //! fenced code boxes with syntax highlight, and inline marker styling.
 
 use ratatui::style::{Modifier, Style};
-use unicode_width::UnicodeWidthStr;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::tui::state::DashboardState;
 use crate::tui::text::{InlineEmojiSlot, RenderedText, TextHighlight, truncate_display_width};
@@ -18,6 +18,7 @@ use super::{
 const MARKDOWN_QUOTE_PREFIX: &str = "▎ ";
 const MARKDOWN_BULLET_PREFIX: &str = "• ";
 const MARKDOWN_BULLET_CONTINUATION_PREFIX: &str = "  ";
+const CODE_TAB_WIDTH: usize = 4;
 
 struct InlineMarkdownText {
     rendered: RenderedText,
@@ -187,16 +188,19 @@ fn wrap_code_block_lines_and_highlight(
     label: Option<String>,
 ) -> Vec<MessageContentLine> {
     let style = markdown_code_style();
+    let text_lines = code_lines
+        .into_iter()
+        .map(|rt| expand_tabs(&rt.text, CODE_TAB_WIDTH))
+        .collect::<Vec<_>>();
     let highlighted_lines = {
         if let Some(language) = label.as_ref().filter(|l| !l.is_empty()) {
-            let text_lines = code_lines.into_iter().map(|rt| rt.text).collect::<Vec<_>>();
             state
                 .syntax_highlight_cache
                 .highlight(&text_lines, language)
         } else {
-            code_lines
+            text_lines
                 .into_iter()
-                .map(|rt| vec![(style, rt.text)])
+                .map(|text| vec![(style, text)])
                 .collect()
         }
     };
@@ -363,6 +367,23 @@ fn markdown_code_fence_closing_content_end(value: &str) -> Option<usize> {
 
 fn markdown_code_style() -> Style {
     Style::default()
+}
+
+fn expand_tabs(line: &str, tab_width: usize) -> String {
+    let tab_width = tab_width.max(1);
+    let mut out = String::with_capacity(line.len());
+    let mut col = 0usize;
+    for ch in line.chars() {
+        if ch == '\t' {
+            let spaces = tab_width - (col % tab_width);
+            out.extend(std::iter::repeat_n(' ', spaces));
+            col += spaces;
+        } else {
+            out.push(ch);
+            col = col.saturating_add(ch.width().unwrap_or(0));
+        }
+    }
+    out
 }
 
 fn inline_code_style() -> Style {

--- a/src/tui/ui/tests/messages.rs
+++ b/src/tui/ui/tests/messages.rs
@@ -810,6 +810,42 @@ fn message_content_applies_supported_markdown_formatting() {
 }
 
 #[test]
+fn fenced_code_block_preserves_space_indentation() {
+    let message = message_with_content(Some("```\nfunc f() {\n    return\n}\n```".to_owned()));
+    let lines = format_message_content_lines(&message, &DashboardState::new(), 80);
+    assert_eq!(
+        line_texts(&lines),
+        vec![
+            "╭────────────╮",
+            "│ func f() { │",
+            "│     return │",
+            "│ }          │",
+            "╰────────────╯",
+        ]
+    );
+}
+
+#[test]
+fn fenced_code_block_expands_tabs_like_discord() {
+    let message = message_with_content(Some(
+        "```\nfunc f() {\n\tif ok {\n\t\treturn\n\t}\n}\n```".to_owned(),
+    ));
+    let lines = format_message_content_lines(&message, &DashboardState::new(), 80);
+    assert_eq!(
+        line_texts(&lines),
+        vec![
+            "╭────────────────╮",
+            "│ func f() {     │",
+            "│     if ok {    │",
+            "│         return │",
+            "│     }          │",
+            "│ }              │",
+            "╰────────────────╯",
+        ]
+    );
+}
+
+#[test]
 fn wrapped_markdown_bullets_use_indented_continuation_lines() {
     let message = message_with_content(Some("- alpha beta\n* gamma delta".to_owned()));
 


### PR DESCRIPTION
<!--
Thanks for the contribution. Please keep the subject under ~72 characters
and use a semantic prefix (feat:, fix:, refactor:, docs:, chore:, test:).

By submitting this PR you agree it will be distributed under GPL-3.0-only.
-->

## Summary

Expand tab indents in fenced code blocks to 4-space stops so Go-style (and other tab-indented) code matches Discord web instead of rendering flush-left.

## Why

No existing issue or PR covers this. Closest related work is #295 (wrapped list bullets) and `fix: Fix fenced code block rendering for pasted multi-block messages`, which are different bugs.

Discord web expands `\t` in code fences. Concord kept the tab character. `unicode-width` reports U+0009 as width 0, so ratatui does not advance the column and the code box looks unindented even though the fence parsed correctly.

## How

Before syntax highlight and wrap, expand tabs in each code-fence line to column-aligned spaces (`CODE_TAB_WIDTH = 4`, same as Discord). Space-indented fences are unchanged.

## Testing

- [x] `cargo fmt --all --check`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [ ] Manual test in a real terminal (describe below)

Locally (rustc/clippy 1.90.0): `cargo fmt --all --check` passed; `cargo test --all-features` — 1727 passed, 1 ignored. New tests cover space indent (already correct) and tab indent (the bug).

Clippy `-D warnings` currently fails on `main` in `src/discord/voice/dave.rs` (`nonminimal_bool`) and `src/tui/fuzzy.rs` (`needless_range_loop`). Those files are outside this change. #334 is already open for the DAVE lint on Rust 1.91.

## Screenshots or recordings

Before: tab-indented Go in a fence is a code box with no visible indent.
After: same fence uses 4-space stops, matching Discord web.

## Checklist

- [x] One logical change per PR.
- [ ] Link a related issue.
- [x] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [x] Change does not add self-bot automation, mass actions, or scraping.
- [ ] Updated `README.md`, if behavior or workflows changed.