### PR TITLE
feat(presence): automatic client switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,9 @@ Linux screen capture depends on the active X11 or Wayland support.
 - The profile settings activity picker can pin a specific app, switch back to
   automatic, or set a manual activity RPC will not override
 - Only apps that speak Discord's Rich Presence (RPC/IPC) protocol are detected.
+- RPC apps connect to the first `discord-ipc` socket that answers, so a running
+  native desktop client (or Vesktop/LegCord/arRPC) receives them instead of
+  concord; concord shows a warning toast when it detects this
 - Toggle with `share_rich_presence` under `[presence]` in `config.toml`
 
 ### Notifications

--- a/README.md
+++ b/README.md
@@ -219,8 +219,12 @@ Linux screen capture depends on the active X11 or Wayland support.
 
 ### Rich Presence
 
-- Concord serves the local `discord-ipc` socket, detects connected apps, and
-  lets you pick which one to share from your profile's activity picker
+- Concord serves the local `discord-ipc` socket and relays Rich Presence from
+  connected apps automatically, like the native client: the most recently
+  updated app becomes your activity, your custom status is kept alongside it,
+  and the activity clears when the app disconnects
+- The profile settings activity picker can pin a specific app, switch back to
+  automatic, or set a manual activity RPC will not override
 - Only apps that speak Discord's Rich Presence (RPC/IPC) protocol are detected.
 - Toggle with `share_rich_presence` under `[presence]` in `config.toml`
 
@@ -379,7 +383,8 @@ emojis_as_links = false
 # favorite_emojis = ["🔥", "👍", "❤️", "😂", "🎉", "😮", "😢", "🙏", "👀", "💯"]
 
 [presence]
-# Relay Rich Presence from local apps as your activity.
+# Relay Rich Presence from local apps as your activity (most recent app wins,
+# like the native client).
 share_rich_presence = true
 
 [credentials]

