### PR TITLE
fix: Disable Opus SIMD only for ARM32 Linux targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ keyring = { version = "3.6.3", default-features = false, features = [
 ] }
 mime_guess = "2.0"
 notify-rust = "4"
-opus = { version = "1.6.1", package = "opusic-c" }
 qrcode = { version = "0.14", default-features = false }
 rand = "0.8"
 ratatui = "0.30.0"
@@ -143,6 +142,14 @@ stream-broadcast = [
   "dep:objc2-screen-capture-kit",
   "dep:objc2-video-toolbox",
 ]
+
+[target.'cfg(all(target_arch = "arm", target_os = "linux"))'.dependencies]
+# Generic ARM32 Linux targets do not guarantee NEON, and bundled libopus cannot
+# compile its runtime NEON path without target-specific C flags.
+opus = { version = "1.6.1", package = "opusic-c", features = ["no-simd"] }
+
+[target.'cfg(not(all(target_arch = "arm", target_os = "linux")))'.dependencies]
+opus = { version = "1.6.1", package = "opusic-c" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 alsa = { version = "0.11", optional = true }


### PR DESCRIPTION
<!--
Thanks for the contribution. Please keep the subject under ~72 characters
and use a semantic prefix (feat:, fix:, refactor:, docs:, chore:, test:).

By submitting this PR you agree it will be distributed under GPL-3.0-only.
-->

## Summary

<!-- What does this change do, in one or two sentences? -->

## Why

Closes #331 

## How

<!-- Notable implementation choices and any non-obvious trade-offs. -->

## Testing

<!-- How you verified the change. Mention the OS, terminal, and graphics protocol used for manual checks. -->

- [ ] `cargo fmt --all --check`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo test --all-features`
- [ ] Manual test in a real terminal (describe below)

## Screenshots or recordings

<!-- For UI changes, attach a screenshot or asciinema/gif. Delete this section if not applicable. -->

## Checklist

- [ ] One logical change per PR.
- [ ] Link a related issue.
- [ ] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [ ] Change does not add self-bot automation, mass actions, or scraping.
- [ ] Updated `README.md`, if behavior or workflows changed.
