### PR TITLE
fix(voice): Replace adaptive mic recovery with fixed platfor buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,10 +436,11 @@ push_to_talk_shortcut = "F8"
 noise_suppression = true
 
 # Optional microphone capture buffer duration in milliseconds, from 10 to 60.
-# When omitted, Concord accepts a sane host default and replaces an excessive
-# negotiated buffer with bounded 40ms or 60ms fixed attempts.
-# Setting a value forces that fixed duration and disables automatic recovery.
-# microphone_buffer_ms = 40
+# When omitted, Concord requests 50ms on Linux and 10ms on other platforms,
+# clamped to the device's supported range. It uses the host default only when
+# the range is unknown or the platform fixed buffer cannot be opened.
+# Setting a value forces that fixed duration.
+# microphone_buffer_ms = 50
 
 # Voice activity threshold in dB. Lower values transmit quieter input.
 microphone_sensitivity = -30

--- a/src/discord/voice.rs
+++ b/src/discord/voice.rs
@@ -110,7 +110,7 @@ use cpal::traits::{DeviceTrait, StreamTrait};
 use futures::{SinkExt, StreamExt};
 use serde_json::{Value, json};
 #[cfg(feature = "voice-playback")]
-use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU8, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
 #[cfg(feature = "voice-playback")]
 use std::sync::{Condvar, Mutex as StdMutex};
 use tokio::{
@@ -199,30 +199,11 @@ const VOICE_MIC_PCM_FRAME_QUEUE: usize = 16;
 #[cfg(feature = "voice-playback")]
 const VOICE_MIC_MAX_LIVE_FRAMES: usize = 3;
 #[cfg(feature = "voice-playback")]
-const VOICE_MIC_TARGET_BUFFER_DURATION: Duration = Duration::from_millis(40);
-#[cfg(feature = "voice-playback")]
-const VOICE_MIC_MAX_BUFFER_DURATION: Duration = Duration::from_millis(60);
-const VOICE_MIC_HEALTH_SWEEP_INTERVAL: Duration = Duration::from_millis(500);
-#[cfg(feature = "voice-playback")]
-const VOICE_MIC_UNHEALTHY_CALLBACK_THRESHOLD: u8 = 3;
-#[cfg(feature = "voice-playback")]
-const VOICE_MIC_UNHEALTHY_CALLBACK_WINDOW: Duration = Duration::from_secs(5);
-#[cfg(feature = "voice-playback")]
-const VOICE_MIC_CALLBACK_GAP_FLOOR: Duration = Duration::from_millis(200);
-#[cfg(feature = "voice-playback")]
-const VOICE_MIC_CAPTURE_DELIVERY_BUDGET: Duration = Duration::from_millis(50);
-#[cfg(feature = "voice-playback")]
-const VOICE_MIC_TRANSMIT_WAIT_BUDGET: Duration = DISCORD_OPUS_FRAME_DURATION;
-#[cfg(feature = "voice-playback")]
-const VOICE_MIC_PROCESSING_BUDGET: Duration = Duration::from_millis(10);
-#[cfg(feature = "voice-playback")]
-const VOICE_MIC_MAX_FRAME_AGE: Duration = VOICE_MIC_CAPTURE_DELIVERY_BUDGET
-    .saturating_add(VOICE_MIC_TRANSMIT_WAIT_BUDGET)
-    .saturating_add(VOICE_MIC_PROCESSING_BUDGET);
-#[cfg(feature = "voice-playback")]
-const VOICE_MIC_RECOVERY_MAX_FAILED_SWEEPS: u8 = 3;
-#[cfg(feature = "voice-playback")]
-const VOICE_MIC_RECOVERY_COOLDOWN: Duration = Duration::from_secs(5);
+const VOICE_MIC_MAX_FRAME_AGE: Duration = Duration::from_millis(80);
+#[cfg(all(feature = "voice-playback", target_os = "linux"))]
+const VOICE_MIC_AUTOMATIC_CALLBACKS_PER_SECOND: u32 = 20;
+#[cfg(all(feature = "voice-playback", not(target_os = "linux")))]
+const VOICE_MIC_AUTOMATIC_CALLBACKS_PER_SECOND: u32 = 100;
 #[cfg(feature = "voice-playback")]
 const VOICE_TRANSMIT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
 #[cfg(feature = "voice-playback")]
@@ -905,8 +886,6 @@ struct VoiceMicrophoneCapture {
     _stream: cpal::Stream,
     _processor: VoiceMicrophoneInputProcessor,
     stats: Arc<VoiceMicrophoneCaptureStats>,
-    buffer_mode: VoiceMicrophoneBufferMode,
-    recovery: VoiceMicrophoneRecoveryState,
 }
 
 #[cfg(feature = "voice-playback")]
@@ -929,15 +908,7 @@ struct VoiceMicrophoneInputProcessor {
 struct VoiceMicrophoneInputChunk<T> {
     samples: Vec<T>,
     captured_at: Instant,
-    timing: VoiceMicrophoneCaptureTiming,
-}
-
-#[cfg(feature = "voice-playback")]
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-struct VoiceMicrophoneCaptureTiming {
     input_dropped: bool,
-    timeline_adjustment_us: i64,
-    callback_unhealthy: bool,
 }
 
 #[cfg(feature = "voice-playback")]
@@ -956,17 +927,9 @@ struct VoiceMicrophoneInputHandoffState<T> {
 #[cfg(feature = "voice-playback")]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum VoiceMicrophoneBufferMode {
-    HostDefault,
-    AutomaticFixed(MicrophoneBufferMs),
+    PlatformFixed,
     UserFixed(MicrophoneBufferMs),
-}
-
-#[cfg(feature = "voice-playback")]
-#[derive(Default)]
-struct VoiceMicrophoneRecoveryState {
-    failed_sweeps: u8,
-    retry_not_before: Option<Instant>,
-    exhausted: bool,
+    HostDefaultFallback,
 }
 
 #[cfg(feature = "voice-playback")]
@@ -1003,13 +966,8 @@ struct VoiceMicrophoneCaptureStats {
     callback_handoff_drops: AtomicU64,
     stream_errors: AtomicU64,
     stream_xruns: AtomicU64,
-    last_capture_end_offset_us: AtomicI64,
-    max_capture_clock_adjustment_us: AtomicU64,
     max_capture_latency_us: AtomicU64,
     max_capture_delivery_age_us: AtomicU64,
-    unhealthy_callback_count: AtomicU8,
-    unhealthy_callback_window_started_us: AtomicU64,
-    restart_requested: AtomicBool,
 }
 
 #[cfg(feature = "voice-playback")]
@@ -1247,9 +1205,6 @@ impl VoiceChildTasks {
                     }
                 }
                 (Some(samples_tx), true, true) => {
-                    if let Some(capture) = self.microphone_capture.as_mut() {
-                        capture.reset_recovery();
-                    }
                     logging::debug(
                         "voice",
                         "starting replacement voice microphone capture for new buffer setting",
@@ -1321,74 +1276,6 @@ impl VoiceChildTasks {
         }
     }
 
-    fn maintain_microphone_capture_health(&mut self) {
-        #[cfg(feature = "voice-playback")]
-        {
-            let recovery_started_at = Instant::now();
-            let (Some(capture), Some(samples_tx)) = (
-                self.microphone_capture.as_mut(),
-                self.microphone_pcm_tx.as_ref(),
-            ) else {
-                return;
-            };
-            let candidates = capture.take_restart_buffers(recovery_started_at);
-            if candidates.is_empty() {
-                return;
-            }
-
-            let mut failures = Vec::new();
-            for next_buffer in candidates {
-                logging::debug(
-                    "voice",
-                    format!(
-                        "voice microphone callback timing is unhealthy, retrying with {}ms fixed buffer",
-                        next_buffer.value(),
-                    ),
-                );
-                match VoiceMicrophoneCapture::start_automatic_fixed(
-                    samples_tx.clone(),
-                    self.microphone_source.as_deref(),
-                    next_buffer,
-                ) {
-                    Ok(capture) => {
-                        self.microphone_capture = Some(capture);
-                        logging::debug(
-                            "voice",
-                            format!(
-                                "replaced unhealthy voice microphone capture with {}ms compatibility buffer",
-                                next_buffer.value(),
-                            ),
-                        );
-                        return;
-                    }
-                    Err(error) => failures.push(format!("{}ms: {error}", next_buffer.value())),
-                }
-            }
-            let exhausted = self
-                .microphone_capture
-                .as_mut()
-                .is_some_and(|capture| capture.record_failed_recovery(Instant::now()));
-            let retry_status = if exhausted {
-                format!(
-                    "automatic recovery exhausted after {} failed sweeps",
-                    VOICE_MIC_RECOVERY_MAX_FAILED_SWEEPS,
-                )
-            } else {
-                format!(
-                    "next retry is delayed by {}ms",
-                    VOICE_MIC_RECOVERY_COOLDOWN.as_millis(),
-                )
-            };
-            logging::error(
-                "voice",
-                format!(
-                    "voice microphone compatibility buffers failed, previous capture remains active, {retry_status}: {}",
-                    failures.join("; "),
-                ),
-            );
-        }
-    }
-
     fn set_voice_audio_sources(
         &mut self,
         sources: VoiceAudioSources,
@@ -1398,9 +1285,6 @@ impl VoiceChildTasks {
         {
             let mut errors = Vec::new();
             if self.microphone_source != sources.input {
-                if let Some(capture) = self.microphone_capture.as_mut() {
-                    capture.reset_recovery();
-                }
                 if let Some(samples_tx) = self.microphone_pcm_tx.clone()
                     && (self.microphone_capture.is_some() || capture_gate.capture_enabled)
                 {

--- a/src/discord/voice/gateway.rs
+++ b/src/discord/voice/gateway.rs
@@ -106,7 +106,6 @@ pub(super) async fn connect_voice_gateway(
     child_tasks.audio_runtime = Some(audio_runtime);
     let mut speaking_tracker = VoiceSpeakingTracker::new(session.user_id);
     let mut speaking_sweep = tokio::time::interval(VOICE_REMOTE_SPEAKING_SWEEP_INTERVAL);
-    let mut microphone_health_sweep = tokio::time::interval(VOICE_MIC_HEALTH_SWEEP_INTERVAL);
     #[cfg_attr(not(feature = "voice-playback"), allow(unused_variables))]
     let (local_speaking_tx, mut local_speaking_rx) = mpsc::unbounded_channel();
     #[cfg_attr(not(feature = "voice-playback"), allow(unused_variables))]
@@ -143,10 +142,6 @@ pub(super) async fn connect_voice_gateway(
 
     loop {
         let frame = tokio::select! {
-            _ = microphone_health_sweep.tick() => {
-                child_tasks.maintain_microphone_capture_health();
-                continue;
-            }
             audio_sources = audio_sources_rx.changed() => {
                 match audio_sources {
                     Ok(()) => {

--- a/src/discord/voice/microphone.rs
+++ b/src/discord/voice/microphone.rs
@@ -12,22 +12,10 @@ impl VoiceMicrophoneCapture {
         microphone_buffer_ms: Option<MicrophoneBufferMs>,
     ) -> Result<Self, String> {
         let buffer_mode = microphone_buffer_ms.map_or(
-            VoiceMicrophoneBufferMode::HostDefault,
+            VoiceMicrophoneBufferMode::PlatformFixed,
             VoiceMicrophoneBufferMode::UserFixed,
         );
         Self::start_with_policy(samples_tx, input_source, buffer_mode)
-    }
-
-    pub(super) fn start_automatic_fixed(
-        samples_tx: mpsc::Sender<VoiceMicrophoneFrame>,
-        input_source: Option<&str>,
-        microphone_buffer_ms: MicrophoneBufferMs,
-    ) -> Result<Self, String> {
-        Self::start_with_policy(
-            samples_tx,
-            input_source,
-            VoiceMicrophoneBufferMode::AutomaticFixed(microphone_buffer_ms),
-        )
     }
 
     fn start_with_policy(
@@ -95,64 +83,7 @@ impl VoiceMicrophoneCapture {
             _stream: input_stream.stream,
             _processor: input_stream.processor,
             stats,
-            buffer_mode: input_stream.buffer_mode,
-            recovery: VoiceMicrophoneRecoveryState::default(),
         })
-    }
-
-    pub(super) fn take_restart_buffers(&mut self, now: Instant) -> Vec<MicrophoneBufferMs> {
-        if !self.recovery.permits_attempt(now) {
-            return Vec::new();
-        }
-        if !self.stats.restart_requested.swap(false, Ordering::AcqRel) {
-            return Vec::new();
-        }
-        let candidates = voice_microphone_recovery_buffers(self.buffer_mode);
-        if candidates.is_empty() {
-            self.recovery.exhaust();
-            logging::error(
-                "voice",
-                format!(
-                    "voice microphone callback timing remains unhealthy with buffer mode {:?}; no safer automatic buffer remains",
-                    self.buffer_mode,
-                ),
-            );
-        }
-        candidates
-    }
-
-    pub(super) fn record_failed_recovery(&mut self, now: Instant) -> bool {
-        self.recovery.record_failed_sweep(now)
-    }
-
-    pub(super) fn reset_recovery(&mut self) {
-        self.recovery = VoiceMicrophoneRecoveryState::default();
-    }
-}
-
-#[cfg(feature = "voice-playback")]
-impl VoiceMicrophoneRecoveryState {
-    pub(super) fn permits_attempt(&self, now: Instant) -> bool {
-        !self.exhausted && self.retry_not_before.is_none_or(|deadline| now >= deadline)
-    }
-
-    pub(super) fn record_failed_sweep(&mut self, now: Instant) -> bool {
-        self.failed_sweeps = self.failed_sweeps.saturating_add(1);
-        if self.failed_sweeps >= VOICE_MIC_RECOVERY_MAX_FAILED_SWEEPS {
-            self.exhaust();
-            return true;
-        }
-        let Some(retry_not_before) = now.checked_add(VOICE_MIC_RECOVERY_COOLDOWN) else {
-            self.exhaust();
-            return true;
-        };
-        self.retry_not_before = Some(retry_not_before);
-        false
-    }
-
-    pub(super) fn exhaust(&mut self) {
-        self.exhausted = true;
-        self.retry_not_before = None;
     }
 }
 
@@ -164,11 +95,13 @@ pub(super) fn build_preferred_voice_input_stream(
     buffer_mode: VoiceMicrophoneBufferMode,
 ) -> Result<VoiceMicrophoneInputStream, String> {
     let supported_config = select_voice_input_config(device)?;
+    let supported_buffer_size = *supported_config.buffer_size();
     let sample_format = supported_config.sample_format();
     let mut stream_config = supported_config.config();
     build_configured_voice_input_stream(
         device,
         &mut stream_config,
+        &supported_buffer_size,
         sample_format,
         stats,
         samples_tx,
@@ -186,11 +119,13 @@ pub(super) fn build_default_voice_input_stream(
     let supported_config = device
         .default_input_config()
         .map_err(|error| format!("voice microphone default input config failed: {error}"))?;
+    let supported_buffer_size = *supported_config.buffer_size();
     let sample_format = supported_config.sample_format();
     let mut stream_config = supported_config.config();
     build_configured_voice_input_stream(
         device,
         &mut stream_config,
+        &supported_buffer_size,
         sample_format,
         stats,
         samples_tx,
@@ -202,129 +137,123 @@ pub(super) fn build_default_voice_input_stream(
 fn build_configured_voice_input_stream(
     device: &cpal::Device,
     stream_config: &mut cpal::StreamConfig,
+    supported_buffer_size: &cpal::SupportedBufferSize,
     sample_format: cpal::SampleFormat,
     stats: Arc<VoiceMicrophoneCaptureStats>,
     samples_tx: mpsc::Sender<VoiceMicrophoneFrame>,
     buffer_mode: VoiceMicrophoneBufferMode,
 ) -> Result<VoiceMicrophoneInputStream, String> {
-    if let VoiceMicrophoneBufferMode::AutomaticFixed(duration)
-    | VoiceMicrophoneBufferMode::UserFixed(duration) = buffer_mode
-    {
-        stream_config.buffer_size =
-            voice_input_buffer_size(Some(duration), stream_config.sample_rate);
-        let (stream, processor) =
-            build_voice_input_stream(device, stream_config, sample_format, stats, samples_tx)?;
-        let stream_reported_buffer_frames = voice_stream_reported_buffer_frames(&stream);
-        if matches!(buffer_mode, VoiceMicrophoneBufferMode::AutomaticFixed(_))
-            && let Err(error) = validate_automatic_voice_input_buffer(
-                duration,
-                stream_reported_buffer_frames,
-                stream_config.sample_rate,
+    match buffer_mode {
+        VoiceMicrophoneBufferMode::UserFixed(duration) => {
+            stream_config.buffer_size =
+                voice_input_buffer_size(duration, stream_config.sample_rate);
+            build_voice_input_stream_with_mode(
+                device,
+                stream_config,
+                sample_format,
+                stats,
+                samples_tx,
+                buffer_mode,
             )
-        {
-            drop(stream);
-            drop(processor);
-            return Err(error);
         }
-        return Ok(VoiceMicrophoneInputStream {
-            stream,
-            processor,
-            stream_config: *stream_config,
-            sample_format,
-            buffer_mode,
-            stream_reported_buffer_frames,
-        });
-    }
+        VoiceMicrophoneBufferMode::PlatformFixed => {
+            let Some(buffer_size) =
+                automatic_voice_input_buffer_size(supported_buffer_size, stream_config.sample_rate)
+            else {
+                logging::debug(
+                    "voice",
+                    "voice microphone buffer range is unknown, using host default buffer",
+                );
+                return build_host_default_voice_input_stream(
+                    device,
+                    stream_config,
+                    sample_format,
+                    stats,
+                    samples_tx,
+                );
+            };
 
-    stream_config.buffer_size = cpal::BufferSize::Default;
-    let (default_stream, default_processor) = build_voice_input_stream(
-        device,
-        stream_config,
-        sample_format,
-        Arc::clone(&stats),
-        samples_tx.clone(),
-    )?;
-    let stream_reported_buffer_frames = voice_stream_reported_buffer_frames(&default_stream);
-    let maximum_frames =
-        voice_frames_for_duration(stream_config.sample_rate, VOICE_MIC_MAX_BUFFER_DURATION);
-    if stream_reported_buffer_frames.is_none_or(|frames| frames <= maximum_frames) {
-        return Ok(VoiceMicrophoneInputStream {
-            stream: default_stream,
-            processor: default_processor,
-            stream_config: *stream_config,
-            sample_format,
-            buffer_mode: VoiceMicrophoneBufferMode::HostDefault,
-            stream_reported_buffer_frames,
-        });
-    }
-
-    let excessive_frames = stream_reported_buffer_frames.expect("excessive buffer is known");
-    logging::debug(
-        "voice",
-        format!(
-            "voice host-default microphone buffer exceeds live limit: stream_reported_frames={} stream_reported_ms={} limit_ms={}",
-            excessive_frames,
-            voice_buffer_duration_ms(excessive_frames, stream_config.sample_rate),
-            VOICE_MIC_MAX_BUFFER_DURATION.as_millis(),
-        ),
-    );
-    drop(default_stream);
-    drop(default_processor);
-
-    let mut failures = Vec::new();
-    for duration in [
-        MicrophoneBufferMs::new(VOICE_MIC_TARGET_BUFFER_DURATION.as_millis() as u16),
-        MicrophoneBufferMs::new(VOICE_MIC_MAX_BUFFER_DURATION.as_millis() as u16),
-    ] {
-        stream_config.buffer_size =
-            cpal::BufferSize::Fixed(duration.frames(stream_config.sample_rate));
-        match build_voice_input_stream(
+            stream_config.buffer_size = buffer_size;
+            match build_voice_input_stream_with_mode(
+                device,
+                stream_config,
+                sample_format,
+                Arc::clone(&stats),
+                samples_tx.clone(),
+                VoiceMicrophoneBufferMode::PlatformFixed,
+            ) {
+                Ok(input_stream) => Ok(input_stream),
+                Err(fixed_error) => {
+                    logging::debug(
+                        "voice",
+                        format!(
+                            "voice fixed microphone input buffer failed, retrying host default buffer: {fixed_error}"
+                        ),
+                    );
+                    build_host_default_voice_input_stream(
+                        device,
+                        stream_config,
+                        sample_format,
+                        stats,
+                        samples_tx,
+                    )
+                    .map_err(|default_error| {
+                        format!(
+                            "voice fixed microphone input buffer failed ({fixed_error}); host default fallback failed ({default_error})"
+                        )
+                    })
+                }
+            }
+        }
+        VoiceMicrophoneBufferMode::HostDefaultFallback => build_host_default_voice_input_stream(
             device,
             stream_config,
             sample_format,
-            Arc::clone(&stats),
-            samples_tx.clone(),
-        ) {
-            Ok((stream, processor)) => {
-                let stream_reported_buffer_frames = voice_stream_reported_buffer_frames(&stream);
-                if let Err(error) = validate_automatic_voice_input_buffer(
-                    duration,
-                    stream_reported_buffer_frames,
-                    stream_config.sample_rate,
-                ) {
-                    failures.push(error);
-                    drop(stream);
-                    drop(processor);
-                    continue;
-                }
-                logging::debug(
-                    "voice",
-                    format!(
-                        "voice microphone capture selected bounded fixed buffer: requested_ms={} requested_frames={} stream_reported_frames={}",
-                        duration.value(),
-                        duration.frames(stream_config.sample_rate),
-                        stream_reported_buffer_frames
-                            .map_or_else(|| "unknown".to_owned(), |frames| frames.to_string(),),
-                    ),
-                );
-                return Ok(VoiceMicrophoneInputStream {
-                    stream,
-                    processor,
-                    stream_config: *stream_config,
-                    sample_format,
-                    buffer_mode: VoiceMicrophoneBufferMode::AutomaticFixed(duration),
-                    stream_reported_buffer_frames,
-                });
-            }
-            Err(error) => failures.push(format!("{}ms: {error}", duration.value())),
-        }
+            stats,
+            samples_tx,
+        ),
     }
+}
 
-    Err(format!(
-        "voice host-default microphone buffer is {}ms and bounded fixed attempts failed ({})",
-        voice_buffer_duration_ms(excessive_frames, stream_config.sample_rate),
-        failures.join("; ")
-    ))
+#[cfg(feature = "voice-playback")]
+fn build_host_default_voice_input_stream(
+    device: &cpal::Device,
+    stream_config: &mut cpal::StreamConfig,
+    sample_format: cpal::SampleFormat,
+    stats: Arc<VoiceMicrophoneCaptureStats>,
+    samples_tx: mpsc::Sender<VoiceMicrophoneFrame>,
+) -> Result<VoiceMicrophoneInputStream, String> {
+    stream_config.buffer_size = cpal::BufferSize::Default;
+    build_voice_input_stream_with_mode(
+        device,
+        stream_config,
+        sample_format,
+        stats,
+        samples_tx,
+        VoiceMicrophoneBufferMode::HostDefaultFallback,
+    )
+}
+
+#[cfg(feature = "voice-playback")]
+fn build_voice_input_stream_with_mode(
+    device: &cpal::Device,
+    stream_config: &cpal::StreamConfig,
+    sample_format: cpal::SampleFormat,
+    stats: Arc<VoiceMicrophoneCaptureStats>,
+    samples_tx: mpsc::Sender<VoiceMicrophoneFrame>,
+    buffer_mode: VoiceMicrophoneBufferMode,
+) -> Result<VoiceMicrophoneInputStream, String> {
+    let (stream, processor) =
+        build_voice_input_stream(device, stream_config, sample_format, stats, samples_tx)?;
+    let stream_reported_buffer_frames = voice_stream_reported_buffer_frames(&stream);
+    Ok(VoiceMicrophoneInputStream {
+        stream,
+        processor,
+        stream_config: *stream_config,
+        sample_format,
+        buffer_mode,
+        stream_reported_buffer_frames,
+    })
 }
 
 #[cfg(feature = "voice-playback")]
@@ -375,76 +304,43 @@ pub(super) fn voice_input_sample_format_rank(format: cpal::SampleFormat) -> u8 {
 
 #[cfg(feature = "voice-playback")]
 pub(super) fn voice_input_buffer_size(
-    microphone_buffer_ms: Option<MicrophoneBufferMs>,
+    microphone_buffer_ms: MicrophoneBufferMs,
     sample_rate: u32,
 ) -> cpal::BufferSize {
-    microphone_buffer_ms.map_or(cpal::BufferSize::Default, |duration| {
-        cpal::BufferSize::Fixed(duration.frames(sample_rate))
-    })
+    cpal::BufferSize::Fixed(microphone_buffer_ms.frames(sample_rate))
 }
 
 #[cfg(feature = "voice-playback")]
-pub(super) fn voice_frames_for_duration(sample_rate: u32, duration: Duration) -> u32 {
-    let nanos = duration.as_nanos();
-    let frames = u128::from(sample_rate)
-        .saturating_mul(nanos)
-        .saturating_add(500_000_000)
-        / 1_000_000_000;
-    u32::try_from(frames).unwrap_or(u32::MAX)
-}
-
-#[cfg(feature = "voice-playback")]
-pub(super) fn voice_buffer_duration_ms(frames: u32, sample_rate: u32) -> u128 {
-    if sample_rate == 0 {
-        return 0;
-    }
-    u128::from(frames).saturating_mul(1_000) / u128::from(sample_rate)
-}
-
-#[cfg(feature = "voice-playback")]
-pub(super) fn validate_automatic_voice_input_buffer(
-    requested: MicrophoneBufferMs,
-    stream_reported_frames: Option<u32>,
+pub(super) fn automatic_voice_input_buffer_size(
+    supported: &cpal::SupportedBufferSize,
     sample_rate: u32,
-) -> Result<(), String> {
-    let Some(stream_reported_frames) = stream_reported_frames else {
-        return Ok(());
-    };
-    let maximum_frames = voice_frames_for_duration(sample_rate, VOICE_MIC_MAX_BUFFER_DURATION);
-    if stream_reported_frames <= maximum_frames {
-        return Ok(());
+) -> Option<cpal::BufferSize> {
+    match supported {
+        cpal::SupportedBufferSize::Range { min, max } => {
+            let callback_period_frames = sample_rate
+                .checked_div(VOICE_MIC_AUTOMATIC_CALLBACKS_PER_SECOND)
+                .unwrap_or(0)
+                .max(1);
+            Some(cpal::BufferSize::Fixed(
+                callback_period_frames.clamp(*min, *max),
+            ))
+        }
+        cpal::SupportedBufferSize::Unknown => None,
     }
-
-    Err(format!(
-        "{}ms automatic buffer reports {} frames ({}ms), above {} frames ({}ms) live limit",
-        requested.value(),
-        stream_reported_frames,
-        voice_buffer_duration_ms(stream_reported_frames, sample_rate),
-        maximum_frames,
-        VOICE_MIC_MAX_BUFFER_DURATION.as_millis(),
-    ))
 }
 
 #[cfg(feature = "voice-playback")]
-pub(super) fn voice_microphone_recovery_buffers(
-    mode: VoiceMicrophoneBufferMode,
-) -> Vec<MicrophoneBufferMs> {
-    match mode {
-        VoiceMicrophoneBufferMode::HostDefault => vec![
-            MicrophoneBufferMs::new(VOICE_MIC_TARGET_BUFFER_DURATION.as_millis() as u16),
-            MicrophoneBufferMs::new(VOICE_MIC_MAX_BUFFER_DURATION.as_millis() as u16),
-        ],
-        VoiceMicrophoneBufferMode::AutomaticFixed(duration)
-            if duration.value() < VOICE_MIC_MAX_BUFFER_DURATION.as_millis() as u16 =>
-        {
-            vec![MicrophoneBufferMs::new(
-                VOICE_MIC_MAX_BUFFER_DURATION.as_millis() as u16,
-            )]
-        }
-        VoiceMicrophoneBufferMode::AutomaticFixed(_) | VoiceMicrophoneBufferMode::UserFixed(_) => {
-            Vec::new()
-        }
+fn duration_for_audio_frames(frames: u64, sample_rate: u32) -> Duration {
+    if sample_rate == 0 {
+        return Duration::ZERO;
     }
+    let nanos = u128::from(frames).saturating_mul(1_000_000_000) / u128::from(sample_rate);
+    Duration::from_nanos(u64::try_from(nanos).unwrap_or(u64::MAX))
+}
+
+#[cfg(feature = "voice-playback")]
+fn voice_buffer_duration_ms(frames: u32, sample_rate: u32) -> u128 {
+    duration_for_audio_frames(u64::from(frames), sample_rate).as_millis()
 }
 
 #[cfg(feature = "voice-playback")]
@@ -479,13 +375,8 @@ impl Default for VoiceMicrophoneCaptureStats {
             callback_handoff_drops: AtomicU64::new(0),
             stream_errors: AtomicU64::new(0),
             stream_xruns: AtomicU64::new(0),
-            last_capture_end_offset_us: AtomicI64::new(i64::MIN),
-            max_capture_clock_adjustment_us: AtomicU64::new(0),
             max_capture_latency_us: AtomicU64::new(0),
             max_capture_delivery_age_us: AtomicU64::new(0),
-            unhealthy_callback_count: AtomicU8::new(0),
-            unhealthy_callback_window_started_us: AtomicU64::new(0),
-            restart_requested: AtomicBool::new(false),
         }
     }
 }
@@ -547,8 +438,8 @@ impl<T> VoiceMicrophoneInputHandoff<T> {
             return Err(chunk);
         }
 
-        chunk.timing.input_dropped |= self.input_dropped.swap(false, Ordering::AcqRel);
-        chunk.timing.input_dropped |= state.pending.is_some();
+        chunk.input_dropped |= self.input_dropped.swap(false, Ordering::AcqRel);
+        chunk.input_dropped |= state.pending.is_some();
         let replaced = state.pending.replace(chunk);
         drop(state);
         self.wake.notify_one();
@@ -587,13 +478,7 @@ impl VoiceMicrophonePcmFrames {
         samples: &[i16],
         captured_at: Instant,
     ) -> Option<Instant> {
-        if self.source_pending.is_empty() && self.output_pending.is_empty() {
-            self.output_pending_at = Some(
-                captured_at
-                    .checked_add(DISCORD_OPUS_FRAME_DURATION)
-                    .unwrap_or(captured_at),
-            );
-        }
+        self.align_output_timeline(captured_at);
         if self.source_sample_rate == DISCORD_VOICE_SAMPLE_RATE {
             self.output_pending.extend_from_slice(samples);
         } else {
@@ -603,30 +488,39 @@ impl VoiceMicrophonePcmFrames {
         self.flush_output_frames()
     }
 
-    pub(super) fn apply_capture_timing(&mut self, timing: VoiceMicrophoneCaptureTiming) {
-        if timing.input_dropped {
+    pub(super) fn apply_input_drop(&mut self, input_dropped: bool) {
+        if input_dropped {
             self.reset_after_input_drop();
-            return;
         }
-        // Capture timestamps adjust only frame-age metadata. They do not prove
-        // sample loss, so clock changes must never clear valid pending audio.
-        let Some(timestamp) = self.output_pending_at else {
-            return;
-        };
-        let adjustment = Duration::from_micros(timing.timeline_adjustment_us.unsigned_abs());
-        let adjusted = if timing.timeline_adjustment_us >= 0 {
-            timestamp.checked_add(adjustment)
-        } else {
-            timestamp.checked_sub(adjustment)
-        };
-        self.output_pending_at = adjusted.or(Some(timestamp));
     }
 
-    pub(super) fn reset_after_input_drop(&mut self) {
+    fn reset_after_input_drop(&mut self) {
         self.source_pending.clear();
         self.output_pending.clear();
         self.output_pending_at = None;
         self.next_source_frame = 0.0;
+    }
+
+    fn align_output_timeline(&mut self, captured_at: Instant) {
+        let pending_output_frames = self.output_pending.len() / DISCORD_VOICE_CHANNELS_USIZE;
+        let pending_source_frames = self.source_pending.len() / DISCORD_VOICE_CHANNELS_USIZE;
+        let pending_source_duration = duration_for_audio_frames(
+            u64::try_from(pending_source_frames).unwrap_or(u64::MAX),
+            self.source_sample_rate,
+        );
+        let pending_output_duration = duration_for_audio_frames(
+            u64::try_from(pending_output_frames).unwrap_or(u64::MAX),
+            DISCORD_VOICE_SAMPLE_RATE,
+        );
+        let pending_duration = pending_source_duration.saturating_add(pending_output_duration);
+        let pending_started_at = captured_at
+            .checked_sub(pending_duration)
+            .unwrap_or(captured_at);
+        self.output_pending_at = Some(
+            pending_started_at
+                .checked_add(DISCORD_OPUS_FRAME_DURATION)
+                .unwrap_or(pending_started_at),
+        );
     }
 
     pub(super) fn resample_pending_source(&mut self) {
@@ -663,6 +557,23 @@ impl VoiceMicrophonePcmFrames {
     }
 
     pub(super) fn flush_output_frames(&mut self) -> Option<Instant> {
+        let completed_frames = self.output_pending.len() / DISCORD_OPUS_20MS_STEREO_SAMPLES;
+        let stale_frames = completed_frames.saturating_sub(VOICE_MIC_MAX_LIVE_FRAMES);
+        if stale_frames > 0 {
+            self.output_pending
+                .drain(..stale_frames * DISCORD_OPUS_20MS_STEREO_SAMPLES);
+            self.output_pending_at = self.output_pending_at.and_then(|captured_at| {
+                captured_at.checked_add(
+                    DISCORD_OPUS_FRAME_DURATION
+                        .saturating_mul(u32::try_from(stale_frames).unwrap_or(u32::MAX)),
+                )
+            });
+            self.stats.dropped_frames.fetch_add(
+                u64::try_from(stale_frames).unwrap_or(u64::MAX),
+                Ordering::Relaxed,
+            );
+        }
+
         let mut oldest_frame_at = None;
         while self.output_pending.len() >= DISCORD_OPUS_20MS_STEREO_SAMPLES {
             let frame = VoiceMicrophoneFrame {
@@ -703,16 +614,13 @@ impl Drop for VoiceMicrophoneCapture {
         logging::debug(
             "voice",
             format!(
-                "voice microphone capture stopped: chunks={} frames={} callback_frames_min={} callback_frames_max={} callback_max_gap_ms={} callback_handoff_drops={} capture_clock_adjustment_max_us={} capture_latency_max_us={} capture_delivery_age_max_us={} stream_errors={} stream_xruns={} queued_20ms_frames={} dropped_20ms_frames={} peak_sample={} clipped_samples={}",
+                "voice microphone capture stopped: chunks={} frames={} callback_frames_min={} callback_frames_max={} callback_max_gap_ms={} callback_handoff_drops={} capture_latency_max_us={} capture_delivery_age_max_us={} stream_errors={} stream_xruns={} queued_20ms_frames={} dropped_20ms_frames={} peak_sample={} clipped_samples={}",
                 self.stats.chunks.load(Ordering::Relaxed),
                 self.stats.frames.load(Ordering::Relaxed),
                 voice_microphone_min_callback_frames(&self.stats),
                 self.stats.max_callback_frames.load(Ordering::Relaxed),
                 self.stats.max_callback_gap_ms.load(Ordering::Relaxed),
                 self.stats.callback_handoff_drops.load(Ordering::Relaxed),
-                self.stats
-                    .max_capture_clock_adjustment_us
-                    .load(Ordering::Relaxed),
                 self.stats.max_capture_latency_us.load(Ordering::Relaxed),
                 self.stats
                     .max_capture_delivery_age_us
@@ -794,16 +702,11 @@ where
             let mut pcm_frames =
                 VoiceMicrophonePcmFrames::new(samples_tx, Arc::clone(&worker_stats), sample_rate);
             while let Some(mut chunk) = worker_handoff.take() {
-                pcm_frames.apply_capture_timing(chunk.timing);
+                pcm_frames.apply_input_drop(chunk.input_dropped);
                 let samples = convert(&chunk.samples, channels);
                 record_voice_input_pcm_stats(&samples, &worker_stats);
                 let oldest_frame_at = pcm_frames.push_stereo_samples(&samples, chunk.captured_at);
-                record_voice_input_health(
-                    chunk.timing,
-                    oldest_frame_at,
-                    Instant::now(),
-                    &worker_stats,
-                );
+                record_voice_input_delivery_age(oldest_frame_at, Instant::now(), &worker_stats);
                 chunk.samples.clear();
                 let _ = recycle_tx.try_send(chunk.samples);
             }
@@ -822,14 +725,7 @@ where
             move |input: &[T], info| {
                 let callback_at = Instant::now();
                 let captured_at = voice_input_capture_instant(info, callback_at);
-                let timing = record_voice_input_chunk(
-                    input.len(),
-                    channels,
-                    sample_rate,
-                    captured_at,
-                    callback_at,
-                    &stats,
-                );
+                record_voice_input_chunk(input.len(), channels, captured_at, callback_at, &stats);
                 let mut samples = recycle_rx
                     .try_recv()
                     .ok()
@@ -840,7 +736,7 @@ where
                 let chunk = VoiceMicrophoneInputChunk {
                     samples,
                     captured_at,
-                    timing,
+                    input_dropped: false,
                 };
                 match handoff.try_replace(chunk) {
                     Ok(replaced) => {
@@ -929,11 +825,10 @@ where
 pub(super) fn record_voice_input_chunk(
     sample_count: usize,
     channels: usize,
-    sample_rate: u32,
     captured_at: Instant,
     callback_at: Instant,
     stats: &VoiceMicrophoneCaptureStats,
-) -> VoiceMicrophoneCaptureTiming {
+) {
     let frames = sample_count / channels.max(1);
     stats.chunks.fetch_add(1, Ordering::Relaxed);
     stats
@@ -963,107 +858,25 @@ pub(super) fn record_voice_input_chunk(
             .fetch_max(callback_gap / 1_000, Ordering::Relaxed);
     }
 
-    let callback_duration_us = frames
-        .saturating_mul(1_000_000)
-        .checked_div(u64::from(sample_rate.max(1)))
-        .unwrap_or(u64::MAX);
-    let callback_duration = Duration::from_micros(callback_duration_us);
-    let excessive_gap = previous_elapsed_us != 0
-        && Duration::from_micros(callback_gap)
-            > VOICE_MIC_CALLBACK_GAP_FLOOR.max(callback_duration.saturating_mul(4));
-
-    // Keep retained resampler output aligned with CPAL's capture timeline. This
-    // value is metadata only and is not evidence that PCM samples were lost.
     let capture_latency = callback_at.saturating_duration_since(captured_at);
     let capture_latency_us = u64::try_from(capture_latency.as_micros()).unwrap_or(u64::MAX);
     stats
         .max_capture_latency_us
         .fetch_max(capture_latency_us, Ordering::Relaxed);
-    let capture_started_us = i64::try_from(elapsed_us)
-        .unwrap_or(i64::MAX)
-        .saturating_sub(i64::try_from(capture_latency_us).unwrap_or(i64::MAX));
-    let capture_end_us =
-        capture_started_us.saturating_add(i64::try_from(callback_duration_us).unwrap_or(i64::MAX));
-    let previous_capture_end_us = stats
-        .last_capture_end_offset_us
-        .swap(capture_end_us, Ordering::Relaxed);
-    let capture_clock_delta_us = if previous_capture_end_us == i64::MIN {
-        0
-    } else {
-        capture_started_us.saturating_sub(previous_capture_end_us)
-    };
-    let capture_clock_adjustment_us = capture_clock_delta_us.unsigned_abs();
-    stats
-        .max_capture_clock_adjustment_us
-        .fetch_max(capture_clock_adjustment_us, Ordering::Relaxed);
-
-    // The worker combines these signals with actual frame delivery age. Keeping
-    // one writer for the health window also counts each processed chunk only once.
-    VoiceMicrophoneCaptureTiming {
-        input_dropped: false,
-        timeline_adjustment_us: capture_clock_delta_us,
-        callback_unhealthy: callback_duration > VOICE_MIC_MAX_BUFFER_DURATION || excessive_gap,
-    }
 }
 
 #[cfg(feature = "voice-playback")]
-pub(super) fn record_voice_input_health(
-    timing: VoiceMicrophoneCaptureTiming,
+fn record_voice_input_delivery_age(
     oldest_frame_at: Option<Instant>,
     ready_at: Instant,
     stats: &VoiceMicrophoneCaptureStats,
 ) {
-    // Only completed frames reveal the delay from partial chunks and resampler
-    // lookahead. Use the same frame-end timestamp as the transmit freshness check,
-    // leaving its pacing and processing allowance intact.
-    let delivery_age =
-        oldest_frame_at.map(|captured_at| ready_at.saturating_duration_since(captured_at));
-    if let Some(age) = delivery_age {
+    if let Some(captured_at) = oldest_frame_at {
+        let age = ready_at.saturating_duration_since(captured_at);
         stats.max_capture_delivery_age_us.fetch_max(
             u64::try_from(age.as_micros()).unwrap_or(u64::MAX),
             Ordering::Relaxed,
         );
-    }
-    if timing.callback_unhealthy
-        || delivery_age.is_some_and(|age| age > VOICE_MIC_CAPTURE_DELIVERY_BUDGET)
-    {
-        let elapsed_us = u64::try_from(
-            ready_at
-                .saturating_duration_since(stats.started_at)
-                .as_micros(),
-        )
-        .unwrap_or(u64::MAX);
-        record_unhealthy_voice_input_callback(elapsed_us, stats);
-    }
-}
-
-#[cfg(feature = "voice-playback")]
-fn record_unhealthy_voice_input_callback(elapsed_us: u64, stats: &VoiceMicrophoneCaptureStats) {
-    let window_us =
-        u64::try_from(VOICE_MIC_UNHEALTHY_CALLBACK_WINDOW.as_micros()).unwrap_or(u64::MAX);
-    let window_started_us = stats
-        .unhealthy_callback_window_started_us
-        .load(Ordering::Relaxed);
-    let count =
-        if window_started_us == 0 || elapsed_us.saturating_sub(window_started_us) > window_us {
-            stats
-                .unhealthy_callback_window_started_us
-                .store(elapsed_us.max(1), Ordering::Relaxed);
-            stats.unhealthy_callback_count.store(1, Ordering::Relaxed);
-            1
-        } else {
-            stats
-                .unhealthy_callback_count
-                .fetch_add(1, Ordering::Relaxed)
-                .saturating_add(1)
-        };
-
-    if count >= VOICE_MIC_UNHEALTHY_CALLBACK_THRESHOLD {
-        stats.unhealthy_callback_count.store(0, Ordering::Relaxed);
-        stats
-            .unhealthy_callback_window_started_us
-            .store(0, Ordering::Relaxed);
-        stats.restart_requested.store(true, Ordering::Release);
     }
 }
 
@@ -1100,11 +913,16 @@ pub(super) fn record_voice_input_stream_error(
     stats.stream_errors.fetch_add(1, Ordering::Relaxed);
     if error.kind() == cpal::ErrorKind::Xrun {
         stats.stream_xruns.fetch_add(1, Ordering::Relaxed);
+        logging::error(
+            "voice",
+            format!("voice microphone input stream reported an xrun: {error}"),
+        );
+    } else {
+        logging::error(
+            "voice",
+            format!("voice microphone input stream failed: {error}"),
+        );
     }
-    logging::error(
-        "voice",
-        format!("voice microphone input stream failed: {error}"),
-    );
 }
 
 #[cfg(all(feature = "voice-playback", target_os = "linux"))]

--- a/src/discord/voice/tests.rs
+++ b/src/discord/voice/tests.rs
@@ -2104,24 +2104,25 @@ fn microphone_pcm_frames_resample_44100_to_48000() {
 
 #[cfg(feature = "voice-playback")]
 #[test]
-fn microphone_pcm_frames_count_full_queue_drops() {
-    let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+fn microphone_pcm_frames_keep_latest_audio_from_large_callbacks() {
+    let (tx, mut rx) = tokio::sync::mpsc::channel(VOICE_MIC_PCM_FRAME_QUEUE);
     let stats = Arc::new(VoiceMicrophoneCaptureStats::default());
     let mut frames =
         VoiceMicrophonePcmFrames::new(tx, Arc::clone(&stats), DISCORD_VOICE_SAMPLE_RATE);
-    let samples = vec![1i16; DISCORD_OPUS_20MS_STEREO_SAMPLES * 2];
+    let callback_frames = VOICE_MIC_MAX_LIVE_FRAMES + 2;
+    let mut samples = Vec::with_capacity(DISCORD_OPUS_20MS_STEREO_SAMPLES * callback_frames);
+    for value in 0..callback_frames {
+        samples.extend(vec![value as i16; DISCORD_OPUS_20MS_STEREO_SAMPLES]);
+    }
 
     frames.push_stereo_samples(&samples, Instant::now());
 
-    assert_eq!(
-        rx.try_recv()
-            .expect("first frame should queue")
-            .samples
-            .len(),
-        DISCORD_OPUS_20MS_STEREO_SAMPLES
-    );
-    assert_eq!(stats.queued_frames.load(Ordering::Relaxed), 1);
-    assert_eq!(stats.dropped_frames.load(Ordering::Relaxed), 1);
+    let queued = std::iter::from_fn(|| rx.try_recv().ok())
+        .map(|frame| frame.samples[0])
+        .collect::<Vec<_>>();
+    assert_eq!(queued, vec![2, 3, 4]);
+    assert_eq!(stats.queued_frames.load(Ordering::Relaxed), 3);
+    assert_eq!(stats.dropped_frames.load(Ordering::Relaxed), 2);
 }
 
 #[cfg(feature = "voice-playback")]
@@ -2147,7 +2148,7 @@ fn microphone_pcm_frames_keep_20ms_capture_timeline_for_batched_input() {
 
 #[cfg(feature = "voice-playback")]
 #[test]
-fn microphone_input_drop_discards_incomplete_old_audio() {
+fn microphone_input_continues_with_fresh_audio_after_handoff_drop() {
     let (tx, mut rx) = tokio::sync::mpsc::channel(1);
     let stats = Arc::new(VoiceMicrophoneCaptureStats::default());
     let mut frames =
@@ -2158,7 +2159,7 @@ fn microphone_input_drop_discards_incomplete_old_audio() {
         &vec![1i16; DISCORD_OPUS_20MS_STEREO_SAMPLES / 2],
         resumed_at - Duration::from_secs(1),
     );
-    frames.reset_after_input_drop();
+    frames.apply_input_drop(true);
     frames.push_stereo_samples(&vec![2i16; DISCORD_OPUS_20MS_STEREO_SAMPLES], resumed_at);
 
     let frame = rx.try_recv().expect("resumed frame should queue");
@@ -2432,7 +2433,6 @@ fn microphone_capture_stats_track_callback_size_and_clipping() {
     record_voice_input_chunk(
         960,
         2,
-        DISCORD_VOICE_SAMPLE_RATE,
         first_captured_at,
         first_captured_at + Duration::from_millis(10),
         &stats,
@@ -2440,7 +2440,6 @@ fn microphone_capture_stats_track_callback_size_and_clipping() {
     record_voice_input_chunk(
         480,
         2,
-        DISCORD_VOICE_SAMPLE_RATE,
         second_captured_at,
         second_captured_at + Duration::from_millis(5),
         &stats,
@@ -2453,328 +2452,6 @@ fn microphone_capture_stats_track_callback_size_and_clipping() {
     assert_eq!(stats.max_callback_frames.load(Ordering::Relaxed), 480);
     assert_eq!(stats.peak_sample.load(Ordering::Relaxed), 32767);
     assert_eq!(stats.clipped_samples.load(Ordering::Relaxed), 2);
-}
-
-#[cfg(feature = "voice-playback")]
-#[test]
-fn repeated_oversized_microphone_callbacks_request_automatic_recovery() {
-    let stats = VoiceMicrophoneCaptureStats::default();
-    let oversized_frames =
-        voice_frames_for_duration(DISCORD_VOICE_SAMPLE_RATE, Duration::from_millis(80));
-    let mut captured_at = stats.started_at + Duration::from_millis(10);
-
-    for _ in 0..VOICE_MIC_UNHEALTHY_CALLBACK_THRESHOLD {
-        let callback_at = captured_at + Duration::from_millis(80);
-        let timing = record_voice_input_chunk(
-            oversized_frames as usize,
-            1,
-            DISCORD_VOICE_SAMPLE_RATE,
-            captured_at,
-            callback_at,
-            &stats,
-        );
-        record_voice_input_health(timing, None, callback_at, &stats);
-        captured_at += Duration::from_millis(80);
-    }
-
-    assert!(stats.restart_requested.load(Ordering::Acquire));
-}
-
-#[cfg(feature = "voice-playback")]
-#[test]
-fn microphone_capture_clock_gap_preserves_44100_audio() {
-    let stats = Arc::new(VoiceMicrophoneCaptureStats::default());
-    let (tx, mut rx) = tokio::sync::mpsc::channel(VOICE_MIC_PCM_FRAME_QUEUE);
-    let mut pcm_frames = VoiceMicrophonePcmFrames::new(tx, Arc::clone(&stats), 44_100);
-    let input_frames = 883;
-    let callback_duration = Duration::from_micros(
-        u64::try_from(input_frames).expect("test frame count fits") * 1_000_000 / 44_100,
-    );
-    let samples = vec![1i16; input_frames * DISCORD_VOICE_CHANNELS_USIZE];
-    let initial_captured_at = stats.started_at + Duration::from_millis(10);
-
-    record_voice_input_chunk(
-        input_frames,
-        1,
-        44_100,
-        initial_captured_at,
-        initial_captured_at + callback_duration,
-        &stats,
-    );
-    pcm_frames.push_stereo_samples(&samples, initial_captured_at);
-    rx.try_recv().expect("initial resampled frame should queue");
-
-    let resumed_at = initial_captured_at + callback_duration + Duration::from_millis(100);
-    let mut fresh_frames = 0;
-    for index in 0..100u32 {
-        let captured_at = resumed_at + callback_duration.saturating_mul(index);
-        let timing = record_voice_input_chunk(
-            input_frames,
-            1,
-            44_100,
-            captured_at,
-            captured_at + callback_duration,
-            &stats,
-        );
-        pcm_frames.apply_capture_timing(timing);
-        let oldest_frame_at = pcm_frames.push_stereo_samples(&samples, captured_at);
-        record_voice_input_health(
-            timing,
-            oldest_frame_at,
-            captured_at + callback_duration,
-            &stats,
-        );
-        let frame = rx.try_recv().expect("resumed resampled frame should queue");
-        let (selected, dropped) =
-            select_fresh_voice_microphone_frame(frame, &mut rx, captured_at + callback_duration);
-        assert!(
-            selected.is_some(),
-            "resumed frame {index} should remain fresh"
-        );
-        assert_eq!(dropped, 0);
-        fresh_frames += 1;
-    }
-
-    assert_eq!(fresh_frames, 100);
-    assert!(
-        stats
-            .max_capture_clock_adjustment_us
-            .load(Ordering::Relaxed)
-            >= 100_000
-    );
-    assert!(!stats.restart_requested.load(Ordering::Acquire));
-}
-
-#[cfg(feature = "voice-playback")]
-#[test]
-fn microphone_timeline_corrects_small_gaps_and_clock_drift() {
-    // Capture-clock changes must move the retained resampler timeline without
-    // discarding the partial source audio held between callbacks.
-    {
-        let stats = Arc::new(VoiceMicrophoneCaptureStats::default());
-        let (tx, mut rx) = tokio::sync::mpsc::channel(VOICE_MIC_PCM_FRAME_QUEUE);
-        let mut pcm_frames = VoiceMicrophonePcmFrames::new(tx, Arc::clone(&stats), 44_100);
-        let input_frames = 883;
-        let callback_duration = Duration::from_micros(
-            u64::try_from(input_frames).expect("test frame count fits") * 1_000_000 / 44_100,
-        );
-        let samples = vec![1i16; input_frames * DISCORD_VOICE_CHANNELS_USIZE];
-        let mut captured_at = stats.started_at + Duration::from_millis(10);
-
-        for index in 0..107 {
-            if index > 0 {
-                captured_at += callback_duration;
-                if index <= 7 {
-                    captured_at += Duration::from_millis(9);
-                }
-            }
-            let callback_at = captured_at + callback_duration;
-            let timing =
-                record_voice_input_chunk(input_frames, 1, 44_100, captured_at, callback_at, &stats);
-            pcm_frames.apply_capture_timing(timing);
-            let oldest_frame_at = pcm_frames.push_stereo_samples(&samples, captured_at);
-            record_voice_input_health(timing, oldest_frame_at, callback_at, &stats);
-
-            let mut frame = rx.try_recv().expect("resampled frame should queue");
-            while let Ok(newer) = rx.try_recv() {
-                frame = newer;
-            }
-            let frame_age = (callback_at + Duration::from_millis(15))
-                .saturating_duration_since(frame.captured_at);
-            assert!(
-                frame_age <= DISCORD_OPUS_FRAME_DURATION,
-                "frame {index} drifted by {}us",
-                frame_age.as_micros(),
-            );
-        }
-
-        assert!(!stats.restart_requested.load(Ordering::Acquire));
-    }
-
-    // A 100 ppm source clock difference is only 2us per 20ms callback. The
-    // individual differences are small, but the retained timeline must absorb
-    // all of them over a long session.
-    {
-        let stats = Arc::new(VoiceMicrophoneCaptureStats::default());
-        let (tx, _rx) = tokio::sync::mpsc::channel(1);
-        let mut pcm_frames = VoiceMicrophonePcmFrames::new(tx, Arc::clone(&stats), 44_100);
-        let timeline_start = stats.started_at + Duration::from_millis(20);
-        pcm_frames.output_pending_at = Some(timeline_start);
-        let mut captured_at = stats.started_at + Duration::from_millis(10);
-
-        let first = record_voice_input_chunk(
-            882,
-            1,
-            44_100,
-            captured_at,
-            captured_at + DISCORD_OPUS_FRAME_DURATION,
-            &stats,
-        );
-        pcm_frames.apply_capture_timing(first);
-        for _ in 0..40_000 {
-            captured_at += Duration::from_micros(20_002);
-            let timing = record_voice_input_chunk(
-                882,
-                1,
-                44_100,
-                captured_at,
-                captured_at + DISCORD_OPUS_FRAME_DURATION,
-                &stats,
-            );
-            pcm_frames.apply_capture_timing(timing);
-            record_voice_input_health(
-                timing,
-                None,
-                captured_at + DISCORD_OPUS_FRAME_DURATION,
-                &stats,
-            );
-        }
-
-        assert_eq!(
-            pcm_frames.output_pending_at,
-            Some(timeline_start + Duration::from_millis(80)),
-        );
-        assert!(!stats.restart_requested.load(Ordering::Acquire));
-    }
-}
-
-#[cfg(feature = "voice-playback")]
-#[test]
-fn microphone_delivery_health_matches_completed_frame_age() {
-    assert_eq!(
-        VOICE_MIC_MAX_FRAME_AGE,
-        VOICE_MIC_CAPTURE_DELIVERY_BUDGET
-            .saturating_add(VOICE_MIC_TRANSMIT_WAIT_BUDGET)
-            .saturating_add(VOICE_MIC_PROCESSING_BUDGET),
-    );
-
-    // Use the assembler rather than assuming each callback completes a frame.
-    // The 882-frame input needs resampler lookahead and 720 frames span 15ms.
-    for (sample_rate, input_frames, capture_latency_ms, worker_delay_ms, needs_recovery) in [
-        (48_000, 960, 70, 0, false),
-        (44_100, 882, 50, 0, false),
-        (48_000, 720, 55, 0, false),
-        (48_000, 480, 60, 0, false),
-        (48_000, 2_880, 60, 0, false),
-        (48_000, 960, 100, 0, true),
-        (44_100, 882, 70, 0, true),
-        (48_000, 720, 65, 0, true),
-        (48_000, 480, 70, 0, true),
-        (48_000, 960, 60, 20, true),
-    ] {
-        let stats = Arc::new(VoiceMicrophoneCaptureStats::default());
-        let (tx, mut rx) = tokio::sync::mpsc::channel(VOICE_MIC_PCM_FRAME_QUEUE);
-        let mut pcm_frames = VoiceMicrophonePcmFrames::new(tx, Arc::clone(&stats), sample_rate);
-        let samples = vec![1i16; input_frames * DISCORD_VOICE_CHANNELS_USIZE];
-        let callback_duration = Duration::from_micros(
-            u64::try_from(input_frames).expect("test frame count fits") * 1_000_000
-                / u64::from(sample_rate),
-        );
-        let mut captured_at = stats.started_at + Duration::from_millis(10);
-        let mut accepted_frames = 0;
-        let mut dropped_frames = 0;
-
-        for _ in 0..100 {
-            let callback_at = captured_at + Duration::from_millis(capture_latency_ms);
-            let ready_at = callback_at + Duration::from_millis(worker_delay_ms);
-            let timing = record_voice_input_chunk(
-                input_frames,
-                1,
-                sample_rate,
-                captured_at,
-                callback_at,
-                &stats,
-            );
-            pcm_frames.apply_capture_timing(timing);
-            let oldest_frame_at = pcm_frames.push_stereo_samples(&samples, captured_at);
-            record_voice_input_health(timing, oldest_frame_at, ready_at, &stats);
-
-            let transmit_at =
-                ready_at + VOICE_MIC_TRANSMIT_WAIT_BUDGET + VOICE_MIC_PROCESSING_BUDGET;
-            while let Ok(frame) = rx.try_recv() {
-                let (selected, dropped) =
-                    select_fresh_voice_microphone_frame(frame, &mut rx, transmit_at);
-                accepted_frames += usize::from(selected.is_some());
-                dropped_frames += dropped;
-            }
-            captured_at += callback_duration;
-        }
-
-        assert_eq!(
-            stats.restart_requested.load(Ordering::Acquire),
-            needs_recovery,
-            "rate={sample_rate}, frames={input_frames}, capture={capture_latency_ms}ms, worker={worker_delay_ms}ms, dropped={dropped_frames}",
-        );
-        if needs_recovery {
-            assert!(dropped_frames > 0, "late frames must still be rejected");
-            assert!(stats.max_capture_delivery_age_us.load(Ordering::Relaxed) > 50_000);
-        } else {
-            assert!(accepted_frames > 0);
-            assert_eq!(dropped_frames, 0);
-            assert!(stats.max_capture_delivery_age_us.load(Ordering::Relaxed) <= 50_000);
-        }
-    }
-}
-
-#[cfg(feature = "voice-playback")]
-#[test]
-fn microphone_health_counts_each_processed_chunk_once() {
-    for input_frames in [DISCORD_OPUS_FRAME_SAMPLES_PER_CHANNEL / 2, 3_840] {
-        let stats = Arc::new(VoiceMicrophoneCaptureStats::default());
-        let (tx, mut rx) = tokio::sync::mpsc::channel(VOICE_MIC_PCM_FRAME_QUEUE);
-        let mut pcm_frames =
-            VoiceMicrophonePcmFrames::new(tx, Arc::clone(&stats), DISCORD_VOICE_SAMPLE_RATE);
-        let samples = vec![1i16; input_frames * DISCORD_VOICE_CHANNELS_USIZE];
-        let callback_duration = Duration::from_micros(
-            u64::try_from(input_frames).expect("test frame count fits") * 1_000_000
-                / u64::from(DISCORD_VOICE_SAMPLE_RATE),
-        );
-        let mut captured_at = stats.started_at + Duration::from_millis(10);
-
-        for index in 0..VOICE_MIC_UNHEALTHY_CALLBACK_THRESHOLD {
-            let previous_count = stats.unhealthy_callback_count.load(Ordering::Relaxed);
-            let callback_at = captured_at + callback_duration;
-            let timing = record_voice_input_chunk(
-                input_frames,
-                1,
-                DISCORD_VOICE_SAMPLE_RATE,
-                captured_at,
-                callback_at,
-                &stats,
-            );
-            // Recording the input must not update the worker-owned health window.
-            assert_eq!(
-                stats.unhealthy_callback_count.load(Ordering::Relaxed),
-                previous_count
-            );
-            pcm_frames.apply_capture_timing(timing);
-            let oldest_frame_at = pcm_frames.push_stereo_samples(&samples, captured_at);
-            record_voice_input_health(
-                timing,
-                oldest_frame_at,
-                callback_at + Duration::from_millis(100),
-                &stats,
-            );
-
-            if input_frames < DISCORD_OPUS_FRAME_SAMPLES_PER_CHANNEL {
-                // Incomplete audio is not a delivery event. Only the second
-                // callback completes a frame, so these three chunks count once.
-                assert_eq!(
-                    stats.unhealthy_callback_count.load(Ordering::Relaxed),
-                    u8::from(index > 0)
-                );
-                assert!(!stats.restart_requested.load(Ordering::Acquire));
-            } else {
-                // Four late frames and an oversized callback are still one event.
-                assert_eq!(
-                    stats.restart_requested.load(Ordering::Acquire),
-                    index + 1 == VOICE_MIC_UNHEALTHY_CALLBACK_THRESHOLD
-                );
-            }
-            while rx.try_recv().is_ok() {}
-            captured_at += callback_duration;
-        }
-    }
 }
 
 #[cfg(feature = "voice-playback")]
@@ -2818,86 +2495,60 @@ fn voice_input_config_prefers_mono_then_sample_format() {
 
 #[cfg(feature = "voice-playback")]
 #[test]
-fn voice_input_buffer_size_uses_auto_or_configured_duration() {
-    assert_eq!(
-        voice_input_buffer_size(None, DISCORD_VOICE_SAMPLE_RATE),
-        cpal::BufferSize::Default
-    );
-    assert_eq!(
-        voice_input_buffer_size(Some(MicrophoneBufferMs::new(40)), DISCORD_VOICE_SAMPLE_RATE,),
-        cpal::BufferSize::Fixed(1_920)
-    );
-    assert_eq!(
-        voice_buffer_duration_ms(96_000, DISCORD_VOICE_SAMPLE_RATE),
-        2_000
-    );
+fn automatic_microphone_buffer_uses_platform_period_and_supported_range() {
+    let callback_period_frames =
+        DISCORD_VOICE_SAMPLE_RATE / VOICE_MIC_AUTOMATIC_CALLBACKS_PER_SECOND;
 
     assert_eq!(
-        voice_microphone_recovery_buffers(VoiceMicrophoneBufferMode::HostDefault),
-        vec![MicrophoneBufferMs::new(40), MicrophoneBufferMs::new(60)]
+        automatic_voice_input_buffer_size(
+            &cpal::SupportedBufferSize::Range {
+                min: 128,
+                max: 8_192,
+            },
+            DISCORD_VOICE_SAMPLE_RATE,
+        ),
+        Some(cpal::BufferSize::Fixed(callback_period_frames))
     );
     assert_eq!(
-        voice_microphone_recovery_buffers(VoiceMicrophoneBufferMode::AutomaticFixed(
-            MicrophoneBufferMs::new(40)
-        )),
-        vec![MicrophoneBufferMs::new(60)]
+        automatic_voice_input_buffer_size(
+            &cpal::SupportedBufferSize::Range {
+                min: callback_period_frames + 1,
+                max: 8_192,
+            },
+            DISCORD_VOICE_SAMPLE_RATE,
+        ),
+        Some(cpal::BufferSize::Fixed(callback_period_frames + 1))
     );
     assert_eq!(
-        voice_microphone_recovery_buffers(VoiceMicrophoneBufferMode::AutomaticFixed(
-            MicrophoneBufferMs::new(60)
-        )),
-        Vec::<MicrophoneBufferMs>::new()
+        automatic_voice_input_buffer_size(
+            &cpal::SupportedBufferSize::Range {
+                min: 128,
+                max: callback_period_frames - 1,
+            },
+            DISCORD_VOICE_SAMPLE_RATE,
+        ),
+        Some(cpal::BufferSize::Fixed(callback_period_frames - 1))
     );
     assert_eq!(
-        voice_microphone_recovery_buffers(VoiceMicrophoneBufferMode::UserFixed(
-            MicrophoneBufferMs::new(40)
-        )),
-        Vec::<MicrophoneBufferMs>::new()
+        automatic_voice_input_buffer_size(
+            &cpal::SupportedBufferSize::Unknown,
+            DISCORD_VOICE_SAMPLE_RATE,
+        ),
+        None
     );
 }
 
 #[cfg(feature = "voice-playback")]
 #[test]
-fn automatic_microphone_buffers_reject_excessive_reported_size() {
-    let requested = MicrophoneBufferMs::new(40);
-
-    assert!(
-        validate_automatic_voice_input_buffer(requested, Some(2_880), DISCORD_VOICE_SAMPLE_RATE,)
-            .is_ok()
+fn configured_microphone_buffer_uses_requested_duration() {
+    assert_eq!(
+        voice_input_buffer_size(MicrophoneBufferMs::new(10), DISCORD_VOICE_SAMPLE_RATE),
+        cpal::BufferSize::Fixed(480)
     );
-    assert!(
-        validate_automatic_voice_input_buffer(requested, None, DISCORD_VOICE_SAMPLE_RATE,).is_ok()
+    assert_eq!(
+        voice_input_buffer_size(MicrophoneBufferMs::new(50), DISCORD_VOICE_SAMPLE_RATE),
+        cpal::BufferSize::Fixed(2_400)
     );
-    assert!(
-        validate_automatic_voice_input_buffer(requested, Some(96_000), DISCORD_VOICE_SAMPLE_RATE,)
-            .is_err()
-    );
-}
-
-#[cfg(feature = "voice-playback")]
-#[test]
-fn microphone_recovery_failures_use_cooldown_and_then_exhaust() {
-    let mut recovery = VoiceMicrophoneRecoveryState::default();
-    let started_at = Instant::now();
-
-    assert!(recovery.permits_attempt(started_at));
-    assert!(!recovery.record_failed_sweep(started_at));
-    assert!(
-        !recovery
-            .permits_attempt(started_at + VOICE_MIC_RECOVERY_COOLDOWN - Duration::from_millis(1))
-    );
-
-    let second_attempt = started_at + VOICE_MIC_RECOVERY_COOLDOWN;
-    assert!(recovery.permits_attempt(second_attempt));
-    assert!(!recovery.record_failed_sweep(second_attempt));
-
-    let third_attempt = second_attempt + VOICE_MIC_RECOVERY_COOLDOWN;
-    assert!(recovery.permits_attempt(third_attempt));
-    assert!(recovery.record_failed_sweep(third_attempt));
-    assert!(!recovery.permits_attempt(third_attempt + Duration::from_secs(60)));
-
-    recovery = VoiceMicrophoneRecoveryState::default();
-    assert!(recovery.permits_attempt(third_attempt));
 }
 
 #[cfg(feature = "voice-playback")]


### PR DESCRIPTION


<!--
Thanks for the contribution. Please keep the subject under ~72 characters
and use a semantic prefix (feat:, fix:, refactor:, docs:, chore:, test:).

By submitting this PR you agree it will be distributed under GPL-3.0-only.
-->

## Summary

<!-- What does this change do, in one or two sentences? -->

Removed runtime buffer swapping, callback health recovery, timestamp correction state, retry cooldowns, and their tests. Added startup-only platform buffer selection and latest-frame preservation.

## Why

Related #360 #315 

## How

<!-- Notable implementation choices and any non-obvious trade-offs. -->

## Testing

<!-- How you verified the change. Mention the OS, terminal, and graphics protocol used for manual checks. -->

- [ ] `cargo fmt --all --check`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo test --all-features`
- [ ] Manual test in a real terminal (describe below)

## Screenshots or recordings

<!-- For UI changes, attach a screenshot or asciinema/gif. Delete this section if not applicable. -->

## Checklist

- [ ] One logical change per PR.
- [ ] Link a related issue.
- [ ] No tokens, passwords, MFA codes, or raw auth bodies in code, tests, or logs.
- [ ] Change does not add self-bot automation, mass actions, or scraping.
- [ ] Updated `README.md`, if behavior or workflows changed.