--- a/src/app/command_dispatch.rs
+++ b/src/app/command_dispatch.rs
@@ -710,6 +710,7 @@ fn runs_inline(command: &AppCommand) -> bool {
         command,
         AppCommand::SetSelectedGuild { .. }
             | AppCommand::SetSelectedMessageChannel { .. }
+            | AppCommand::UpdateCurrentUserActivity { .. }
             | AppCommand::JoinVoiceChannel { .. }
             | AppCommand::UpdateVoiceState { .. }
             | AppCommand::UpdateVoiceCapturePermission { .. }
@@ -735,6 +736,11 @@ mod tests {
 
     #[test]
     fn only_order_sensitive_control_commands_run_inline() {
+        assert!(runs_inline(&AppCommand::UpdateCurrentUserActivity {
+            status: crate::discord::PresenceStatus::Online,
+            activities: Vec::new(),
+            rich_presence: crate::discord::RichPresenceSelection::Automatic,
+        }));
         assert!(runs_inline(&AppCommand::SetSelectedGuild {
             guild_id: Some(Id::new(1)),
         }));

--- a/src/app/command_dispatch.rs
+++ b/src/app/command_dispatch.rs
@@ -602,13 +602,13 @@ impl CommandDispatcher {
             AppCommand::UpdateCurrentUserActivity {
                 status,
                 activities,
-                track_client_id,
+                rich_presence,
             } => {
                 user_commands::update_activity(
                     self.client.clone(),
                     status,
                     activities,
-                    track_client_id,
+                    rich_presence,
                 )
                 .await;
             }

--- a/src/app/user_commands.rs
+++ b/src/app/user_commands.rs
@@ -5,8 +5,8 @@ use crate::discord::ids::{
 use crate::{
     DiscordClient,
     discord::{
-        ActivityInfo, AppEvent, PresenceEventFields, PresenceStatus, UserProfileUpdate,
-        UserSettingsInfo,
+        ActivityInfo, AppEvent, PresenceEventFields, PresenceStatus, RichPresenceSelection,
+        UserProfileUpdate, UserSettingsInfo,
     },
 };
 
@@ -142,9 +142,16 @@ pub(super) async fn update_activity(
     client: DiscordClient,
     status: PresenceStatus,
     mut activities: Vec<ActivityInfo>,
-    track_client_id: Option<String>,
+    rich_presence: RichPresenceSelection,
 ) {
-    client.select_rich_presence(track_client_id);
+    client.set_rich_presence_selection(rich_presence.clone());
+    // Automatic mode is owned by the RPC debounce loop: it recomputes from
+    // the live registry and keeps the user's custom status composed in, which
+    // no snapshot passed through here can match.
+    if matches!(rich_presence, RichPresenceSelection::Automatic) {
+        client.notify_rich_presence_dirty();
+        return;
+    }
     for activity in &mut activities {
         client.resolve_activity_external_assets(activity).await;
     }

--- a/src/app/user_commands.rs
+++ b/src/app/user_commands.rs
@@ -145,10 +145,9 @@ pub(super) async fn update_activity(
     rich_presence: RichPresenceSelection,
 ) {
     client.set_rich_presence_selection(rich_presence.clone());
-    // Automatic mode is owned by the RPC debounce loop: it recomputes from
-    // the live registry and keeps the user's custom status composed in, which
-    // no snapshot passed through here can match.
-    if matches!(rich_presence, RichPresenceSelection::Automatic) {
+    // Both relay modes use the live registry and preserve custom status.
+    // Only a manual activity is taken from the command's UI snapshot.
+    if !matches!(rich_presence, RichPresenceSelection::Manual) {
         client.notify_rich_presence_dirty();
         return;
     }
@@ -195,6 +194,45 @@ async fn publish_gateway_error(client: &DiscordClient, error: &crate::AppError) 
 mod tests {
     use super::*;
     use crate::discord::{GlobalUserProfileUpdate, UserProfileUpdate};
+
+    #[tokio::test]
+    async fn relay_selections_notify_the_coordinator_without_publishing_ui_snapshots() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let client = DiscordClient::new("test-token".to_owned()).expect("valid token header");
+        let user_id = Id::new(10);
+        client
+            .publish_event(AppEvent::Ready {
+                user: "neo".to_owned(),
+                user_id: Some(user_id),
+            })
+            .await;
+        let custom = ActivityInfo::test(crate::discord::ActivityKind::Custom, "deep in thought");
+        publish_self_presence(&client, PresenceStatus::Offline, vec![custom.clone()]).await;
+        let mut commands = client.take_gateway_commands_for_test();
+        let dirty = client.rich_presence_dirty();
+
+        for selection in [
+            RichPresenceSelection::Automatic,
+            RichPresenceSelection::App("123".to_owned()),
+        ] {
+            update_activity(
+                client.clone(),
+                PresenceStatus::Online,
+                vec![ActivityInfo::playing("Stale UI activity")],
+                selection.clone(),
+            )
+            .await;
+            assert_eq!(client.rich_presence_selection(), selection);
+            assert_eq!(client.current_user_activities(), vec![custom.clone()]);
+            assert!(
+                commands.try_recv().is_err(),
+                "the coordinator owns the presence payload"
+            );
+            tokio::time::timeout(std::time::Duration::from_secs(1), dirty.notified())
+                .await
+                .expect("relay selection wakes the coordinator");
+        }
+    }
 
     #[tokio::test]
     async fn profile_update_for_another_user_is_rejected_before_any_request() {

--- a/src/discord/client.rs
+++ b/src/discord/client.rs
@@ -296,12 +296,15 @@ impl DiscordClient {
                 .expect("voice runtime task mutex is not poisoned") = Some(task);
         }
 
-        // Best-effort, so it never blocks the gateway from starting.
-        if serve_rich_presence {
-            tokio::spawn(crate::discord::rpc::run_rpc_server(self.clone()));
-        }
-
+        let presence_client = self.clone();
         tokio::spawn(async move {
+            // Selection changes still need a coordinator when IPC is disabled.
+            // Owning the task here also stops it when this session ends.
+            let mut presence_tasks = tokio::task::JoinSet::new();
+            presence_tasks.spawn(crate::discord::rpc::run_rich_presence(
+                presence_client,
+                serve_rich_presence,
+            ));
             let runtime = GatewayRuntime {
                 fingerprint,
                 state,
@@ -309,6 +312,7 @@ impl DiscordClient {
                 event_publisher,
             };
             run_gateway(token, gateway_commands, runtime).await;
+            presence_tasks.shutdown().await;
         })
     }
 
@@ -855,14 +859,24 @@ impl DiscordClient {
             .clone()
     }
 
-    /// Wake the RPC presence debounce loop so it re-broadcasts. A no-op when
-    /// the RPC server is not running.
+    /// Wake the presence coordinator, including when the IPC listener is disabled.
     pub fn notify_rich_presence_dirty(&self) {
         self.rich_presence_dirty.notify_one();
     }
 
     pub(crate) fn rich_presence_dirty(&self) -> Arc<Notify> {
         Arc::clone(&self.rich_presence_dirty)
+    }
+
+    pub(in crate::discord) fn clear_rich_presence_pin(&self, client_id: &str) {
+        let mut selection = self
+            .rich_presence_selection
+            .write()
+            .expect("selected rich presence lock is not poisoned");
+        // A disconnect must not overwrite a newer manual choice or another pin.
+        if matches!(&*selection, RichPresenceSelection::App(id) if id == client_id) {
+            *selection = RichPresenceSelection::Automatic;
+        }
     }
 
     /// So the RPC server can relay an activity without clobbering a manually chosen status.

--- a/src/discord/client.rs
+++ b/src/discord/client.rs
@@ -18,7 +18,7 @@ use crate::discord::ids::{
 };
 use reqwest::header::HeaderValue;
 use tokio::{
-    sync::{Mutex as AsyncMutex, mpsc, watch},
+    sync::{Mutex as AsyncMutex, Notify, mpsc, watch},
     task::JoinHandle,
     time::{Duration, timeout},
 };
@@ -28,7 +28,7 @@ use crate::{AppError, Result};
 use super::{
     ActivityInfo, ApplicationCommandAutocompleteInvocation, ApplicationCommandInfo,
     ApplicationCommandInvocation, DiscordAction, DiscordAuthSession, DiscordPermission,
-    PresenceStatus,
+    PresenceStatus, RichPresenceSelection,
     application_commands::{
         application_command_autocomplete_from_invocation,
         application_command_interaction_from_invocation,
@@ -92,7 +92,11 @@ pub struct DiscordClient {
     state: Arc<RwLock<DiscordState>>,
     requested_voice: Arc<RwLock<Option<CurrentVoiceConnectionState>>>,
     push_to_talk: Arc<RwLock<bool>>,
-    selected_rich_presence: Arc<RwLock<Option<String>>>,
+    rich_presence_selection: Arc<RwLock<RichPresenceSelection>>,
+    /// Woken whenever the RPC registry or the selection changes, so the
+    /// presence debounce loop re-broadcasts. Lives on the client (not inside
+    /// the RPC server) so the app layer can also trigger a broadcast.
+    rich_presence_dirty: Arc<Notify>,
     /// `application_id -> (external image url -> media-proxy path)`, so a url is
     /// registered with Discord only once.
     external_assets: Arc<Mutex<HashMap<String, HashMap<String, String>>>>,
@@ -173,7 +177,8 @@ impl DiscordClient {
             state,
             requested_voice: Arc::new(RwLock::new(None)),
             push_to_talk: Arc::new(RwLock::new(false)),
-            selected_rich_presence: Arc::new(RwLock::new(None)),
+            rich_presence_selection: Arc::new(RwLock::new(RichPresenceSelection::Automatic)),
+            rich_presence_dirty: Arc::new(Notify::new()),
             external_assets: Arc::new(Mutex::new(HashMap::new())),
             gateway_session_id: Arc::new(RwLock::new(None)),
             application_command_requests,
@@ -200,6 +205,17 @@ impl DiscordClient {
 
     pub fn subscribe_snapshots(&self) -> watch::Receiver<SnapshotRevision> {
         self.snapshots_tx.subscribe()
+    }
+
+    /// Test-only access to the gateway command stream, so sibling modules (for
+    /// example the RPC tests) can observe presence updates the client sends.
+    #[cfg(test)]
+    pub(crate) fn take_gateway_commands_for_test(&self) -> mpsc::UnboundedReceiver<GatewayCommand> {
+        self.gateway_commands_rx
+            .lock()
+            .expect("gateway command receiver mutex is not poisoned")
+            .take()
+            .expect("gateway commands can only be taken once")
     }
 
     pub(super) fn read_state(&self) -> RwLockReadGuard<'_, DiscordState> {
@@ -823,20 +839,30 @@ impl DiscordClient {
         }
     }
 
-    /// Record which app's activity to broadcast. `None` means a manual/no
-    /// activity that RPC updates must not override.
-    pub fn select_rich_presence(&self, client_id: Option<String>) {
+    /// Record how RPC activities are relayed to the user's profile. See
+    /// [`RichPresenceSelection`] for the semantics of each mode.
+    pub fn set_rich_presence_selection(&self, selection: RichPresenceSelection) {
         *self
-            .selected_rich_presence
+            .rich_presence_selection
             .write()
-            .expect("selected rich presence lock is not poisoned") = client_id;
+            .expect("selected rich presence lock is not poisoned") = selection;
     }
 
-    pub fn selected_rich_presence(&self) -> Option<String> {
-        self.selected_rich_presence
+    pub fn rich_presence_selection(&self) -> RichPresenceSelection {
+        self.rich_presence_selection
             .read()
             .expect("selected rich presence lock is not poisoned")
             .clone()
+    }
+
+    /// Wake the RPC presence debounce loop so it re-broadcasts. A no-op when
+    /// the RPC server is not running.
+    pub fn notify_rich_presence_dirty(&self) {
+        self.rich_presence_dirty.notify_one();
+    }
+
+    pub(crate) fn rich_presence_dirty(&self) -> Arc<Notify> {
+        Arc::clone(&self.rich_presence_dirty)
     }
 
     /// So the RPC server can relay an activity without clobbering a manually chosen status.

--- a/src/discord/client/tests.rs
+++ b/src/discord/client/tests.rs
@@ -27,7 +27,8 @@ use crate::{
 use serde_json::{Value, json};
 
 use super::{
-    DiscordClient, MEMBER_SEARCH_MAX_LIMIT, OFFICIAL_WORDLE_APPLICATION_ID, validate_token_header,
+    DiscordClient, MEMBER_SEARCH_MAX_LIMIT, OFFICIAL_WORDLE_APPLICATION_ID, RichPresenceSelection,
+    validate_token_header,
 };
 
 #[tokio::test]
@@ -430,6 +431,27 @@ async fn current_user_activities_returns_cached_presence_activity() {
         .await;
 
     assert_eq!(client.current_user_activities(), vec![activity]);
+}
+
+#[test]
+fn rich_presence_selection_defaults_to_automatic_and_round_trips() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let client = DiscordClient::new("test-token".to_owned()).expect("token is valid header");
+
+    assert_eq!(
+        client.rich_presence_selection(),
+        RichPresenceSelection::Automatic
+    );
+    client.set_rich_presence_selection(RichPresenceSelection::App("client-123".to_owned()));
+    assert_eq!(
+        client.rich_presence_selection(),
+        RichPresenceSelection::App("client-123".to_owned())
+    );
+    client.set_rich_presence_selection(RichPresenceSelection::Manual);
+    assert_eq!(
+        client.rich_presence_selection(),
+        RichPresenceSelection::Manual
+    );
 }
 
 #[tokio::test]

--- a/src/discord/commands.rs
+++ b/src/discord/commands.rs
@@ -15,7 +15,7 @@ use super::application_commands::{
 };
 use super::emoji::custom_emoji_image_url;
 use super::message::MessageInfo;
-use super::{ActivityInfo, PresenceStatus, VoiceScope};
+use super::{ActivityInfo, PresenceStatus, RichPresenceSelection, VoiceScope};
 
 pub const MAX_UPLOAD_ATTACHMENT_COUNT: usize = 10;
 pub const MAX_PROFILE_AVATAR_BYTES: u64 = 10 * 1024 * 1024;
@@ -667,9 +667,10 @@ pub enum AppCommand {
     UpdateCurrentUserActivity {
         status: PresenceStatus,
         activities: Vec<ActivityInfo>,
-        /// RPC `client_id` whose live activity this is, so the RPC server keeps
-        /// re-broadcasting it. `None` for a manual activity, which RPC must not override.
-        track_client_id: Option<String>,
+        /// How RPC activities are relayed afterwards: automatic (most recent
+        /// app wins, native-like), a pinned app, or manual (RPC never
+        /// overrides).
+        rich_presence: RichPresenceSelection,
     },
     AckChannel {
         channel_id: Id<ChannelMarker>,

--- a/src/discord/events.rs
+++ b/src/discord/events.rs
@@ -508,6 +508,12 @@ pub enum AppEvent {
     RichPresenceDetected {
         activities: Vec<ActivityInfo>,
     },
+    /// Rich Presence server could not take over `discord-ipc-0` (or any socket),
+    /// so local apps likely relay through another client. Surfaced as a toast
+    /// because the silent fallback is otherwise invisible.
+    RichPresenceWarning {
+        message: String,
+    },
     VoiceStateUpdate {
         state: VoiceStateInfo,
     },
@@ -907,6 +913,7 @@ define_app_event_kinds! {
     GuildMemberRemove: AppEvent::GuildMemberRemove { .. },
     PresenceUpdate: AppEvent::PresenceUpdate { .. },
     RichPresenceDetected: AppEvent::RichPresenceDetected { .. },
+    RichPresenceWarning: AppEvent::RichPresenceWarning { .. },
     VoiceStateUpdate: AppEvent::VoiceStateUpdate { .. },
     VoiceSpeakingUpdate: AppEvent::VoiceSpeakingUpdate { .. },
     VoiceServerUpdate: AppEvent::VoiceServerUpdate { .. },
@@ -1980,6 +1987,7 @@ impl AppEventKind {
             | AppEventKind::VoiceConnectionStatusChanged
             | AppEventKind::VoiceSound
             | AppEventKind::RichPresenceDetected
+            | AppEventKind::RichPresenceWarning
             | AppEventKind::GatewayResumed
             | AppEventKind::GatewayClosed => AppEventMetadata::effect_only(),
 

--- a/src/discord/mod.rs
+++ b/src/discord/mod.rs
@@ -111,7 +111,7 @@ pub(crate) use permission::PermissionDecision;
 pub use permission::{DiscordPermission, PermissionDataGap};
 pub use presence::{
     ActivityAssets, ActivityButton, ActivityEmoji, ActivityInfo, ActivityKind, ActivityParty,
-    ActivitySecrets, ActivityTimestamps, PresenceStatus,
+    ActivitySecrets, ActivityTimestamps, PresenceStatus, RichPresenceSelection,
 };
 pub use profile::{
     FriendStatus, MutualFriendInfo, MutualGuildInfo, RelationshipInfo, RelationshipUpdateInfo,

--- a/src/discord/presence.rs
+++ b/src/discord/presence.rs
@@ -41,6 +41,21 @@ impl PresenceStatus {
     }
 }
 
+/// Which local Rich Presence (RPC) activity concord broadcasts on the user's
+/// profile. Mirrors the native client's automatic relay while keeping an
+/// explicit escape hatch.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RichPresenceSelection {
+    /// Broadcast the most recently updated RPC activity (last writer wins),
+    /// falling back to the next most recent when that app disconnects.
+    Automatic,
+    /// The user pinned a specific app in the profile settings picker; falls
+    /// back to [`Self::Automatic`] once that app is gone.
+    App(String),
+    /// A manual activity or an explicit none: RPC must never override it.
+    Manual,
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum ActivityKind {
     Playing,

--- a/src/discord/rpc/mod.rs
+++ b/src/discord/rpc/mod.rs
@@ -48,10 +48,30 @@ pub(crate) async fn run_rpc_server(client: DiscordClient) {
     let bound = match socket::bind_first_available() {
         Ok(bound) => bound,
         Err(error) => {
-            logging::debug("rpc", format!("rich presence server disabled: {error}"));
+            let message = format!(
+                "Rich Presence is disabled: no discord-ipc socket could be bound ({error})"
+            );
+            logging::error("rpc", &message);
+            client
+                .publish_event(AppEvent::RichPresenceWarning { message })
+                .await;
             return;
         }
     };
+    // RPC apps probe discord-ipc-0 first and connect to the first socket that
+    // answers, so a nonzero slot usually means another local client receives
+    // the activity instead of concord. Still serve the slot for apps that
+    // reach it, but make the steal visible.
+    if bound.slot > 0 {
+        let message = format!(
+            "Another client owns discord-ipc-0; Rich Presence apps may relay through it instead of concord (concord listens on discord-ipc-{})",
+            bound.slot
+        );
+        logging::error("rpc", &message);
+        client
+            .publish_event(AppEvent::RichPresenceWarning { message })
+            .await;
+    }
     logging::debug(
         "rpc",
         format!(

--- a/src/discord/rpc/mod.rs
+++ b/src/discord/rpc/mod.rs
@@ -1,5 +1,7 @@
-//! Local Rich Presence (RPC/IPC) server. Detected apps are surfaced to the UI so
-//! the user picks which one to broadcast. Nothing is broadcast automatically.
+//! Local Rich Presence (RPC/IPC) server. Detected apps are relayed to the
+//! user's profile automatically — the most recently updated activity wins,
+//! like the native client. The profile settings picker can pin a specific
+//! app or opt out entirely with a manual activity.
 
 mod codec;
 mod protocol;
@@ -14,10 +16,10 @@ use std::time::Duration;
 use interprocess::local_socket::tokio::Stream;
 use interprocess::local_socket::traits::tokio::Listener as _;
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio::sync::{Mutex, Notify};
+use tokio::sync::Mutex;
 
 use crate::discord::events::{AppEvent, PresenceEventFields};
-use crate::discord::{ActivityInfo, DiscordClient};
+use crate::discord::{ActivityInfo, ActivityKind, DiscordClient, RichPresenceSelection};
 use crate::logging;
 
 use codec::{Opcode, read_frame, write_frame};
@@ -40,7 +42,6 @@ struct RpcContext {
     registry: SharedRegistry,
     names: NameCache,
     assets: AssetCache,
-    presence_dirty: Arc<Notify>,
 }
 
 pub(crate) async fn run_rpc_server(client: DiscordClient) {
@@ -65,7 +66,6 @@ pub(crate) async fn run_rpc_server(client: DiscordClient) {
         registry: Arc::new(Mutex::new(ActivityRegistry::default())),
         names: Arc::new(Mutex::new(HashMap::new())),
         assets: Arc::new(Mutex::new(HashMap::new())),
-        presence_dirty: Arc::new(Notify::new()),
     };
     tokio::spawn(presence_debounce_loop(context.clone()));
     loop {
@@ -145,7 +145,7 @@ where
         }
         drop(registry);
         publish_detected(context).await;
-        context.presence_dirty.notify_one();
+        context.client.notify_rich_presence_dirty();
     }
     outcome
 }
@@ -197,7 +197,7 @@ where
                 }
             }
             publish_detected(context).await;
-            context.presence_dirty.notify_one();
+            context.client.notify_rich_presence_dirty();
             write_frame(
                 stream,
                 Opcode::Frame,
@@ -217,33 +217,46 @@ async fn publish_detected(context: &RpcContext) {
 }
 
 async fn presence_debounce_loop(context: RpcContext) {
+    let dirty = context.client.rich_presence_dirty();
     loop {
-        context.presence_dirty.notified().await;
+        dirty.notified().await;
         broadcast_selected_now(&context).await;
         tokio::time::sleep(MIN_PRESENCE_INTERVAL).await;
     }
 }
 
-/// Does nothing when no app is selected, so a manual activity is never
-/// overridden.
+/// Relays the current RPC activity to the user's presence, mirroring the
+/// native client: the selected app wins (falling back to the most recent
+/// one when it is gone), and the user's custom status survives alongside it.
 async fn broadcast_selected_now(context: &RpcContext) {
-    let Some(client_id) = context.client.selected_rich_presence() else {
-        return;
+    let rpc_activity = {
+        let registry = context.registry.lock().await;
+        match context.client.rich_presence_selection() {
+            // A manual activity is owned by the user; RPC never overrides it.
+            RichPresenceSelection::Manual => return,
+            RichPresenceSelection::App(client_id) => registry
+                .activity_for_client(&client_id)
+                .or_else(|| registry.latest_activity()),
+            RichPresenceSelection::Automatic => registry.latest_activity(),
+        }
     };
+
+    // Keep the custom status alive next to the relayed activity, like the
+    // native client does when a game is running.
     let mut activities: Vec<ActivityInfo> = context
-        .registry
-        .lock()
-        .await
-        .activity_for_client(&client_id)
+        .client
+        .current_user_activities()
         .into_iter()
+        .filter(|activity| activity.kind == ActivityKind::Custom)
         .collect();
     // Turn raw external image URLs into `mp:` refs here (only for the app we
     // broadcast), since the gateway needs them registered first.
-    if let Some(activity) = activities.first_mut() {
+    if let Some(mut activity) = rpc_activity {
         context
             .client
-            .resolve_activity_external_assets(activity)
+            .resolve_activity_external_assets(&mut activity)
             .await;
+        activities.push(activity);
     }
 
     let status = context.client.current_user_status();
@@ -343,21 +356,34 @@ mod tests {
     use std::sync::Arc;
 
     use tokio::io::AsyncWriteExt;
-    use tokio::sync::{Mutex, Notify};
+    use tokio::sync::Mutex;
 
     use super::codec::{Opcode, encode_frame, read_frame};
     use super::registry::ActivityRegistry;
-    use super::{RpcContext, is_external_image_url, needs_key_lookup, serve_connection};
-    use crate::discord::DiscordClient;
+    use super::{
+        RpcContext, broadcast_selected_now, is_external_image_url, needs_key_lookup,
+        serve_connection,
+    };
+    use crate::discord::events::{AppEvent, PresenceEventFields};
+    use crate::discord::gateway::GatewayCommand;
+    use crate::discord::ids::Id;
+    use crate::discord::{
+        ActivityInfo, ActivityKind, DiscordClient, PresenceStatus, RichPresenceSelection,
+    };
 
-    fn test_context() -> RpcContext {
+    fn context_with_client(client: DiscordClient) -> RpcContext {
         RpcContext {
-            client: DiscordClient::new("test-token".to_owned()).expect("valid token header"),
+            client,
             registry: Arc::new(Mutex::new(ActivityRegistry::default())),
             names: Arc::new(Mutex::new(HashMap::new())),
             assets: Arc::new(Mutex::new(HashMap::new())),
-            presence_dirty: Arc::new(Notify::new()),
         }
+    }
+
+    fn test_context() -> RpcContext {
+        context_with_client(
+            DiscordClient::new("test-token".to_owned()).expect("valid token header"),
+        )
     }
 
     #[test]
@@ -466,5 +492,104 @@ mod tests {
             .await
             .expect("send close");
         server_task.await.expect("server task joins cleanly");
+    }
+
+    fn presence_update_command(command: GatewayCommand) -> (PresenceStatus, Vec<ActivityInfo>) {
+        match command {
+            GatewayCommand::UpdatePresence { status, activities } => (status, activities),
+            other => panic!("expected UpdatePresence, got {other:?}"),
+        }
+    }
+
+    async fn test_client_with_current_user()
+    -> (DiscordClient, Id<crate::discord::ids::marker::UserMarker>) {
+        let client = DiscordClient::new("test-token".to_owned()).expect("valid token header");
+        let user_id = Id::new(10);
+        client
+            .publish_event(AppEvent::Ready {
+                user: "neo".to_owned(),
+                user_id: Some(user_id),
+            })
+            .await;
+        (client, user_id)
+    }
+
+    #[tokio::test]
+    async fn automatic_mode_broadcasts_latest_activity_and_keeps_custom_status() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let (client, user_id) = test_client_with_current_user().await;
+        let mut gateway_commands = client.take_gateway_commands_for_test();
+
+        let custom = ActivityInfo::test(ActivityKind::Custom, "deep in thought");
+        client
+            .publish_event(AppEvent::PresenceUpdate {
+                guild_id: None,
+                presence: PresenceEventFields {
+                    user_id,
+                    status: PresenceStatus::Online,
+                    activities: vec![custom.clone()],
+                },
+            })
+            .await;
+
+        let context = context_with_client(client.clone());
+        {
+            let mut registry = context.registry.lock().await;
+            registry.set(
+                "app-a".to_owned(),
+                1,
+                ActivityInfo::test(ActivityKind::Playing, "Game A"),
+            );
+            registry.set(
+                "app-b".to_owned(),
+                2,
+                ActivityInfo::test(ActivityKind::Playing, "Song B"),
+            );
+        }
+
+        // Automatic (the default) relays the most recently updated activity,
+        // with the custom status still alongside it.
+        broadcast_selected_now(&context).await;
+        let (status, activities) =
+            presence_update_command(gateway_commands.recv().await.expect("presence update"));
+        assert_eq!(status, PresenceStatus::Online);
+        assert_eq!(
+            activities,
+            vec![custom, ActivityInfo::test(ActivityKind::Playing, "Song B"),]
+        );
+
+        // A pinned app that is gone falls back to the latest remaining one.
+        client.set_rich_presence_selection(RichPresenceSelection::App("gone".to_owned()));
+        broadcast_selected_now(&context).await;
+        let (_status, activities) =
+            presence_update_command(gateway_commands.recv().await.expect("presence update"));
+        assert_eq!(
+            activities.last().map(|activity| activity.name.as_str()),
+            Some("Song B")
+        );
+
+        // Manual never broadcasts, so a manual activity cannot be overridden.
+        client.set_rich_presence_selection(RichPresenceSelection::Manual);
+        broadcast_selected_now(&context).await;
+        assert!(
+            gateway_commands.try_recv().is_err(),
+            "manual mode must not broadcast"
+        );
+
+        // An empty registry in automatic mode clears the relayed activity but
+        // keeps the custom status.
+        client.set_rich_presence_selection(RichPresenceSelection::Automatic);
+        context.registry.lock().await.clear("app-a", 1);
+        context.registry.lock().await.clear("app-b", 2);
+        broadcast_selected_now(&context).await;
+        let (_status, activities) =
+            presence_update_command(gateway_commands.recv().await.expect("presence update"));
+        assert_eq!(
+            activities
+                .iter()
+                .map(|activity| activity.name.as_str())
+                .collect::<Vec<_>>(),
+            ["deep in thought"]
+        );
     }
 }

--- a/src/discord/rpc/mod.rs
+++ b/src/discord/rpc/mod.rs
@@ -8,7 +8,7 @@ mod protocol;
 mod registry;
 mod socket;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::io;
 use std::sync::Arc;
 use std::time::Duration;
@@ -44,7 +44,24 @@ struct RpcContext {
     assets: AssetCache,
 }
 
-pub(crate) async fn run_rpc_server(client: DiscordClient) {
+pub(crate) async fn run_rich_presence(client: DiscordClient, serve_rpc: bool) {
+    let context = RpcContext {
+        client,
+        registry: Arc::new(Mutex::new(ActivityRegistry::default())),
+        names: Arc::new(Mutex::new(HashMap::new())),
+        assets: Arc::new(Mutex::new(HashMap::new())),
+    };
+    // IPC availability only controls detection. Switching away from a manual
+    // activity must still work when sharing is disabled or binding fails.
+    tokio::join!(presence_debounce_loop(context.clone()), async {
+        if serve_rpc {
+            run_rpc_server(context).await;
+        }
+    });
+}
+
+async fn run_rpc_server(context: RpcContext) {
+    let client = &context.client;
     let bound = match socket::bind_first_available() {
         Ok(bound) => bound,
         Err(error) => {
@@ -81,24 +98,31 @@ pub(crate) async fn run_rpc_server(client: DiscordClient) {
     );
     let _socket_cleanup = socket::SocketCleanup::new(bound.path.clone());
 
-    let context = RpcContext {
-        client,
-        registry: Arc::new(Mutex::new(ActivityRegistry::default())),
-        names: Arc::new(Mutex::new(HashMap::new())),
-        assets: Arc::new(Mutex::new(HashMap::new())),
-    };
-    tokio::spawn(presence_debounce_loop(context.clone()));
+    let mut connections = tokio::task::JoinSet::new();
     loop {
-        match bound.listener.accept().await {
-            Ok(stream) => {
-                tokio::spawn(handle_connection(stream, context.clone()));
-            }
-            Err(error) => {
-                logging::error("rpc", format!("accept failed: {error}"));
-                break;
-            }
+        tokio::select! {
+            accepted = bound.listener.accept() => match accepted {
+                Ok(stream) => {
+                    connections.spawn(handle_connection(stream, context.clone()));
+                }
+                Err(error) => {
+                    logging::error("rpc", format!("accept failed: {error}"));
+                    break;
+                }
+            },
+            Some(_) = connections.join_next() => {}
         }
     }
+    connections.shutdown().await;
+    {
+        let mut registry = context.registry.lock().await;
+        *registry = ActivityRegistry::default();
+        if let RichPresenceSelection::App(client_id) = client.rich_presence_selection() {
+            client.clear_rich_presence_pin(&client_id);
+        }
+    }
+    publish_detected(&context).await;
+    client.notify_rich_presence_dirty();
 }
 
 async fn handle_connection(mut stream: Stream, context: RpcContext) {
@@ -128,7 +152,9 @@ where
     let user = context.client.current_user_rpc_identity();
     write_frame(stream, Opcode::Frame, &protocol::build_ready_payload(user)).await?;
 
-    let mut active_pids: HashSet<i64> = HashSet::new();
+    // Keep the entry revision owned by this connection. An old connection's
+    // cleanup must not remove an activity already replaced by a reconnect.
+    let mut active_pids: HashMap<i64, u64> = HashMap::new();
     let outcome = loop {
         let frame = match read_frame(stream).await {
             Ok(frame) => frame,
@@ -160,8 +186,11 @@ where
 
     if !active_pids.is_empty() {
         let mut registry = context.registry.lock().await;
-        for pid in &active_pids {
-            registry.clear(&client_id, *pid);
+        for (pid, sequence) in &active_pids {
+            registry.clear_if_current(&client_id, *pid, *sequence);
+        }
+        if registry.activity_for_client(&client_id).is_none() {
+            context.client.clear_rich_presence_pin(&client_id);
         }
         drop(registry);
         publish_detected(context).await;
@@ -174,7 +203,7 @@ async fn handle_command<S>(
     stream: &mut S,
     payload: &[u8],
     client_id: &str,
-    active_pids: &mut HashSet<i64>,
+    active_pids: &mut HashMap<i64, u64>,
     context: &RpcContext,
 ) -> io::Result<()>
 where
@@ -204,16 +233,30 @@ where
                 Some(mut activity) => {
                     activity.name = resolve_app_name(context, client_id).await;
                     resolve_asset_keys(context, client_id, &mut activity).await;
-                    context
-                        .registry
-                        .lock()
-                        .await
-                        .set(client_id.to_owned(), pid, *activity);
-                    active_pids.insert(pid);
+                    let sequence =
+                        context
+                            .registry
+                            .lock()
+                            .await
+                            .set(client_id.to_owned(), pid, *activity);
+                    active_pids.insert(pid, sequence);
                 }
                 None => {
-                    context.registry.lock().await.clear(client_id, pid);
-                    active_pids.remove(&pid);
+                    let mut registry = context.registry.lock().await;
+                    if pid == 0 {
+                        // A zero-PID clear applies to this connection, not every
+                        // process using the same application ID.
+                        for (pid, sequence) in active_pids.drain() {
+                            registry.clear_if_current(client_id, pid, sequence);
+                        }
+                    } else {
+                        // An explicit PID clear can arrive on a new connection.
+                        active_pids.remove(&pid);
+                        registry.clear(client_id, pid);
+                    }
+                    if registry.activity_for_client(client_id).is_none() {
+                        context.client.clear_rich_presence_pin(client_id);
+                    }
                 }
             }
             publish_detected(context).await;
@@ -238,8 +281,22 @@ async fn publish_detected(context: &RpcContext) {
 
 async fn presence_debounce_loop(context: RpcContext) {
     let dirty = context.client.rich_presence_dirty();
+    let mut snapshots = context.client.subscribe_snapshots();
     loop {
         dirty.notified().await;
+        // Keep this dirty update pending until READY supplies self presence.
+        // Watching snapshots avoids polling and needs no second RPC update.
+        while context
+            .client
+            .read_state()
+            .session
+            .current_user_session_status
+            .is_none()
+        {
+            if snapshots.changed().await.is_err() {
+                return;
+            }
+        }
         broadcast_selected_now(&context).await;
         tokio::time::sleep(MIN_PRESENCE_INTERVAL).await;
     }
@@ -249,37 +306,68 @@ async fn presence_debounce_loop(context: RpcContext) {
 /// native client: the selected app wins (falling back to the most recent
 /// one when it is gone), and the user's custom status survives alongside it.
 async fn broadcast_selected_now(context: &RpcContext) {
-    let rpc_activity = {
+    if context
+        .client
+        .read_state()
+        .session
+        .current_user_session_status
+        .is_none()
+    {
+        return;
+    }
+    let (selection, rpc_activity) = {
         let registry = context.registry.lock().await;
-        match context.client.rich_presence_selection() {
+        let mut selection = context.client.rich_presence_selection();
+        let activity = match &selection {
             // A manual activity is owned by the user; RPC never overrides it.
             RichPresenceSelection::Manual => return,
-            RichPresenceSelection::App(client_id) => registry
-                .activity_for_client(&client_id)
-                .or_else(|| registry.latest_activity()),
+            RichPresenceSelection::App(client_id) => {
+                if let Some(activity) = registry.activity_for_client(client_id) {
+                    Some(activity)
+                } else {
+                    context.client.clear_rich_presence_pin(client_id);
+                    selection = RichPresenceSelection::Automatic;
+                    registry.latest_activity()
+                }
+            }
             RichPresenceSelection::Automatic => registry.latest_activity(),
-        }
+        };
+        (selection, activity)
     };
 
-    // Keep the custom status alive next to the relayed activity, like the
-    // native client does when a game is running.
-    let mut activities: Vec<ActivityInfo> = context
-        .client
-        .current_user_activities()
-        .into_iter()
-        .filter(|activity| activity.kind == ActivityKind::Custom)
-        .collect();
     // Turn raw external image URLs into `mp:` refs here (only for the app we
     // broadcast), since the gateway needs them registered first.
-    if let Some(mut activity) = rpc_activity {
+    let mut rpc_activity = rpc_activity;
+    if let Some(activity) = rpc_activity.as_mut() {
         context
             .client
-            .resolve_activity_external_assets(&mut activity)
+            .resolve_activity_external_assets(activity)
             .await;
-        activities.push(activity);
     }
 
-    let status = context.client.current_user_status();
+    // Asset lookup can yield to a manual selection, re-identify, or a status
+    // change. Never publish the old selection or a guessed Online status.
+    if context.client.rich_presence_selection() != selection {
+        return;
+    }
+    let (user_id, status, mut activities) = {
+        let state = context.client.read_state();
+        let Some(status) = state.session.current_user_session_status else {
+            context.client.notify_rich_presence_dirty();
+            return;
+        };
+        let Some(user_id) = state.current_user_id() else {
+            return;
+        };
+        let custom_status = state
+            .user_activities(user_id)
+            .iter()
+            .filter(|activity| activity.kind == ActivityKind::Custom)
+            .cloned()
+            .collect::<Vec<_>>();
+        (user_id, status, custom_status)
+    };
+    activities.extend(rpc_activity);
     if let Err(error) = context
         .client
         .update_presence_activity(status, activities.clone())
@@ -287,19 +375,17 @@ async fn broadcast_selected_now(context: &RpcContext) {
         logging::error("rpc", format!("live presence update failed: {error}"));
         return;
     }
-    if let Some(user_id) = context.client.current_user_id() {
-        context
-            .client
-            .publish_event(AppEvent::PresenceUpdate {
-                guild_id: None,
-                presence: PresenceEventFields {
-                    user_id,
-                    status,
-                    activities,
-                },
-            })
-            .await;
-    }
+    context
+        .client
+        .publish_event(AppEvent::PresenceUpdate {
+            guild_id: None,
+            presence: PresenceEventFields {
+                user_id,
+                status,
+                activities,
+            },
+        })
+        .await;
 }
 
 async fn resolve_app_name(context: &RpcContext, client_id: &str) -> String {
@@ -535,6 +621,480 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn automatic_waits_for_initial_self_presence_and_replays_pending_activity() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let context = test_context();
+        let client = context.client.clone();
+        let mut commands = client.take_gateway_commands_for_test();
+        let game = ActivityInfo::playing("Game A");
+        context
+            .registry
+            .lock()
+            .await
+            .set("app-a".to_owned(), 1, game.clone());
+        let task = tokio::spawn(super::presence_debounce_loop(context));
+        client.notify_rich_presence_dirty();
+
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(30), commands.recv())
+                .await
+                .is_err()
+        );
+        let user_id = Id::new(10);
+        client
+            .publish_event(AppEvent::Ready {
+                user: "neo".to_owned(),
+                user_id: Some(user_id),
+            })
+            .await;
+        // Guild presence is not the session's own status, and can arrive first.
+        client
+            .publish_event(AppEvent::PresenceUpdate {
+                guild_id: Some(Id::new(20)),
+                presence: PresenceEventFields {
+                    user_id,
+                    status: PresenceStatus::Online,
+                    activities: Vec::new(),
+                },
+            })
+            .await;
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(30), commands.recv())
+                .await
+                .is_err()
+        );
+
+        let custom = ActivityInfo::test(ActivityKind::Custom, "deep in thought");
+        client
+            .publish_event(AppEvent::PresenceUpdate {
+                guild_id: None,
+                presence: PresenceEventFields {
+                    user_id,
+                    status: PresenceStatus::Offline,
+                    activities: vec![custom.clone()],
+                },
+            })
+            .await;
+        // No second RPC update is needed to release the pending activity.
+        let command = tokio::time::timeout(std::time::Duration::from_secs(1), commands.recv())
+            .await
+            .expect("readiness wakes the relay")
+            .expect("presence update");
+        assert_eq!(
+            presence_update_command(command),
+            (PresenceStatus::Offline, vec![custom, game])
+        );
+        task.abort();
+    }
+
+    #[tokio::test]
+    async fn disconnected_pin_stays_automatic_after_the_app_restarts() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let (client, user_id) = test_client_with_current_user().await;
+        client
+            .publish_event(AppEvent::PresenceUpdate {
+                guild_id: None,
+                presence: PresenceEventFields {
+                    user_id,
+                    status: PresenceStatus::Online,
+                    activities: Vec::new(),
+                },
+            })
+            .await;
+        let mut commands = client.take_gateway_commands_for_test();
+        let context = context_with_client(client.clone());
+        client.set_rich_presence_selection(RichPresenceSelection::App("app-a".to_owned()));
+        context
+            .registry
+            .lock()
+            .await
+            .set("app-b".to_owned(), 2, ActivityInfo::playing("Game B"));
+        broadcast_selected_now(&context).await;
+        assert_eq!(
+            client.rich_presence_selection(),
+            RichPresenceSelection::Automatic
+        );
+        commands.try_recv().expect("fallback update");
+
+        context.registry.lock().await.set(
+            "app-a".to_owned(),
+            1,
+            ActivityInfo::playing("Game A restarted"),
+        );
+        context.registry.lock().await.set(
+            "app-b".to_owned(),
+            2,
+            ActivityInfo::playing("Game B latest"),
+        );
+        broadcast_selected_now(&context).await;
+        let (_, activities) = presence_update_command(commands.try_recv().expect("latest update"));
+        assert_eq!(activities, vec![ActivityInfo::playing("Game B latest")]);
+    }
+
+    #[tokio::test]
+    async fn automatic_clears_manual_activity_without_an_ipc_listener() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let (client, user_id) = test_client_with_current_user().await;
+        let custom = ActivityInfo::test(ActivityKind::Custom, "deep in thought");
+        client
+            .publish_event(AppEvent::PresenceUpdate {
+                guild_id: None,
+                presence: PresenceEventFields {
+                    user_id,
+                    status: PresenceStatus::DoNotDisturb,
+                    activities: vec![custom.clone(), ActivityInfo::playing("Manual Game")],
+                },
+            })
+            .await;
+        let mut commands = client.take_gateway_commands_for_test();
+        client.set_rich_presence_selection(RichPresenceSelection::Manual);
+        let task = tokio::spawn(super::run_rich_presence(client.clone(), false));
+        client.set_rich_presence_selection(RichPresenceSelection::Automatic);
+        client.notify_rich_presence_dirty();
+
+        let command = tokio::time::timeout(std::time::Duration::from_secs(1), commands.recv())
+            .await
+            .expect("automatic works without IPC")
+            .expect("presence update");
+        assert_eq!(
+            presence_update_command(command),
+            (PresenceStatus::DoNotDisturb, vec![custom])
+        );
+        assert!(
+            !task.is_finished(),
+            "the coordinator stays available without a listener"
+        );
+        task.abort();
+    }
+
+    #[tokio::test]
+    async fn clearing_or_disconnecting_the_last_pinned_process_releases_the_pin() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        for disconnect in [false, true] {
+            let context = test_context();
+            context
+                .names
+                .lock()
+                .await
+                .insert("123".to_owned(), "Game A".to_owned());
+            let (mut app, mut server) = tokio::io::duplex(4096);
+            let server_context = context.clone();
+            let task =
+                tokio::spawn(async move { serve_connection(&mut server, &server_context).await });
+            app.write_all(&encode_frame(
+                Opcode::Handshake,
+                br#"{"v":1,"client_id":"123"}"#,
+            ))
+            .await
+            .expect("send handshake");
+            read_frame(&mut app).await.expect("ready frame");
+            for pid in [1, 2] {
+                let payload = serde_json::json!({"cmd":"SET_ACTIVITY","args":{"pid":pid,"activity":{"type":0}}});
+                app.write_all(&encode_frame(Opcode::Frame, payload.to_string().as_bytes()))
+                    .await
+                    .expect("set activity");
+                read_frame(&mut app).await.expect("activity acknowledged");
+            }
+            context
+                .client
+                .set_rich_presence_selection(RichPresenceSelection::App("123".to_owned()));
+            let clear = |pid| {
+                serde_json::json!({"cmd":"SET_ACTIVITY","args":{"pid":pid,"activity":null}})
+                    .to_string()
+            };
+            app.write_all(&encode_frame(Opcode::Frame, clear(1).as_bytes()))
+                .await
+                .expect("clear first process");
+            read_frame(&mut app).await.expect("clear acknowledged");
+            assert_eq!(
+                context.client.rich_presence_selection(),
+                RichPresenceSelection::App("123".to_owned())
+            );
+
+            if !disconnect {
+                app.write_all(&encode_frame(Opcode::Frame, clear(2).as_bytes()))
+                    .await
+                    .expect("clear final process");
+                read_frame(&mut app).await.expect("clear acknowledged");
+                assert_eq!(
+                    context.client.rich_presence_selection(),
+                    RichPresenceSelection::Automatic
+                );
+            }
+            app.write_all(&encode_frame(Opcode::Close, b""))
+                .await
+                .expect("close app");
+            task.await
+                .expect("connection task joins")
+                .expect("clean close");
+            assert_eq!(
+                context.client.rich_presence_selection(),
+                RichPresenceSelection::Automatic
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn explicit_clear_from_reconnected_client_removes_the_previous_activity() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let (client, user_id) = test_client_with_current_user().await;
+        let custom = ActivityInfo::test(ActivityKind::Custom, "deep in thought");
+        client
+            .publish_event(AppEvent::PresenceUpdate {
+                guild_id: None,
+                presence: PresenceEventFields {
+                    user_id,
+                    status: PresenceStatus::Online,
+                    activities: vec![custom.clone()],
+                },
+            })
+            .await;
+        let mut commands = client.take_gateway_commands_for_test();
+        let context = context_with_client(client);
+        context
+            .names
+            .lock()
+            .await
+            .insert("123".to_owned(), "Neovim".to_owned());
+
+        let (mut app, mut server) = tokio::io::duplex(4096);
+        let server_context = context.clone();
+        let activity_task =
+            tokio::spawn(async move { serve_connection(&mut server, &server_context).await });
+        app.write_all(&encode_frame(
+            Opcode::Handshake,
+            br#"{"v":1,"client_id":"123"}"#,
+        ))
+        .await
+        .expect("send activity connection handshake");
+        read_frame(&mut app)
+            .await
+            .expect("activity connection ready");
+        let set = serde_json::json!({
+            "cmd": "SET_ACTIVITY",
+            "args": { "pid": 42, "activity": { "type": 0, "details": "Editing" } }
+        });
+        app.write_all(&encode_frame(Opcode::Frame, set.to_string().as_bytes()))
+            .await
+            .expect("set activity");
+        read_frame(&mut app).await.expect("set acknowledged");
+
+        // An explicit clear is keyed by application and process, so it must
+        // also work when it arrives over a replacement IPC connection.
+        let (mut clearing_app, mut clearing_server) = tokio::io::duplex(4096);
+        let clearing_context = context.clone();
+        let clearing_task =
+            tokio::spawn(
+                async move { serve_connection(&mut clearing_server, &clearing_context).await },
+            );
+        clearing_app
+            .write_all(&encode_frame(
+                Opcode::Handshake,
+                br#"{"v":1,"client_id":"123"}"#,
+            ))
+            .await
+            .expect("send clearing connection handshake");
+        read_frame(&mut clearing_app)
+            .await
+            .expect("clearing connection ready");
+        let clear = serde_json::json!({
+            "cmd": "SET_ACTIVITY",
+            "args": { "pid": 42, "activity": null }
+        });
+        clearing_app
+            .write_all(&encode_frame(Opcode::Frame, clear.to_string().as_bytes()))
+            .await
+            .expect("clear activity");
+        read_frame(&mut clearing_app)
+            .await
+            .expect("clear acknowledged");
+
+        let detected = context.registry.lock().await.activities();
+        broadcast_selected_now(&context).await;
+        let outbound = presence_update_command(commands.recv().await.expect("presence update"));
+        let local_activities = context.client.current_user_activities();
+
+        clearing_app
+            .write_all(&encode_frame(Opcode::Close, b""))
+            .await
+            .expect("close clearing connection");
+        clearing_task
+            .await
+            .expect("clearing task joins")
+            .expect("clearing connection closes cleanly");
+        app.write_all(&encode_frame(Opcode::Close, b""))
+            .await
+            .expect("close activity connection");
+        activity_task
+            .await
+            .expect("activity task joins")
+            .expect("activity connection closes cleanly");
+
+        assert!(
+            detected.is_empty(),
+            "the cleared app must not stay detected"
+        );
+        assert_eq!(outbound, (PresenceStatus::Online, vec![custom.clone()]));
+        assert_eq!(local_activities, vec![custom]);
+    }
+
+    #[tokio::test]
+    async fn zero_pid_clear_removes_connection_activity_and_preserves_custom_status() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let (client, user_id) = test_client_with_current_user().await;
+        let custom = ActivityInfo::test(ActivityKind::Custom, "deep in thought");
+        client
+            .publish_event(AppEvent::PresenceUpdate {
+                guild_id: None,
+                presence: PresenceEventFields {
+                    user_id,
+                    status: PresenceStatus::DoNotDisturb,
+                    activities: vec![custom.clone()],
+                },
+            })
+            .await;
+        let mut commands = client.take_gateway_commands_for_test();
+        let context = context_with_client(client);
+        context
+            .names
+            .lock()
+            .await
+            .insert("123".to_owned(), "Neovim".to_owned());
+
+        let (mut app, mut server) = tokio::io::duplex(4096);
+        let server_context = context.clone();
+        let task =
+            tokio::spawn(async move { serve_connection(&mut server, &server_context).await });
+        app.write_all(&encode_frame(
+            Opcode::Handshake,
+            br#"{"v":1,"client_id":"123"}"#,
+        ))
+        .await
+        .expect("send handshake");
+        read_frame(&mut app).await.expect("connection ready");
+        let set = serde_json::json!({
+            "cmd": "SET_ACTIVITY",
+            "args": {
+                "pid": 42,
+                "activity": { "type": 0, "details": "Editing concord" }
+            }
+        });
+        app.write_all(&encode_frame(Opcode::Frame, set.to_string().as_bytes()))
+            .await
+            .expect("set activity");
+        read_frame(&mut app).await.expect("set acknowledged");
+
+        // A persistent RPC process can clear the activities owned by this
+        // connection with pid 0 and no activity field.
+        let clear = serde_json::json!({
+            "cmd": "SET_ACTIVITY",
+            "args": { "pid": 0 }
+        });
+        app.write_all(&encode_frame(Opcode::Frame, clear.to_string().as_bytes()))
+            .await
+            .expect("clear activity");
+        let clear_response = read_frame(&mut app).await.expect("clear acknowledged");
+        let clear_response: serde_json::Value =
+            serde_json::from_slice(&clear_response.payload).expect("clear response is JSON");
+
+        let detected = context.registry.lock().await.activities();
+        broadcast_selected_now(&context).await;
+        let outbound = presence_update_command(commands.recv().await.expect("presence update"));
+        let local_activities = context.client.current_user_activities();
+
+        app.write_all(&encode_frame(Opcode::Close, b""))
+            .await
+            .expect("close connection");
+        task.await
+            .expect("connection task joins")
+            .expect("connection closes cleanly");
+
+        assert!(
+            clear_response["evt"].is_null(),
+            "clear must be acknowledged"
+        );
+        assert!(
+            detected.is_empty(),
+            "the cleared app must not stay detected"
+        );
+        assert_eq!(
+            outbound,
+            (PresenceStatus::DoNotDisturb, vec![custom.clone()])
+        );
+        assert_eq!(local_activities, vec![custom]);
+    }
+
+    #[tokio::test]
+    async fn zero_pid_clear_only_removes_entries_owned_by_the_connection() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let context = test_context();
+        context
+            .names
+            .lock()
+            .await
+            .insert("123".to_owned(), "Neovim".to_owned());
+
+        let (mut app, mut server) = tokio::io::duplex(4096);
+        let server_context = context.clone();
+        let task =
+            tokio::spawn(async move { serve_connection(&mut server, &server_context).await });
+        app.write_all(&encode_frame(
+            Opcode::Handshake,
+            br#"{"v":1,"client_id":"123"}"#,
+        ))
+        .await
+        .expect("send handshake");
+        read_frame(&mut app).await.expect("connection ready");
+        for pid in [42, 43] {
+            let set = serde_json::json!({
+                "cmd": "SET_ACTIVITY",
+                "args": { "pid": pid, "activity": { "type": 0, "details": pid.to_string() } }
+            });
+            app.write_all(&encode_frame(Opcode::Frame, set.to_string().as_bytes()))
+                .await
+                .expect("set connection activity");
+            read_frame(&mut app).await.expect("set acknowledged");
+        }
+
+        // Model a newer connection replacing one key, plus an unrelated app.
+        // The pid-zero clear must not remove either entry.
+        {
+            let mut registry = context.registry.lock().await;
+            registry.set(
+                "123".to_owned(),
+                43,
+                ActivityInfo::playing("Replacement connection"),
+            );
+            registry.set("456".to_owned(), 9, ActivityInfo::playing("Unrelated app"));
+        }
+
+        let clear = serde_json::json!({
+            "cmd": "SET_ACTIVITY",
+            "args": { "pid": 0 }
+        });
+        app.write_all(&encode_frame(Opcode::Frame, clear.to_string().as_bytes()))
+            .await
+            .expect("clear connection activities");
+        read_frame(&mut app).await.expect("clear acknowledged");
+
+        // Inspect before closing so disconnect cleanup cannot mask a bad clear.
+        let remaining = context.registry.lock().await.activities();
+        app.write_all(&encode_frame(Opcode::Close, b""))
+            .await
+            .expect("close connection");
+        task.await
+            .expect("connection task joins")
+            .expect("connection closes cleanly");
+
+        let names = remaining
+            .iter()
+            .map(|activity| activity.name.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(names, ["Unrelated app", "Replacement connection"]);
+        assert_eq!(context.registry.lock().await.activities(), remaining);
+    }
+
+    #[tokio::test]
     async fn automatic_mode_broadcasts_latest_activity_and_keeps_custom_status() {
         let _ = rustls::crypto::ring::default_provider().install_default();
         let (client, user_id) = test_client_with_current_user().await;
@@ -567,16 +1127,24 @@ mod tests {
             );
         }
 
-        // Automatic (the default) relays the most recently updated activity,
-        // with the custom status still alongside it.
-        broadcast_selected_now(&context).await;
-        let (status, activities) =
-            presence_update_command(gateway_commands.recv().await.expect("presence update"));
-        assert_eq!(status, PresenceStatus::Online);
-        assert_eq!(
-            activities,
-            vec![custom, ActivityInfo::test(ActivityKind::Playing, "Song B"),]
-        );
+        // Both automatic and pinned relay keep the custom status alongside it.
+        for (selection, name) in [
+            (RichPresenceSelection::Automatic, "Song B"),
+            (RichPresenceSelection::App("app-a".to_owned()), "Game A"),
+        ] {
+            client.set_rich_presence_selection(selection);
+            broadcast_selected_now(&context).await;
+            let (status, activities) =
+                presence_update_command(gateway_commands.recv().await.expect("presence update"));
+            assert_eq!(status, PresenceStatus::Online);
+            assert_eq!(
+                activities,
+                vec![
+                    custom.clone(),
+                    ActivityInfo::test(ActivityKind::Playing, name)
+                ]
+            );
+        }
 
         // A pinned app that is gone falls back to the latest remaining one.
         client.set_rich_presence_selection(RichPresenceSelection::App("gone".to_owned()));

--- a/src/discord/rpc/protocol.rs
+++ b/src/discord/rpc/protocol.rs
@@ -71,10 +71,8 @@ pub(super) fn parse_command(payload: &[u8], client_id: &str) -> Result<Command, 
         .get("pid")
         .and_then(Value::as_i64)
         .ok_or_else(|| CommandError::invalid_payload(Some(cmd.clone()), nonce.clone()))?;
-    let raw_activity = args
-        .get("activity")
-        .cloned()
-        .ok_or_else(|| CommandError::invalid_payload(Some(cmd.clone()), nonce.clone()))?;
+    // RPC clients can clear activity by omitting this optional field.
+    let raw_activity = args.get("activity").cloned().unwrap_or(Value::Null);
     let activity = match &raw_activity {
         Value::Null => None,
         Value::Object(_) => Some(Box::new(
@@ -329,16 +327,19 @@ mod tests {
     }
 
     #[test]
-    fn parse_command_treats_null_activity_as_clear() {
-        let payload = json!({
-            "cmd": "SET_ACTIVITY",
-            "args": { "pid": 1, "activity": null }
-        })
-        .to_string();
+    fn parse_command_treats_null_or_omitted_activity_as_clear() {
+        for args in [
+            json!({ "pid": 1, "activity": null }),
+            json!({ "pid": 1 }),
+            json!({ "pid": 0 }),
+        ] {
+            let payload = json!({ "cmd": "SET_ACTIVITY", "args": args }).to_string();
 
-        let command = parse_command(payload.as_bytes(), "999").expect("command parses");
-        let Command::SetActivity { activity, .. } = command;
-        assert!(activity.is_none());
+            let command = parse_command(payload.as_bytes(), "999").expect("command parses");
+            let Command::SetActivity { activity, echo, .. } = command;
+            assert!(activity.is_none());
+            assert!(echo.is_null());
+        }
     }
 
     #[test]

--- a/src/discord/rpc/registry.rs
+++ b/src/discord/rpc/registry.rs
@@ -14,14 +14,25 @@ pub(super) struct ActivityRegistry {
 }
 
 impl ActivityRegistry {
-    pub(super) fn set(&mut self, client_id: String, pid: i64, activity: ActivityInfo) {
+    pub(super) fn set(&mut self, client_id: String, pid: i64, activity: ActivityInfo) -> u64 {
         let sequence = self.next_sequence;
         self.next_sequence = sequence.saturating_add(1);
         self.entries.insert((client_id, pid), (activity, sequence));
+        sequence
     }
 
     pub(super) fn clear(&mut self, client_id: &str, pid: i64) {
         self.entries.remove(&(client_id.to_owned(), pid));
+    }
+
+    pub(super) fn clear_if_current(&mut self, client_id: &str, pid: i64, sequence: u64) {
+        if self
+            .entries
+            .get(&(client_id.to_owned(), pid))
+            .is_some_and(|(_, current)| *current == sequence)
+        {
+            self.clear(client_id, pid);
+        }
     }
 
     /// All activities, most recently updated first. Also drives the UI picker
@@ -162,6 +173,21 @@ mod tests {
         );
 
         registry.clear("game", 2);
+        assert!(registry.latest_activity().is_none());
+    }
+
+    #[test]
+    fn stale_connection_cleanup_keeps_the_reconnected_activity() {
+        let mut registry = ActivityRegistry::default();
+        let old = registry.set("app".to_owned(), 1, ActivityInfo::playing("Old activity"));
+        let new = registry.set("app".to_owned(), 1, ActivityInfo::playing("New activity"));
+
+        registry.clear_if_current("app", 1, old);
+        assert_eq!(
+            registry.latest_activity(),
+            Some(ActivityInfo::playing("New activity"))
+        );
+        registry.clear_if_current("app", 1, new);
         assert!(registry.latest_activity().is_none());
     }
 }

--- a/src/discord/rpc/registry.rs
+++ b/src/discord/rpc/registry.rs
@@ -4,30 +4,48 @@ use crate::discord::ActivityInfo;
 
 type ActivityKey = (String, i64);
 
+/// Monotonic counter stamping each `set` so the most recently updated entry
+/// (the one the native client would display) can be found later.
 #[derive(Default)]
 pub(super) struct ActivityRegistry {
     // BTreeMap keeps broadcast order stable across changes.
-    entries: BTreeMap<ActivityKey, ActivityInfo>,
+    entries: BTreeMap<ActivityKey, (ActivityInfo, u64)>,
+    next_sequence: u64,
 }
 
 impl ActivityRegistry {
     pub(super) fn set(&mut self, client_id: String, pid: i64, activity: ActivityInfo) {
-        self.entries.insert((client_id, pid), activity);
+        let sequence = self.next_sequence;
+        self.next_sequence = sequence.saturating_add(1);
+        self.entries.insert((client_id, pid), (activity, sequence));
     }
 
     pub(super) fn clear(&mut self, client_id: &str, pid: i64) {
         self.entries.remove(&(client_id.to_owned(), pid));
     }
 
+    /// All activities, most recently updated first. Also drives the UI picker
+    /// order, so the top entry is what automatic mode would broadcast.
     pub(super) fn activities(&self) -> Vec<ActivityInfo> {
-        self.entries.values().cloned().collect()
+        let mut entries: Vec<(ActivityInfo, u64)> = self.entries.values().cloned().collect();
+        entries.sort_by(|(_, a), (_, b)| b.cmp(a));
+        entries.into_iter().map(|(activity, _)| activity).collect()
     }
 
     pub(super) fn activity_for_client(&self, client_id: &str) -> Option<ActivityInfo> {
         self.entries
             .iter()
             .find(|((id, _pid), _)| id == client_id)
-            .map(|(_, activity)| activity.clone())
+            .map(|(_, (activity, _))| activity.clone())
+    }
+
+    /// The most recently updated activity across all connected apps, matching
+    /// the native client's last-writer-wins behavior.
+    pub(super) fn latest_activity(&self) -> Option<ActivityInfo> {
+        self.entries
+            .iter()
+            .max_by_key(|(_, (_, sequence))| *sequence)
+            .map(|(_, (activity, _))| activity.clone())
     }
 }
 
@@ -55,7 +73,8 @@ mod tests {
             .iter()
             .map(|activity| activity.name.as_str())
             .collect();
-        assert_eq!(names, ["Game A", "Song B"]);
+        // Most recently updated first.
+        assert_eq!(names, ["Song B", "Game A"]);
 
         registry.set(
             "app-a".to_owned(),
@@ -99,5 +118,50 @@ mod tests {
         );
 
         assert!(registry.activity_for_client("unknown").is_none());
+    }
+
+    #[test]
+    fn latest_activity_returns_most_recent_update() {
+        let mut registry = ActivityRegistry::default();
+        registry.set(
+            "vscode".to_owned(),
+            1,
+            ActivityInfo::test(ActivityKind::Playing, "Editing a.rs"),
+        );
+        assert_eq!(
+            registry.latest_activity().map(|activity| activity.name),
+            Some("Editing a.rs".to_owned())
+        );
+
+        registry.set(
+            "game".to_owned(),
+            2,
+            ActivityInfo::test(ActivityKind::Playing, "Epic Game"),
+        );
+        assert_eq!(
+            registry.latest_activity().map(|activity| activity.name),
+            Some("Epic Game".to_owned())
+        );
+
+        // Re-updating an older entry makes it the most recent again.
+        registry.set(
+            "vscode".to_owned(),
+            1,
+            ActivityInfo::test(ActivityKind::Playing, "Editing b.rs"),
+        );
+        assert_eq!(
+            registry.latest_activity().map(|activity| activity.name),
+            Some("Editing b.rs".to_owned())
+        );
+
+        // Clearing the latest entry falls back to the next most recent.
+        registry.clear("vscode", 1);
+        assert_eq!(
+            registry.latest_activity().map(|activity| activity.name),
+            Some("Epic Game".to_owned())
+        );
+
+        registry.clear("game", 2);
+        assert!(registry.latest_activity().is_none());
     }
 }

--- a/src/discord/state.rs
+++ b/src/discord/state.rs
@@ -590,8 +590,9 @@ impl DiscordState {
             | AppEvent::InboxRecentMentionDeleteFailed { .. }
             | AppEvent::InboxChannelMessagesLoaded { .. }
             | AppEvent::InboxChannelMessagesLoadFailed { .. } => {}
-            // Detected Rich Presence is UI-only. It does not mutate the shared cache.
-            AppEvent::RichPresenceDetected { .. } => {}
+            // Detected Rich Presence and its warnings are UI-only. They do not
+            // mutate the shared cache.
+            AppEvent::RichPresenceDetected { .. } | AppEvent::RichPresenceWarning { .. } => {}
             AppEvent::MessageHistoryLoadFailed { .. } => {}
             AppEvent::MessageSearchLoadFailed { .. } => {}
             AppEvent::MessageUpdateDispatch { update } => {

--- a/src/discord/state.rs
+++ b/src/discord/state.rs
@@ -783,6 +783,8 @@ impl DiscordState {
                 if guild_id.is_none() {
                     self.update_user_activities(user_id, &presence.activities);
                     if self.session.current_user_id == Some(user_id) {
+                        self.session_mut().current_user_session_status =
+                            (status != PresenceStatus::Unknown).then_some(status);
                         self.update_cached_guild_activities_for_user(user_id, &presence.activities);
                     }
                     self.update_cached_guild_presence_for_user(user_id, status);
@@ -884,6 +886,7 @@ impl DiscordState {
                 *is_bot,
             ),
             AppEvent::Ready { user, user_id } => {
+                self.session_mut().current_user_session_status = None;
                 self.session_mut().current_user = Some(user.clone());
                 if let Some(user_id) = user_id {
                     self.session_mut().current_user_id = Some(*user_id);

--- a/src/discord/state/caches.rs
+++ b/src/discord/state/caches.rs
@@ -146,6 +146,9 @@ pub(in crate::discord) struct SessionState {
     /// and consulted by `can_view_channel` to look up our own roles and
     /// match member-level permission overwrites.
     pub(in crate::discord) current_user_id: Option<Id<UserMarker>>,
+    /// Guild presence can arrive before READY's own session presence. Do not
+    /// publish local activities until the user's actual status is known.
+    pub(in crate::discord) current_user_session_status: Option<PresenceStatus>,
     pub(in crate::discord) current_user: Option<String>,
     pub(in crate::discord) current_user_premium_tier: Option<PremiumTier>,
     pub(in crate::discord) current_user_email_verified: Option<bool>,

--- a/src/tui/input/tests.rs
+++ b/src/tui/input/tests.rs
@@ -33,8 +33,9 @@ use crate::{
         GuildMemberListOperation, GuildMemberListUpdateInfo, GuildNotificationSettingsInfo,
         MemberInfo, MessageInfo, MessageReferenceInfo, MessageSnapshotInfo,
         MicrophoneSensitivityDb, NotificationLevel, PollAnswerInfo, PollInfo, PresenceEventFields,
-        PresenceStatus, ReactionEmoji, ReactionUserInfo, ReadStateInfo, RoleInfo,
-        UserGuildSettingsInfo, UserSettingsInfo, VoiceConnectionStatus, VoiceVolumePercent,
+        PresenceStatus, ReactionEmoji, ReactionUserInfo, ReadStateInfo, RichPresenceSelection,
+        RoleInfo, UserGuildSettingsInfo, UserSettingsInfo, VoiceConnectionStatus,
+        VoiceVolumePercent,
     },
     tui::state::{
         ChannelPaneEntry, DashboardState, FocusPane, GuildPaneEntry, MessageActionKind,

--- a/src/tui/input/tests/misc.rs
+++ b/src/tui/input/tests/misc.rs
@@ -189,6 +189,8 @@ fn profile_activity_edit_enter_dispatches_presence_update() {
     handle_key(&mut state, char_key('j'));
     handle_key(&mut state, char_key('j'));
     handle_key(&mut state, key(KeyCode::Enter));
+    // Move past the automatic row onto the manual row before committing.
+    handle_key(&mut state, char_key('j'));
     handle_key(&mut state, key(KeyCode::Enter));
 
     for value in "Concord".chars() {
@@ -200,9 +202,51 @@ fn profile_activity_edit_enter_dispatches_presence_update() {
         Some(AppCommand::UpdateCurrentUserActivity {
             status: PresenceStatus::Online,
             activities: vec![ActivityInfo::playing("Concord")],
-            track_client_id: None,
+            rich_presence: RichPresenceSelection::Manual,
         })
     );
+}
+
+#[test]
+fn profile_activity_picker_enter_defaults_to_automatic() {
+    let mut state = DashboardState::new();
+    let user_id = Id::new(10);
+    state.push_event(AppEvent::Ready {
+        user: "neo".to_owned(),
+        user_id: Some(user_id),
+    });
+    state.push_event(AppEvent::PresenceUpdate {
+        guild_id: None,
+        presence: crate::discord::PresenceEventFields {
+            user_id,
+            status: PresenceStatus::Online,
+            activities: Vec::new(),
+        },
+    });
+    state.set_detected_rich_presence(vec![ActivityInfo {
+        application_id: Some("client-1".to_owned()),
+        ..ActivityInfo::playing("Visual Studio Code")
+    }]);
+    state.open_current_user_profile_popup();
+    for _ in 0..4 {
+        handle_key(&mut state, char_key('j'));
+    }
+    handle_key(&mut state, key(KeyCode::Enter));
+
+    // The picker opens on the automatic row, so Enter relays the latest
+    // detected app without further navigation.
+    assert_eq!(
+        handle_key(&mut state, key(KeyCode::Enter)),
+        Some(AppCommand::UpdateCurrentUserActivity {
+            status: PresenceStatus::Online,
+            activities: vec![ActivityInfo {
+                application_id: Some("client-1".to_owned()),
+                ..ActivityInfo::playing("Visual Studio Code")
+            }],
+            rich_presence: RichPresenceSelection::Automatic,
+        })
+    );
+    assert!(!state.is_user_profile_activity_picker_open());
 }
 
 #[test]

--- a/src/tui/state/events.rs
+++ b/src/tui/state/events.rs
@@ -167,6 +167,10 @@ impl DashboardState {
                 self.runtime.gateway_error = Some(message.clone());
                 self.show_error_toast(message, Instant::now());
             }
+            AppEvent::RichPresenceWarning { message } => {
+                logging::error("tui", message);
+                self.show_error_toast(message, Instant::now());
+            }
             AppEvent::CaptchaRequired { action } => {
                 self.show_captcha_toast(
                     format!(

--- a/src/tui/state/popups/mod.rs
+++ b/src/tui/state/popups/mod.rs
@@ -2153,7 +2153,7 @@ impl DashboardState {
                     .settings
                     .activity_picker
                     .as_ref()?;
-                (selection, self.detected_rich_presence().len() + 1)
+                (selection, self.detected_rich_presence().len() + 2)
             }
             SelectablePopupTarget::EmojiReactions => {
                 let selection = &self.popups.emoji_reaction_picker()?.selection;
@@ -2396,7 +2396,7 @@ impl DashboardState {
                 }
             }
             SelectablePopupTarget::UserProfileActivity => {
-                let len = self.detected_rich_presence().len() + 1;
+                let len = self.detected_rich_presence().len() + 2;
                 if let Some(selection) = self
                     .popups
                     .user_profile_popup_mut()

--- a/src/tui/state/popups/user.rs
+++ b/src/tui/state/popups/user.rs
@@ -656,8 +656,15 @@ impl DashboardState {
         let detected = self.detected_rich_presence();
         let len = detected.len() + 2;
         let selected = picker.selected_for_len(len);
-        let mut rows: Vec<(String, bool)> =
-            vec![(AUTOMATIC_ACTIVITY_PICKER_LABEL.to_owned(), selected == 0)];
+        // Surface what automatic mode is currently relaying so detection is
+        // visible without opening the picker's other rows.
+        let automatic_label = match detected.first() {
+            Some(latest) if !latest.name.trim().is_empty() => {
+                format!("{AUTOMATIC_ACTIVITY_PICKER_LABEL} — {}", latest.name.trim())
+            }
+            _ => AUTOMATIC_ACTIVITY_PICKER_LABEL.to_owned(),
+        };
+        let mut rows: Vec<(String, bool)> = vec![(automatic_label, selected == 0)];
         rows.extend(
             detected
                 .iter()

--- a/src/tui/state/popups/user.rs
+++ b/src/tui/state/popups/user.rs
@@ -606,6 +606,7 @@ impl DashboardState {
             let activities = detected.first().cloned().into_iter().collect();
             if let Some(popup) = self.popups.user_profile_popup_mut() {
                 popup.settings.activity_picker = None;
+                popup.settings.manual_activity = None;
                 popup.pending_scroll_reveal = true;
             }
             return Some(AppCommand::UpdateCurrentUserActivity {

--- a/src/tui/state/popups/user.rs
+++ b/src/tui/state/popups/user.rs
@@ -277,8 +277,11 @@ impl DashboardState {
                 .cache
                 .user_activities(user_id)
                 .iter()
+                // Any non-custom activity is a presence worth showing here,
+                // including RPC-relayed ones whose kind is not `Playing`
+                // (e.g. music bridges send `Listening`).
                 .find(|activity| {
-                    activity.kind == ActivityKind::Playing && !activity.name.trim().is_empty()
+                    activity.kind != ActivityKind::Custom && !activity.name.trim().is_empty()
                 })
                 .map(|activity| activity.name.clone())
         })

--- a/src/tui/state/popups/user.rs
+++ b/src/tui/state/popups/user.rs
@@ -4,8 +4,8 @@ use crate::discord::ids::{
 };
 use crate::discord::{
     ActivityInfo, ActivityKind, AppCommand, GlobalUserProfileUpdate, GuildUserProfileUpdate,
-    MessageAttachmentUpload, PresenceStatus, ProfileAvatarUpload, RoleState, UserProfileInfo,
-    UserProfileUpdate,
+    MessageAttachmentUpload, PresenceStatus, ProfileAvatarUpload, RichPresenceSelection, RoleState,
+    UserProfileInfo, UserProfileUpdate,
 };
 use crate::tui::keybindings::{KeyChord, SelectionAction};
 use crate::tui::text_input::TextEditAction;
@@ -448,12 +448,12 @@ impl DashboardState {
             if field == UserProfileSettingsField::ManualActivity {
                 let status = self.user_profile_settings_presence_status();
                 let activities = self.user_profile_settings_manual_activities();
-                // track_client_id None: a manually-typed activity is not tracked,
-                // so RPC updates must not override it.
+                // A manually-typed activity is owned by the user, so RPC
+                // updates must not override it.
                 return Some(AppCommand::UpdateCurrentUserActivity {
                     status,
                     activities,
-                    track_client_id: None,
+                    rich_presence: RichPresenceSelection::Manual,
                 });
             }
             return None;
@@ -588,16 +588,38 @@ impl DashboardState {
             return None;
         }
         let detected = self.detected_rich_presence().to_vec();
-        let len = detected.len() + 1;
+        let len = detected.len() + 2;
         let selected = {
             let popup = self.popups.user_profile_popup()?;
             let picker = popup.settings.activity_picker.as_ref()?;
             picker.selected_for_len(len)
         };
 
-        if let Some(activity) = detected.get(selected).cloned() {
+        if selected == 0 {
+            // Automatic: relay the most recent app, like the native client.
+            // `detected` is ordered most recent first, matching what the RPC
+            // server broadcasts.
             let status = self.user_profile_settings_presence_status();
-            let track_client_id = activity.application_id.clone();
+            let activities = detected.first().cloned().into_iter().collect();
+            if let Some(popup) = self.popups.user_profile_popup_mut() {
+                popup.settings.activity_picker = None;
+                popup.pending_scroll_reveal = true;
+            }
+            return Some(AppCommand::UpdateCurrentUserActivity {
+                status,
+                activities,
+                rich_presence: RichPresenceSelection::Automatic,
+            });
+        }
+
+        if let Some(activity) = detected.get(selected - 1).cloned() {
+            let status = self.user_profile_settings_presence_status();
+            // RPC activities always carry the handshake `client_id` here; a
+            // missing one falls back to manual so nothing is silently pinned.
+            let rich_presence = match activity.application_id.clone() {
+                Some(client_id) => RichPresenceSelection::App(client_id),
+                None => RichPresenceSelection::Manual,
+            };
             if let Some(popup) = self.popups.user_profile_popup_mut() {
                 popup.settings.activity_picker = None;
                 popup.settings.manual_activity = Some(activity.name.clone());
@@ -606,7 +628,7 @@ impl DashboardState {
             return Some(AppCommand::UpdateCurrentUserActivity {
                 status,
                 activities: vec![activity],
-                track_client_id,
+                rich_presence,
             });
         }
 
@@ -629,17 +651,17 @@ impl DashboardState {
             return Vec::new();
         };
         let detected = self.detected_rich_presence();
-        let len = detected.len() + 1;
+        let len = detected.len() + 2;
         let selected = picker.selected_for_len(len);
-        let mut rows: Vec<(String, bool)> = detected
-            .iter()
-            .enumerate()
-            .map(|(index, activity)| (activity_picker_label(activity), index == selected))
-            .collect();
-        rows.push((
-            MANUAL_ACTIVITY_PICKER_LABEL.to_owned(),
-            selected == detected.len(),
-        ));
+        let mut rows: Vec<(String, bool)> =
+            vec![(AUTOMATIC_ACTIVITY_PICKER_LABEL.to_owned(), selected == 0)];
+        rows.extend(
+            detected
+                .iter()
+                .enumerate()
+                .map(|(index, activity)| (activity_picker_label(activity), index + 1 == selected)),
+        );
+        rows.push((MANUAL_ACTIVITY_PICKER_LABEL.to_owned(), selected + 1 == len));
         rows
     }
 
@@ -940,6 +962,7 @@ impl DashboardState {
     }
 }
 
+const AUTOMATIC_ACTIVITY_PICKER_LABEL: &str = "Automatic (most recent app)";
 const MANUAL_ACTIVITY_PICKER_LABEL: &str = "Set manually…";
 
 fn manual_activity_from_text(value: &str) -> Vec<ActivityInfo> {

--- a/src/tui/state/tests/profiles.rs
+++ b/src/tui/state/tests/profiles.rs
@@ -464,6 +464,72 @@ fn profile_settings_activity_manual_entry_dispatches_presence_update() {
 }
 
 #[test]
+fn profile_settings_automatic_activity_follows_live_updates_while_open() {
+    let user_id = Id::new(10);
+    let mut state = DashboardState::new();
+    state.push_event(AppEvent::Ready {
+        user: "neo".to_owned(),
+        user_id: Some(user_id),
+    });
+    state.push_event(AppEvent::PresenceUpdate {
+        guild_id: None,
+        presence: crate::discord::PresenceEventFields {
+            user_id,
+            status: PresenceStatus::Online,
+            activities: Vec::new(),
+        },
+    });
+    state.open_current_user_profile_popup();
+    for _ in 0..4 {
+        state.next_user_profile_settings_field();
+    }
+
+    // First choose a manual activity so the popup holds a local draft value.
+    assert_eq!(state.start_or_commit_user_profile_edit(), None);
+    state.move_user_profile_activity_picker_down();
+    assert_eq!(state.activate_user_profile_activity_picker(), None);
+    state.insert_user_profile_edit_text("Concord");
+    assert_eq!(
+        state.start_or_commit_user_profile_edit(),
+        Some(AppCommand::UpdateCurrentUserActivity {
+            status: PresenceStatus::Online,
+            activities: vec![ActivityInfo::playing("Concord")],
+            rich_presence: RichPresenceSelection::Manual,
+        })
+    );
+
+    let detected = ActivityInfo {
+        application_id: Some("client-123".to_owned()),
+        ..ActivityInfo::playing("Visual Studio Code")
+    };
+    state.set_detected_rich_presence(vec![detected.clone()]);
+    assert_eq!(state.start_or_commit_user_profile_edit(), None);
+    assert_eq!(
+        state.activate_user_profile_activity_picker(),
+        Some(AppCommand::UpdateCurrentUserActivity {
+            status: PresenceStatus::Online,
+            activities: vec![detected],
+            rich_presence: RichPresenceSelection::Automatic,
+        })
+    );
+
+    state.push_event(AppEvent::PresenceUpdate {
+        guild_id: None,
+        presence: crate::discord::PresenceEventFields {
+            user_id,
+            status: PresenceStatus::Online,
+            activities: vec![ActivityInfo::playing("A New Game")],
+        },
+    });
+
+    assert_eq!(
+        state.user_profile_settings_field_value(UserProfileSettingsField::ManualActivity),
+        "A New Game",
+        "automatic mode should follow live activity updates without reopening the profile"
+    );
+}
+
+#[test]
 fn profile_settings_activity_picker_selects_detected_app() {
     let user_id = Id::new(10);
     let mut state = DashboardState::new();

--- a/src/tui/state/tests/profiles.rs
+++ b/src/tui/state/tests/profiles.rs
@@ -4,7 +4,7 @@ use crate::discord::test_builders::{
 };
 use crate::discord::{
     ActivityInfo, AppCommand, GlobalUserProfileUpdate, GuildUserProfileUpdate,
-    MessageAttachmentUpload, ProfileAvatarUpload, UserProfileUpdate,
+    MessageAttachmentUpload, ProfileAvatarUpload, RichPresenceSelection, UserProfileUpdate,
 };
 use crate::tui::state::UserProfileSettingsField;
 use crate::tui::text_input::TextEditAction;
@@ -440,6 +440,8 @@ fn profile_settings_activity_manual_entry_dispatches_presence_update() {
 
     assert_eq!(state.start_or_commit_user_profile_edit(), None);
     assert!(state.is_user_profile_activity_picker_open());
+    // The picker defaults to automatic; move down to the manual row.
+    state.move_user_profile_activity_picker_down();
     assert_eq!(state.activate_user_profile_activity_picker(), None);
     assert!(!state.is_user_profile_activity_picker_open());
     assert_eq!(
@@ -456,7 +458,7 @@ fn profile_settings_activity_manual_entry_dispatches_presence_update() {
         Some(AppCommand::UpdateCurrentUserActivity {
             status: PresenceStatus::Online,
             activities: vec![ActivityInfo::playing("Concord")],
-            track_client_id: None,
+            rich_presence: RichPresenceSelection::Manual,
         })
     );
 }
@@ -489,16 +491,33 @@ fn profile_settings_activity_picker_selects_detected_app() {
 
     assert_eq!(state.start_or_commit_user_profile_edit(), None);
     let rows = state.user_profile_activity_picker_rows();
-    assert_eq!(rows.len(), 2);
-    assert_eq!(rows[0].0, "Visual Studio Code");
-    assert!(rows[0].1, "detected app is selected first");
+    assert_eq!(rows.len(), 3);
+    assert_eq!(rows[0].0, "Automatic (most recent app)");
+    assert_eq!(rows[1].0, "Visual Studio Code");
+    assert_eq!(rows[2].0, "Set manually…");
+    assert!(rows[0].1, "automatic is selected first");
 
+    // Automatic relays the most recently detected app, like the native client.
+    assert_eq!(
+        state.activate_user_profile_activity_picker(),
+        Some(AppCommand::UpdateCurrentUserActivity {
+            status: PresenceStatus::Online,
+            activities: vec![detected.clone()],
+            rich_presence: RichPresenceSelection::Automatic,
+        })
+    );
+    assert!(!state.is_user_profile_activity_picker_open());
+
+    // Pinning the app keeps relaying exactly that app.
+    assert_eq!(state.start_or_commit_user_profile_edit(), None);
+    assert!(state.is_user_profile_activity_picker_open());
+    state.move_user_profile_activity_picker_down();
     assert_eq!(
         state.activate_user_profile_activity_picker(),
         Some(AppCommand::UpdateCurrentUserActivity {
             status: PresenceStatus::Online,
             activities: vec![detected],
-            track_client_id: Some("client-123".to_owned()),
+            rich_presence: RichPresenceSelection::App("client-123".to_owned()),
         })
     );
     assert!(!state.is_user_profile_activity_picker_open());

--- a/src/tui/state/tests/profiles.rs
+++ b/src/tui/state/tests/profiles.rs
@@ -492,7 +492,10 @@ fn profile_settings_activity_picker_selects_detected_app() {
     assert_eq!(state.start_or_commit_user_profile_edit(), None);
     let rows = state.user_profile_activity_picker_rows();
     assert_eq!(rows.len(), 3);
-    assert_eq!(rows[0].0, "Automatic (most recent app)");
+    assert_eq!(
+        rows[0].0, "Automatic (most recent app) — Visual Studio Code",
+        "the automatic row names the app it would relay"
+    );
     assert_eq!(rows[1].0, "Visual Studio Code");
     assert_eq!(rows[2].0, "Set manually…");
     assert!(rows[0].1, "automatic is selected first");

--- a/src/tui/state/tests/profiles.rs
+++ b/src/tui/state/tests/profiles.rs
@@ -524,6 +524,72 @@ fn profile_settings_activity_picker_selects_detected_app() {
 }
 
 #[test]
+fn profile_settings_activity_field_shows_non_playing_relayed_activity() {
+    // Music bridges (e.g. mprisence) relay `Listening` activities. The field
+    // must show them instead of "(not set)".
+    let user_id = Id::new(10);
+    let mut state = DashboardState::new();
+    state.push_event(AppEvent::Ready {
+        user: "neo".to_owned(),
+        user_id: Some(user_id),
+    });
+    state.push_event(AppEvent::PresenceUpdate {
+        guild_id: None,
+        presence: crate::discord::PresenceEventFields {
+            user_id,
+            status: PresenceStatus::Online,
+            activities: vec![
+                ActivityInfo::test(crate::discord::ActivityKind::Custom, "deep in thought"),
+                ActivityInfo::test(crate::discord::ActivityKind::Listening, "Spotify"),
+            ],
+        },
+    });
+    state.open_current_user_profile_popup();
+    for _ in 0..4 {
+        state.next_user_profile_settings_field();
+    }
+
+    assert_eq!(
+        state.user_profile_settings_field_value(UserProfileSettingsField::ManualActivity),
+        "Spotify",
+        "a non-playing activity still names the relayed presence"
+    );
+}
+
+#[test]
+fn profile_settings_activity_field_ignores_custom_status() {
+    // The custom status is composed alongside the relayed activity, so it must
+    // never leak into the activity field as a name.
+    let user_id = Id::new(10);
+    let mut state = DashboardState::new();
+    state.push_event(AppEvent::Ready {
+        user: "neo".to_owned(),
+        user_id: Some(user_id),
+    });
+    state.push_event(AppEvent::PresenceUpdate {
+        guild_id: None,
+        presence: crate::discord::PresenceEventFields {
+            user_id,
+            status: PresenceStatus::Online,
+            activities: vec![ActivityInfo::test(
+                crate::discord::ActivityKind::Custom,
+                "deep in thought",
+            )],
+        },
+    });
+    state.open_current_user_profile_popup();
+    for _ in 0..4 {
+        state.next_user_profile_settings_field();
+    }
+
+    assert_eq!(
+        state.user_profile_settings_field_value(UserProfileSettingsField::ManualActivity),
+        "",
+        "a custom-status-only presence leaves the activity field empty"
+    );
+}
+
+#[test]
 fn profile_settings_ignore_non_current_user_profile() {
     let mut state = DashboardState::new();
     state.push_event(AppEvent::Ready {

--- a/src/tui/state/toast.rs
+++ b/src/tui/state/toast.rs
@@ -383,6 +383,22 @@ mod tests {
     }
 
     #[test]
+    fn rich_presence_warning_event_shows_toast_without_gateway_banner() {
+        let mut state = DashboardState::new();
+
+        state.push_event(AppEvent::RichPresenceWarning {
+            message: "Another client owns discord-ipc-0".to_owned(),
+        });
+
+        let toast = state.toast_message().expect("rpc warning toast is visible");
+        assert!(toast.text.contains("discord-ipc-0"));
+        assert_eq!(toast.kind, ToastKind::Error);
+        // An RPC socket steal is not a connection failure, so the persistent
+        // gateway-error banner must stay clear.
+        assert!(state.gateway_error().is_none());
+    }
+
+    #[test]
     fn newer_toast_replaces_previous_toast() {
         let mut state = DashboardState::new();
         let now = Instant::now();


### PR DESCRIPTION
<!--
Thanks for the contribution. Please keep the subject under ~72 characters
and use a semantic prefix (feat:, fix:, refactor:, docs:, chore:, test:).

By submitting this PR you agree it will be distributed under GPL-3.0-only.
-->

## Summary

Builds on top of #239, making the Rich Presence relay automatic, matching the native Discord client, instead of requiring manual selection in profile settings.

## Why

Its very annoying to have to manually set the activity status when opening a game/other app that uses rpc. 
Related to #140 (I would say closes 140 but its already closed)

## How

- New `RichPresenceSelection { Automatic, App(id), Manual }` tri-state (default `Automatic`) on `DiscordClient`, replacing the old `Option<String>` "selected client", replacing the shared `debounce` Notify so the app layer can also trigger re-broadcasts.
- `ActivityRegistry` now stamps recency on each `SET_ACTIVITY` and exposes `latest_activity()` so that the most recently updated app wins, like the native discord app.
- `broadcast_selected_now` relays: Automatic → latest activity; a pinned app falls back to the latest remaining one when it disconnects; Manual never broadcasts. The user's custom status is composed alongside the relayed activity, and survives when the game activity clears.

## Testing

<!-- How you verified the change. Mention the OS, terminal, and graphics protocol used for manual checks. -->

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] Manual test in a real terminal (describe below)

Tested in ghostty on linux, using mpisence to test rpc.

## Screenshots or recordings
<img width="739" height="670" alt="image" src="https://github.com/user-attachments/assets/5ec3a6b8-5919-49d3-b215-180a87adcb27" />


## Checklist

- [x] One logical change per PR.
- [x] Link a related issue.
- [x] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [x] Change does not add self-bot automation, mass actions, or scraping.
- [x] Updated `README.md`, if behavior or workflows changed.
