### PR TITLE
perf(tui): coalesce rapid input redraws

### DIFF
--- a/src/tui/runtime/mod.rs
+++ b/src/tui/runtime/mod.rs
@@ -38,7 +38,10 @@ use media_runtime::{
     DashboardMediaRuntime, LocalUploadPreviewResult, drain_pending_commands_after_draw,
     schedule_media_loads_after_draw, store_local_upload_preview_result,
 };
-use redraw::{DashboardRedrawState, draw_dashboard_transaction};
+use redraw::{
+    DashboardRedrawState, INPUT_REDRAW_INTERVAL, draw_dashboard_transaction, redraw_is_due,
+    schedule_redraw,
+};
 use scheduler::DashboardCommandScheduler;
 
 type ClipboardPasteResult = std::result::Result<
@@ -177,7 +180,8 @@ pub(super) async fn run_dashboard(
     // events only schedule a redraw when this moves (see `redraw_gate`).
     let mut last_view_signature = redraw_gate::view_signature(&state);
     while !state.should_quit() {
-        if dirty {
+        if dirty && redraw_is_due(pending_redraw_deadline, tokio::time::Instant::now()) {
+            pending_redraw_deadline = None;
             let size = terminal.size()?;
             let area = Rect::new(0, 0, size.width, size.height);
             // Resolve where every overlay image lands this frame and diff it
@@ -353,6 +357,11 @@ pub(super) async fn run_dashboard(
                         if outcome.dirty {
                             dirty = true;
                         }
+                        schedule_redraw(
+                            &mut pending_redraw_deadline,
+                            tokio::time::Instant::now(),
+                            INPUT_REDRAW_INTERVAL,
+                        );
                     }
                     Some(Err(error)) => return Err(error.into()),
                     None => {
@@ -643,9 +652,11 @@ fn schedule_background_redraw(
     pending_redraw_deadline: &mut Option<tokio::time::Instant>,
     debounce: std::time::Duration,
 ) {
-    if pending_redraw_deadline.is_none() {
-        *pending_redraw_deadline = Some(tokio::time::Instant::now() + debounce);
-    }
+    schedule_redraw(
+        pending_redraw_deadline,
+        tokio::time::Instant::now(),
+        debounce,
+    );
 }
 
 fn apply_clipboard_paste_result(state: &mut DashboardState, result: ClipboardPasteResult) {

--- a/src/tui/runtime/redraw.rs
+++ b/src/tui/runtime/redraw.rs
@@ -10,12 +10,26 @@ use crossterm::{
     terminal::{BeginSynchronizedUpdate, EndSynchronizedUpdate},
 };
 use ratatui::{DefaultTerminal, layout::Rect};
+use tokio::time::{Duration, Instant};
 
 use crate::tui::state::DashboardState;
 
 use super::media_runtime::{
     DashboardMediaRuntime, clear_image_surfaces_frame, draw_dashboard_frame,
 };
+
+pub(super) const INPUT_REDRAW_INTERVAL: Duration = Duration::from_millis(12);
+
+pub(super) fn schedule_redraw(deadline: &mut Option<Instant>, now: Instant, delay: Duration) {
+    let candidate = now + delay;
+    if deadline.is_none_or(|current| candidate < current) {
+        *deadline = Some(candidate);
+    }
+}
+
+pub(super) fn redraw_is_due(deadline: Option<Instant>, now: Instant) -> bool {
+    deadline.is_none_or(|deadline| deadline <= now)
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) struct RedrawPlan {
@@ -77,7 +91,40 @@ pub(super) fn draw_dashboard_transaction(
 
 #[cfg(test)]
 mod tests {
-    use super::{DashboardRedrawState, RedrawPlan};
+    use std::time::Duration;
+
+    use tokio::time::Instant;
+
+    use super::{DashboardRedrawState, RedrawPlan, redraw_is_due, schedule_redraw};
+
+    #[test]
+    fn input_redraw_shortens_background_deadline_without_replacing_it_later() {
+        let now = Instant::now();
+        let mut deadline = None;
+        schedule_redraw(&mut deadline, now, Duration::from_millis(80));
+        let background_deadline = deadline;
+
+        schedule_redraw(&mut deadline, now, Duration::from_millis(12));
+        assert!(deadline < background_deadline);
+
+        schedule_redraw(&mut deadline, now, Duration::from_millis(80));
+        assert_eq!(deadline, Some(now + Duration::from_millis(12)));
+    }
+
+    #[test]
+    fn redraw_deadline_coalesces_events_until_the_due_frame() {
+        let now = Instant::now();
+        let mut deadline = None;
+        schedule_redraw(&mut deadline, now, Duration::from_millis(12));
+        schedule_redraw(
+            &mut deadline,
+            now + Duration::from_millis(4),
+            Duration::from_millis(12),
+        );
+
+        assert!(!redraw_is_due(deadline, now + Duration::from_millis(11)));
+        assert!(redraw_is_due(deadline, now + Duration::from_millis(12)));
+    }
 
     #[test]
     fn redraw_plan_synchronizes_media_animation_and_placement_cleanup() {


### PR DESCRIPTION
## Summary

Coalesce rapid input redraw requests behind a 12 ms deadline while preserving synchronized media-animation and stale-placement cleanup transactions.

## Why

Related to #332 as an independent performance follow-up. This branch is based directly on current `main`, does not depend on the guild-icon feature chain, and changes no guild-icon files.

## How

Keep the earliest pending redraw deadline, shorten a background deadline when input arrives, and consume media-animation requests in the redraw plan. The change is limited to the redraw scheduler and runtime integration.

## Testing

- [x] `cargo fmt --all --check`
- [x] `git diff --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` (1,743 library tests passed, 1 binary test passed, 1 ignored)
- [ ] Manual test in a real terminal (responsiveness check remains for maintainer/CI environment)

## Chain context

```text
Guild icon chain: #333 -> compact -> media -> render
Independent: 📍 redraw coalescing -> main
```

Start: current `main`. End: rapid input no longer replaces the existing redraw deadline, while media cleanup remains synchronized. Follow-up: none required for #332. Out of scope: guild icon state, media, and rendering.

## Screenshots or recordings

Not required; this is a timing/behavior optimization.

## Checklist

- [x] One logical change per PR.
- [x] Link a related issue.
- [x] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [x] Change does not add self-bot automation, mass actions, or scraping.
- [ ] Updated `README.md`, if behavior or workflows changed (not required for this internal timing optimization).