### PR TITLE
fix(notifications): use OSC protocols for macOS terminal alerts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3390,14 +3390,16 @@ dependencies = [
 
 [[package]]
 name = "mac-notification-sys"
-version = "0.6.12"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29a16783dd1a47849b8c8133c9cd3eb2112cfbc6901670af3dba47c8bbfb07d3"
+checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
 dependencies = [
  "cc",
+ "log",
  "objc2",
  "objc2-foundation",
  "time",
+ "uuid",
 ]
 
 [[package]]

--- a/src/support.rs
+++ b/src/support.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "voice-playback")]
 pub(crate) mod audio_output;
+#[cfg(any(target_os = "macos", test))]
+pub(crate) mod macos_notification;
 pub(crate) mod media_player;
 pub mod paths;
 pub(crate) mod private_file;

--- a/src/support/macos_notification.rs
+++ b/src/support/macos_notification.rs
@@ -1,0 +1,291 @@
+#[cfg(target_os = "macos")]
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+
+const MAX_NOTIFICATION_TEXT_BYTES: usize = 2_048;
+#[cfg(target_os = "macos")]
+static NEXT_NOTIFICATION_ID: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum NotificationProtocol {
+    Osc9,
+    Osc777,
+    Osc99,
+}
+
+#[derive(Debug, Default)]
+struct TerminalEnvironment<'a> {
+    term_program: Option<&'a str>,
+    kitty_window_id: bool,
+    wezterm_pane: bool,
+    iterm_session_id: bool,
+    tmux: bool,
+    screen: bool,
+    zellij: bool,
+}
+
+/// Builds a desktop notification request for the terminal that owns the TUI.
+///
+/// Unsupported terminals return `None` so the caller can use the native macOS
+/// fallback. Multiplexers that cannot reliably forward notifications also use
+/// the fallback rather than silently swallowing the request.
+#[cfg(target_os = "macos")]
+pub(crate) fn sequence_for_current_terminal(title: &str, body: &str) -> Option<Vec<u8>> {
+    let term_program = std::env::var("TERM_PROGRAM").ok();
+    let environment = TerminalEnvironment {
+        term_program: term_program.as_deref(),
+        kitty_window_id: std::env::var_os("KITTY_WINDOW_ID").is_some(),
+        wezterm_pane: std::env::var_os("WEZTERM_PANE").is_some(),
+        iterm_session_id: std::env::var_os("ITERM_SESSION_ID").is_some(),
+        tmux: std::env::var_os("TMUX").is_some(),
+        screen: std::env::var_os("STY").is_some(),
+        zellij: std::env::var_os("ZELLIJ").is_some()
+            || std::env::var_os("ZELLIJ_SESSION_NAME").is_some(),
+    };
+    let protocol = select_protocol(&environment)?;
+    let notification_id = format!(
+        "concord-{}-{}",
+        std::process::id(),
+        NEXT_NOTIFICATION_ID.fetch_add(1, Ordering::Relaxed)
+    );
+    Some(build_sequence(protocol, title, body, &notification_id))
+}
+
+fn select_protocol(environment: &TerminalEnvironment<'_>) -> Option<NotificationProtocol> {
+    if environment.tmux || environment.screen || environment.zellij {
+        return None;
+    }
+    if environment.kitty_window_id {
+        return Some(NotificationProtocol::Osc99);
+    }
+    if environment.wezterm_pane {
+        return Some(NotificationProtocol::Osc777);
+    }
+    if environment.iterm_session_id {
+        return Some(NotificationProtocol::Osc9);
+    }
+
+    match environment
+        .term_program
+        .map(str::trim)
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("ghostty" | "wezterm" | "warp" | "warpterminal") => Some(NotificationProtocol::Osc777),
+        Some("iterm.app" | "iterm2") => Some(NotificationProtocol::Osc9),
+        Some("kitty") => Some(NotificationProtocol::Osc99),
+        _ => None,
+    }
+}
+
+fn build_sequence(
+    protocol: NotificationProtocol,
+    title: &str,
+    body: &str,
+    notification_id: &str,
+) -> Vec<u8> {
+    match protocol {
+        NotificationProtocol::Osc9 => build_osc9_sequence(title, body),
+        NotificationProtocol::Osc777 => build_osc777_sequence(title, body),
+        NotificationProtocol::Osc99 => build_osc99_sequence(title, body, notification_id),
+    }
+}
+
+fn build_osc9_sequence(title: &str, body: &str) -> Vec<u8> {
+    let message = match (title.trim().is_empty(), body.trim().is_empty()) {
+        (false, false) => format!("{title}: {body}"),
+        (false, true) => title.to_owned(),
+        (true, false) => body.to_owned(),
+        (true, true) => "Concord".to_owned(),
+    };
+    format!("\x1b]9;{}\x1b\\", sanitize_text(&message)).into_bytes()
+}
+
+fn build_osc777_sequence(title: &str, body: &str) -> Vec<u8> {
+    let title = sanitize_osc777_field(title);
+    let title = if title.is_empty() {
+        "Concord".to_owned()
+    } else {
+        title
+    };
+    let body = sanitize_osc777_field(body);
+    format!("\x1b]777;notify;{title};{body}\x1b\\").into_bytes()
+}
+
+fn build_osc99_sequence(title: &str, body: &str, notification_id: &str) -> Vec<u8> {
+    let title = sanitize_text(title);
+    let title = if title.is_empty() {
+        "Concord".to_owned()
+    } else {
+        title
+    };
+    let body = sanitize_text(body);
+    let encoded_title = STANDARD.encode(title);
+    let encoded_body = STANDARD.encode(body);
+
+    format!(
+        concat!(
+            "\x1b]99;i={notification_id}:d=0:p=title:e=1;{encoded_title}\x1b\\",
+            "\x1b]99;i={notification_id}:d=1:p=body:e=1;{encoded_body}\x1b\\",
+        ),
+        notification_id = notification_id,
+        encoded_title = encoded_title,
+        encoded_body = encoded_body
+    )
+    .into_bytes()
+}
+
+fn sanitize_osc777_field(value: &str) -> String {
+    sanitize_text(value).replace(';', ",")
+}
+
+fn sanitize_text(value: &str) -> String {
+    let mut sanitized = String::with_capacity(value.len().min(MAX_NOTIFICATION_TEXT_BYTES));
+    let mut pending_space = false;
+
+    for character in value.chars() {
+        if character.is_control() || character.is_whitespace() {
+            pending_space = !sanitized.is_empty();
+            continue;
+        }
+
+        let added_bytes = character.len_utf8() + usize::from(pending_space);
+        if sanitized.len() + added_bytes > MAX_NOTIFICATION_TEXT_BYTES {
+            break;
+        }
+        if pending_space {
+            sanitized.push(' ');
+            pending_space = false;
+        }
+        sanitized.push(character);
+    }
+
+    sanitized
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{NotificationProtocol, TerminalEnvironment, build_sequence, select_protocol};
+
+    #[test]
+    fn terminal_environment_selects_supported_protocols_and_native_fallbacks() {
+        for (environment, expected) in [
+            (
+                TerminalEnvironment {
+                    term_program: Some("ghostty"),
+                    ..TerminalEnvironment::default()
+                },
+                Some(NotificationProtocol::Osc777),
+            ),
+            (
+                TerminalEnvironment {
+                    term_program: Some("WezTerm"),
+                    ..TerminalEnvironment::default()
+                },
+                Some(NotificationProtocol::Osc777),
+            ),
+            (
+                TerminalEnvironment {
+                    term_program: Some("iTerm.app"),
+                    ..TerminalEnvironment::default()
+                },
+                Some(NotificationProtocol::Osc9),
+            ),
+            (
+                TerminalEnvironment {
+                    term_program: Some("WarpTerminal"),
+                    ..TerminalEnvironment::default()
+                },
+                Some(NotificationProtocol::Osc777),
+            ),
+            (
+                TerminalEnvironment {
+                    kitty_window_id: true,
+                    ..TerminalEnvironment::default()
+                },
+                Some(NotificationProtocol::Osc99),
+            ),
+            (
+                TerminalEnvironment {
+                    wezterm_pane: true,
+                    term_program: Some("tmux"),
+                    tmux: true,
+                    ..TerminalEnvironment::default()
+                },
+                None,
+            ),
+            (
+                TerminalEnvironment {
+                    iterm_session_id: true,
+                    term_program: Some("tmux"),
+                    tmux: true,
+                    ..TerminalEnvironment::default()
+                },
+                None,
+            ),
+            (
+                TerminalEnvironment {
+                    term_program: Some("Apple_Terminal"),
+                    ..TerminalEnvironment::default()
+                },
+                None,
+            ),
+            (
+                TerminalEnvironment {
+                    term_program: Some("FutureTerminal"),
+                    ..TerminalEnvironment::default()
+                },
+                None,
+            ),
+            (
+                TerminalEnvironment {
+                    term_program: Some("ghostty"),
+                    zellij: true,
+                    ..TerminalEnvironment::default()
+                },
+                None,
+            ),
+            (
+                TerminalEnvironment {
+                    term_program: Some("ghostty"),
+                    screen: true,
+                    ..TerminalEnvironment::default()
+                },
+                None,
+            ),
+        ] {
+            assert_eq!(select_protocol(&environment), expected, "{environment:?}");
+        }
+    }
+
+    #[test]
+    fn protocols_encode_safe_notification_text() {
+        assert_eq!(
+            build_sequence(
+                NotificationProtocol::Osc9,
+                "Concord\nAlert",
+                "Hello\x1b world",
+                "test-id",
+            ),
+            b"\x1b]9;Concord Alert: Hello world\x1b\\"
+        );
+        assert_eq!(
+            build_sequence(
+                NotificationProtocol::Osc777,
+                "Concord;Alert",
+                "Hello;\nworld",
+                "test-id",
+            ),
+            b"\x1b]777;notify;Concord,Alert;Hello, world\x1b\\"
+        );
+        assert_eq!(
+            build_sequence(NotificationProtocol::Osc99, "Concord", "Hello", "test-id",),
+            concat!(
+                "\x1b]99;i=test-id:d=0:p=title:e=1;Q29uY29yZA==\x1b\\",
+                "\x1b]99;i=test-id:d=1:p=body:e=1;SGVsbG8=\x1b\\",
+            )
+            .as_bytes()
+        );
+    }
+}

