### PR TITLE
fix(tui): Fix filtered channel highlight restoration after background…

### DIFF
--- a/src/tui/state/channels.rs
+++ b/src/tui/state/channels.rs
@@ -1172,18 +1172,32 @@ impl DashboardState {
     }
 
     pub(super) fn restore_channel_cursor(&mut self, channel_id: Option<Id<ChannelMarker>>) {
-        self.restore_channel_pane_cursor(channel_id.map(ChannelPaneCursor::Channel));
+        let Some(channel_id) = channel_id else {
+            return;
+        };
+        let cursor = ChannelPaneCursor::Channel(channel_id);
+        // Explicit navigation can target a channel that does not match an active
+        // pane filter, so resolve it against the complete channel tree.
+        let index = self
+            .channel_pane_entries()
+            .iter()
+            .position(|entry| entry.cursor() == cursor);
+        if let Some(index) = index {
+            self.navigation.channels.list.selected = index;
+        }
     }
 
     pub(super) fn restore_channel_pane_cursor(&mut self, cursor: Option<ChannelPaneCursor>) {
         let Some(cursor) = cursor else {
             return;
         };
-        if let Some(index) = self
-            .channel_pane_entries()
+        // Event repair preserves the highlighted row from the rendered pane.
+        // Its index must come from the same filtered entries as the captured cursor.
+        let index = self
+            .channel_pane_filtered_entries()
             .iter()
-            .position(|entry| entry.cursor() == cursor)
-        {
+            .position(|entry| entry.cursor() == cursor);
+        if let Some(index) = index {
             self.navigation.channels.list.selected = index;
         }
     }

--- a/src/tui/state/tests/panes.rs
+++ b/src/tui/state/tests/panes.rs
@@ -355,6 +355,53 @@ fn channel_tree_groups_category_children() {
 }
 
 #[test]
+fn channel_filter_preserves_highlight_across_background_events() {
+    let guild_id = Id::new(1);
+    let category_id = Id::new(10);
+    let highlighted_channel_id = Id::new(11);
+    let mut state = DashboardState::new();
+    state.push_event(guild_create_event(
+        guild_id,
+        "guild",
+        vec![
+            category_channel_info(guild_id, category_id, "Text Channels", 0),
+            child_text_channel_info(
+                guild_id,
+                highlighted_channel_id,
+                category_id,
+                "alpha-one",
+                0,
+            ),
+            child_text_channel_info(guild_id, Id::new(12), category_id, "general", 1),
+            child_text_channel_info(guild_id, Id::new(13), category_id, "alpha-two", 2),
+        ],
+    ));
+    state.activate_guild(ActiveGuildScope::Guild(guild_id));
+    state.open_channel_pane_filter();
+    for value in "alpha".chars() {
+        state.push_channel_pane_filter_char(value);
+    }
+
+    assert_eq!(
+        state
+            .selected_channel_pane_entry()
+            .and_then(|entry| entry.channel_id()),
+        Some(highlighted_channel_id)
+    );
+
+    state.push_event(AppEvent::CurrentUserCapabilities {
+        premium_tier: PremiumTier::None,
+    });
+
+    assert_eq!(
+        state
+            .selected_channel_pane_entry()
+            .and_then(|entry| entry.channel_id()),
+        Some(highlighted_channel_id)
+    );
+}
+
+#[test]
 fn channel_tree_keeps_empty_categories_for_channel_managers() {
     let current_user_id = Id::new(99);
     let manager_role_id = Id::new(50);


### PR DESCRIPTION
… events

<!--
Thanks for the contribution. Please keep the subject under ~72 characters
and use a semantic prefix (feat:, fix:, refactor:, docs:, chore:, test:).

By submitting this PR you agree it will be distributed under GPL-3.0-only.
-->

## Summary

<!-- What does this change do, in one or two sentences? -->

## Why

fixes #355 

## How

<!-- Notable implementation choices and any non-obvious trade-offs. -->

## Testing

<!-- How you verified the change. Mention the OS, terminal, and graphics protocol used for manual checks. -->

- [ ] `cargo fmt --all --check`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo test --all-features`
- [ ] Manual test in a real terminal (describe below)

## Screenshots or recordings

<!-- For UI changes, attach a screenshot or asciinema/gif. Delete this section if not applicable. -->

## Checklist

- [ ] One logical change per PR.
- [ ] Link a related issue.
- [ ] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [ ] Change does not add self-bot automation, mass actions, or scraping.
- [ ] Updated `README.md`, if behavior or workflows changed.