--- a/src/tui/runtime/effects.rs
+++ b/src/tui/runtime/effects.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 #[cfg(target_os = "macos")]
-use std::sync::Once;
+use std::sync::OnceLock;
 
 use tokio::sync::mpsc;
 
@@ -30,6 +30,9 @@ use super::media_runtime::DashboardMediaRuntime;
 
 pub(super) const MAX_DRAINED_EFFECT_EVENTS: usize = 1024;
 static NOTIFICATION_FAILURE_LOGGED: AtomicBool = AtomicBool::new(false);
+
+#[cfg(target_os = "macos")]
+const MACOS_NOTIFICATION_BUNDLE_ID: &str = "com.apple.Terminal";
 
 pub(super) struct EffectContext<'a> {
     pub(super) state: &'a mut DashboardState,
@@ -201,6 +204,20 @@ fn enqueue_member_hydration_requests(
 fn dispatch_desktop_notification(notification: DesktopNotification, icon: Option<String>) {
     let title = notification.title;
     let body = notification.body;
+
+    #[cfg(target_os = "macos")]
+    if let Some(sequence) =
+        crate::support::macos_notification::sequence_for_current_terminal(&title, &body)
+    {
+        match deliver_terminal_notification(&sequence) {
+            Ok(()) => return,
+            Err(error) => logging::debug(
+                "notification",
+                format!("terminal notification failed, using macOS fallback: {error}"),
+            ),
+        }
+    }
+
     spawn_notification_task("notification", "desktop notification", move || {
         deliver_desktop_notification(&title, &body, icon.as_deref())
     });
@@ -274,7 +291,7 @@ fn deliver_desktop_notification(
     body: &str,
     icon: Option<&str>,
 ) -> std::result::Result<(), String> {
-    deliver_notify_rust_notification(title, body, icon)
+    deliver_platform_notification(title, body, icon)
 }
 
 fn play_voice_sound(
@@ -321,13 +338,22 @@ fn voice_sound_path(kind: VoiceSoundKind, options: &NotificationOptions) -> Opti
     }
 }
 
-fn deliver_notify_rust_notification(
+#[cfg(target_os = "macos")]
+fn deliver_terminal_notification(sequence: &[u8]) -> std::result::Result<(), String> {
+    let mut output = stdout().lock();
+    output
+        .write_all(sequence)
+        .and_then(|()| output.flush())
+        .map_err(|error| error.to_string())
+}
+
+fn deliver_platform_notification(
     title: &str,
     body: &str,
     icon: Option<&str>,
 ) -> std::result::Result<(), String> {
     #[cfg(target_os = "macos")]
-    init_macos_notification_identity();
+    init_macos_notification_identity()?;
 
     let mut notification = notify_rust::Notification::new();
     if let Some(icon) = icon {
@@ -344,31 +370,13 @@ fn deliver_notify_rust_notification(
 }
 
 #[cfg(target_os = "macos")]
-fn init_macos_notification_identity() {
-    static INIT: Once = Once::new();
-    INIT.call_once(|| {
-        // macOS needs a real app bundle, so fall back to Terminal for terminals
-        // we can't identify (e.g. kitty, tmux) -- otherwise notifications vanish.
-        let app_name = std::env::var("TERM_PROGRAM")
-            .ok()
-            .and_then(|program| macos_terminal_app_name(&program))
-            .unwrap_or("Terminal");
-        let bundle_id = notify_rust::get_bundle_identifier_or_default(app_name);
-        if bundle_id != "com.apple.Finder" {
-            let _ = notify_rust::set_application(&bundle_id);
-        }
-    });
-}
-
-#[cfg(target_os = "macos")]
-fn macos_terminal_app_name(term_program: &str) -> Option<&'static str> {
-    match term_program {
-        "Apple_Terminal" => Some("Terminal"),
-        "iTerm.app" => Some("iTerm"),
-        "WezTerm" => Some("WezTerm"),
-        "WarpTerminal" => Some("Warp"),
-        _ => None,
-    }
+fn init_macos_notification_identity() -> Result<(), String> {
+    static INIT: OnceLock<Result<(), String>> = OnceLock::new();
+    INIT.get_or_init(|| {
+        notify_rust::set_application(MACOS_NOTIFICATION_BUNDLE_ID)
+            .map_err(|error| format!("macOS notification identity setup failed: {error}"))
+    })
+    .clone()
 }
 
 fn ring_terminal_bell() {


### PR DESCRIPTION
<!--
Thanks for the contribution. Please keep the subject under ~72 characters
and use a semantic prefix (feat:, fix:, refactor:, docs:, chore:, test:).

By submitting this PR you agree it will be distributed under GPL-3.0-only.
-->

## Summary

<!-- What does this change do, in one or two sentences? -->

## Why

Closes #341 

## How

<!-- Notable implementation choices and any non-obvious trade-offs. -->

## Testing

<!-- How you verified the change. Mention the OS, terminal, and graphics protocol used for manual checks. -->

- [ ] `cargo fmt --all --check`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo test --all-features`
- [ ] Manual test in a real terminal (describe below)

## Screenshots or recordings

<!-- For UI changes, attach a screenshot or asciinema/gif. Delete this section if not applicable. -->

## Checklist

- [ ] One logical change per PR.
- [ ] Link a related issue.
- [ ] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [ ] Change does not add self-bot automation, mass actions, or scraping.
- [ ] Updated `README.md`, if behavior or workflows changed.
